### PR TITLE
improve output in error case

### DIFF
--- a/pre_commit/util.py
+++ b/pre_commit/util.py
@@ -108,15 +108,23 @@ class CalledProcessError(RuntimeError):
         self.output = output
 
     def __str__(self):
+        output = []
+        for text in self.output:
+            if text:
+                output.append('\n    ' + text.replace('\n', '\n    '))
+            else:
+                output.append('(none)')
+
         return (
             'Command: {0!r}\n'
             'Return code: {1}\n'
             'Expected return code: {2}\n'
-            'Output: {3!r}\n'.format(
+            'Output: {3}\n'
+            'Errors: {4}\n'.format(
                 self.cmd,
                 self.returncode,
                 self.expected_returncode,
-                self.output,
+                *output
             )
         )
 

--- a/tests/prefixed_command_runner_test.py
+++ b/tests/prefixed_command_runner_test.py
@@ -19,7 +19,23 @@ def test_CalledProcessError_str():
         "Command: ['git', 'status']\n"
         "Return code: 1\n"
         "Expected return code: 0\n"
-        "Output: ('stdout', 'stderr')\n"
+        "Output: \n"
+        "    stdout\n"
+        "Errors: \n"
+        "    stderr\n"
+    )
+
+
+def test_CalledProcessError_str_nooutput():
+    error = CalledProcessError(
+        1, [str('git'), str('status')], 0, (str(''), str(''))
+    )
+    assert str(error) == (
+        "Command: ['git', 'status']\n"
+        "Return code: 1\n"
+        "Expected return code: 0\n"
+        "Output: (none)\n"
+        "Errors: (none)\n"
     )
 
 


### PR DESCRIPTION
before:

```
$ python -m pre_commit.main install -f --install-hooks
pre-commit installed at /nail/home/buck/pg/2/.git/hooks/pre-commit
An unexpected error has occurred: CalledProcessError: Command: (u'virtualenv', u'/nail/home/buck/.pre-commit/repoSvhFNZ/py_env')
Return code: 1
Expected return code: 0
Output: (u'Using real prefix \'/usr\'\nNew python executable in /nail/home/buck/.pre-commit/repoSvhFNZ/py_env/bin/python2.6\nAlso creating executable in /nail/home/buck/.pre-commit/repoSvhFNZ/py_env/bi
n/python\nInstalling setuptools, pip...\n  Complete output from command /nail/home/buck/.pre...py_env/bin/python2.6 -c "import sys, pip; sys...d\\"] + sys.argv[1:]))" setuptools pip:\n  \'import site\'
 failed; use -v for traceback\nTraceback (most recent call last):\n  File "<string>", line 1, in <module>\n  File "/nail/home/buck/pg/2/virtualenv_run/lib/python2.6/site-packages/virtualenv_support/pip
-6.0.6-py2.py3-none-any.whl/pip/__init__.py", line 13, in <module>\n  File "/nail/home/buck/pg/2/virtualenv_run/lib/python2.6/site-packages/virtualenv_support/pip-6.0.6-py2.py3-none-any.whl/pip/utils/_
_init__.py", line 18, in <module>\n  File "/nail/home/buck/pg/2/virtualenv_run/lib/python2.6/site-packages/virtualenv_support/pip-6.0.6-py2.py3-none-any.whl/pip/locations.py", line 7, in <module>\n  Fi
le "/nail/home/buck/.pre-commit/repoSvhFNZ/py_env/lib/python2.6/site.py", line 703, in <module>\n    main()\n  File "/nail/home/buck/.pre-commit/repoSvhFNZ/py_env/lib/python2.6/site.py", line 683, in m
ain\n    paths_in_sys = addsitepackages(paths_in_sys)\n  File "/nail/home/buck/.pre-commit/repoSvhFNZ/py_env/lib/python2.6/site.py", line 282, in addsitepackages\n    addsitedir(sitedir, known_paths)\n
  File "/nail/home/buck/.pre-commit/repoSvhFNZ/py_env/lib/python2.6/site.py", line 204, in addsitedir\n    addpackage(sitedir, name, known_paths)\n  File "/nail/home/buck/.pre-commit/repoSvhFNZ/py_env/
lib/python2.6/site.py", line 173, in addpackage\n    exec(line)\n  File "<string>", line 1, in <module>\nImportError: No module named yelp_bootstrap\n----------------------------------------\n...Instal
ling setuptools, pip...done.\n', u'\'import site\' failed; use -v for traceback\nTraceback (most recent call last):\n  File "/nail/home/buck/pg/2/virtualenv_run/bin/virtualenv", line 11, in <module>\n
   sys.exit(main())\n  File "/nail/home/buck/pg/2/virtualenv_run/lib/python2.6/site-packages/virtualenv.py", line 825, in main\n    symlink=options.symlink)\n  File "/nail/home/buck/pg/2/virtualenv_run
/lib/python2.6/site-packages/virtualenv.py", line 993, in create_environment\n    install_wheel(to_install, py_executable, search_dirs)\n  File "/nail/home/buck/pg/2/virtualenv_run/lib/python2.6/site-p
ackages/virtualenv.py", line 961, in install_wheel\n    \'PIP_NO_INDEX\': \'1\'\n  File "/nail/home/buck/pg/2/virtualenv_run/lib/python2.6/site-packages/virtualenv.py", line 903, in call_subprocess\n
  % (cmd_desc, proc.returncode))\nOSError: Command /nail/home/buck/.pre...py_env/bin/python2.6 -c "import sys, pip; sys...d\\"] + sys.argv[1:]))" setuptools pip failed with error code 1\n')

Check the log at ~/.pre-commit/pre-commit.log
```

after:

```
$ python -m pre_commit.main install -f --install-hooks
pre-commit installed at /nail/home/buck/pg/2/.git/hooks/pre-commit
An unexpected error has occurred: CalledProcessError: Command: (u'virtualenv', u'/nail/home/buck/.pre-commit/repoSvhFNZ/py_env')
Return code: 1
Expected return code: 0
Output:
    Using real prefix '/usr'
    New python executable in /nail/home/buck/.pre-commit/repoSvhFNZ/py_env/bin/python2.6
    Also creating executable in /nail/home/buck/.pre-commit/repoSvhFNZ/py_env/bin/python
    Installing setuptools, pip...
      Complete output from command /nail/home/buck/.pre...py_env/bin/python2.6 -c "import sys, pip; sys...d\"] + sys.argv[1:]))" setuptools pip:
      'import site' failed; use -v for traceback
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/nail/home/buck/pg/2/virtualenv_run/lib/python2.6/site-packages/virtualenv_support/pip-6.0.6-py2.py3-none-any.whl/pip/__init__.py", line 13, in <module>
      File "/nail/home/buck/pg/2/virtualenv_run/lib/python2.6/site-packages/virtualenv_support/pip-6.0.6-py2.py3-none-any.whl/pip/utils/__init__.py", line 18, in <module>
      File "/nail/home/buck/pg/2/virtualenv_run/lib/python2.6/site-packages/virtualenv_support/pip-6.0.6-py2.py3-none-any.whl/pip/locations.py", line 7, in <module>
      File "/nail/home/buck/.pre-commit/repoSvhFNZ/py_env/lib/python2.6/site.py", line 703, in <module>
        main()
      File "/nail/home/buck/.pre-commit/repoSvhFNZ/py_env/lib/python2.6/site.py", line 683, in main
        paths_in_sys = addsitepackages(paths_in_sys)
      File "/nail/home/buck/.pre-commit/repoSvhFNZ/py_env/lib/python2.6/site.py", line 282, in addsitepackages
        addsitedir(sitedir, known_paths)
      File "/nail/home/buck/.pre-commit/repoSvhFNZ/py_env/lib/python2.6/site.py", line 204, in addsitedir
        addpackage(sitedir, name, known_paths)
      File "/nail/home/buck/.pre-commit/repoSvhFNZ/py_env/lib/python2.6/site.py", line 173, in addpackage
        exec(line)
      File "<string>", line 1, in <module>
    ImportError: No module named yelp_bootstrap
    ----------------------------------------
    ...Installing setuptools, pip...done.

Errors:
    'import site' failed; use -v for traceback
    Traceback (most recent call last):
      File "/nail/home/buck/pg/2/virtualenv_run/bin/virtualenv", line 11, in <module>
        sys.exit(main())
      File "/nail/home/buck/pg/2/virtualenv_run/lib/python2.6/site-packages/virtualenv.py", line 825, in main
        symlink=options.symlink)
      File "/nail/home/buck/pg/2/virtualenv_run/lib/python2.6/site-packages/virtualenv.py", line 993, in create_environment
        install_wheel(to_install, py_executable, search_dirs)
      File "/nail/home/buck/pg/2/virtualenv_run/lib/python2.6/site-packages/virtualenv.py", line 961, in install_wheel
        'PIP_NO_INDEX': '1'
      File "/nail/home/buck/pg/2/virtualenv_run/lib/python2.6/site-packages/virtualenv.py", line 903, in call_subprocess
        % (cmd_desc, proc.returncode))
    OSError: Command /nail/home/buck/.pre...py_env/bin/python2.6 -c "import sys, pip; sys...d\"] + sys.argv[1:]))" setuptools pip failed with error code 1


Check the log at ~/.pre-commit/pre-commit.log
```