### PR TITLE
Remove defaulting behavior of validate_*.  It was complicated and unnecessary

### DIFF
--- a/pre_commit/clientlib/validate_base.py
+++ b/pre_commit/clientlib/validate_base.py
@@ -4,11 +4,8 @@ import jsonschema.exceptions
 import os.path
 import yaml
 
-from pre_commit import git
-
 
 def get_validator(
-    default_filename,
     json_schema,
     exception_type,
     additional_validation_strategy=lambda obj: None,
@@ -16,17 +13,13 @@ def get_validator(
     """Returns a function which will validate a yaml file for correctness
 
     Args:
-        default_filename - Default filename to look for if none is specified
         json_schema - JSON schema to validate file with
         exception_type - Error type to raise on failure
         additional_validation_strategy - Strategy for additional validation of
             the object read from the file.  The function should either raise
             exception_type on failure.
     """
-
-    def validate(filename=None, load_strategy=yaml.load):
-        filename = filename or os.path.join(git.get_root(), default_filename)
-
+    def validate(filename, load_strategy=yaml.load):
         if not os.path.exists(filename):
             raise exception_type('File {0} does not exist'.format(filename))
 

--- a/pre_commit/clientlib/validate_config.py
+++ b/pre_commit/clientlib/validate_config.py
@@ -5,7 +5,6 @@ import argparse
 import re
 import sys
 
-import pre_commit.constants as C
 from pre_commit.clientlib.validate_base import get_validator
 from pre_commit.util import entry
 
@@ -58,7 +57,6 @@ def validate_config_extra(config):
 
 
 load_config = get_validator(
-    C.CONFIG_FILE,
     CONFIG_JSON_SCHEMA,
     InvalidConfigError,
     additional_validation_strategy=validate_config_extra,
@@ -68,19 +66,11 @@ load_config = get_validator(
 @entry
 def run(argv):
     parser = argparse.ArgumentParser()
-    parser.add_argument(
-        'filenames',
-        nargs='*', default=None,
-        help='Config filenames.  Defaults to {0} at root of git repo'.format(
-            C.CONFIG_FILE,
-        )
-    )
+    parser.add_argument('filenames', nargs='*', help='Config filenames.')
     args = parser.parse_args(argv)
 
-    filenames = args.filenames or [C.CONFIG_FILE]
     retval = 0
-
-    for filename in filenames:
+    for filename in args.filenames:
         try:
             load_config(filename)
         except InvalidConfigError as e:

--- a/pre_commit/clientlib/validate_manifest.py
+++ b/pre_commit/clientlib/validate_manifest.py
@@ -4,7 +4,6 @@ from __future__ import print_function
 import argparse
 import sys
 
-import pre_commit.constants as C
 from pre_commit.clientlib.validate_base import get_validator
 from pre_commit.languages.all import all_languages
 from pre_commit.util import entry
@@ -48,7 +47,6 @@ def additional_manifest_check(obj):
 
 
 load_manifest = get_validator(
-    C.MANIFEST_FILE,
     MANIFEST_JSON_SCHEMA,
     InvalidManifestError,
     additional_manifest_check,
@@ -58,19 +56,11 @@ load_manifest = get_validator(
 @entry
 def run(argv):
     parser = argparse.ArgumentParser()
-    parser.add_argument(
-        'filenames',
-        nargs='*', default=None,
-        help='Manifest filenames.  Defaults to {0} at root of git repo'.format(
-            C.MANIFEST_FILE,
-        )
-    )
+    parser.add_argument('filenames', nargs='*', help='Manifest filenames.')
     args = parser.parse_args(argv)
 
-    filenames = args.filenames or [C.MANIFEST_FILE]
     retval = 0
-
-    for filename in filenames:
+    for filename in args.filenames:
         try:
             load_manifest(filename)
         except InvalidManifestError as e:


### PR DESCRIPTION
This refers to defaulting to a config file at the root of the repository.  This had weird side-effects if this were to ever be wrong about a config file and/or out of date and the config file was unchanged.
