### PR TITLE
Use virtualenv python from install-time for less virtualenv requirements at commit time.

### DIFF
--- a/pre_commit/commands/install_uninstall.py
+++ b/pre_commit/commands/install_uninstall.py
@@ -6,6 +6,7 @@ import logging
 import os
 import os.path
 import stat
+import sys
 
 from pre_commit.logging_handler import LoggingHandler
 from pre_commit.util import resource_filename
@@ -15,12 +16,13 @@ logger = logging.getLogger('pre_commit')
 
 
 # This is used to identify the hook file we install
-PREVIOUS_IDENTIFYING_HASHES = [
+PREVIOUS_IDENTIFYING_HASHES = (
+    '4d9958c90bc262f47553e2c073f14cfe',
     'd8ee923c46731b42cd95cc869add4062',
-]
+)
 
 
-IDENTIFYING_HASH = '4d9958c90bc262f47553e2c073f14cfe'
+IDENTIFYING_HASH = '49fd668cb42069aa1b6048464be5d395'
 
 
 def is_our_pre_commit(filename):
@@ -63,8 +65,11 @@ def install(runner, overwrite=False, hooks=False):
             )
         )
 
-    with open(runner.pre_commit_path, 'w') as pre_commit_file_obj:
-        pre_commit_file_obj.write(open(pre_commit_file).read())
+    with io.open(runner.pre_commit_path, 'w') as pre_commit_file_obj:
+        contents = io.open(pre_commit_file).read().format(
+            sys_executable=sys.executable,
+        )
+        pre_commit_file_obj.write(contents)
     make_executable(runner.pre_commit_path)
 
     print('pre-commit installed at {0}'.format(runner.pre_commit_path))

--- a/pre_commit/output.py
+++ b/pre_commit/output.py
@@ -1,5 +1,6 @@
 from __future__ import unicode_literals
 
+import os
 import subprocess
 import sys
 
@@ -10,7 +11,7 @@ from pre_commit import five
 # TODO: smell: import side-effects
 COLS = int(
     subprocess.Popen(
-        ['tput', 'cols'], stdout=subprocess.PIPE
+        ['tput', 'cols'], stdout=subprocess.PIPE, stderr=open(os.devnull, 'w'),
     ).communicate()[0] or
     # Default in the case of no terminal
     80

--- a/pre_commit/resources/pre-commit-hook
+++ b/pre_commit/resources/pre-commit-hook
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # This is a randomish md5 to identify this script
-# 4d9958c90bc262f47553e2c073f14cfe
+# 49fd668cb42069aa1b6048464be5d395
 
 pushd `dirname $0` > /dev/null
 HERE=`pwd`
@@ -8,12 +8,21 @@ popd > /dev/null
 
 retv=0
 
+ENV_PYTHON='{sys_executable}'
+
 which pre-commit >& /dev/null
 WHICH_RETV=$?
+"$ENV_PYTHON" -c 'import pre_commit.main' >& /dev/null
+ENV_PYTHON_RETV=$?
 python -c 'import pre_commit.main' >& /dev/null
 PYTHON_RETV=$?
 
-if [ $WHICH_RETV -ne 0 ] && [ $PYTHON_RETV -ne 0 ]; then
+
+if ((
+        (WHICH_RETV != 0) &&
+        (ENV_PYTHON_RETV != 0) &&
+        (PYTHON_RETV != 0)
+)); then
     echo '`pre-commit` not found.  Did you forget to activate your virtualenv?'
     exit 1
 fi
@@ -29,15 +38,18 @@ fi
 
 
 # Run pre-commit
-if [ $WHICH_RETV -eq 0 ]; then
+if ((WHICH_RETV == 0)); then
     pre-commit
+    PRE_COMMIT_RETV=$?
+elif ((ENV_PYTHON_RETV == 0)); then
+    "$ENV_PYTHON" -m pre_commit.main
     PRE_COMMIT_RETV=$?
 else
     python -m pre_commit.main
     PRE_COMMIT_RETV=$?
 fi
 
-if [ $PRE_COMMIT_RETV -ne 0 ]; then
+if ((PRE_COMMIT_RETV != 0)); then
     retv=1
 fi
 


### PR DESCRIPTION
This enables the following workflow:

```
$ sh -c '. venv/bin/activate && pre-commit install'
$ git commit -m ...
```

which previously would have needed to have been:

```
$ sh -c '. venv/bin/activate && pre-commit install'
$ . venv/bin/activate
$ git commit -m ...
```

Closes #164 
