### PR TITLE
Default arguments from hooks.yaml

### DIFF
--- a/pre_commit/clientlib/validate_config.py
+++ b/pre_commit/clientlib/validate_config.py
@@ -30,7 +30,6 @@ CONFIG_JSON_SCHEMA = {
                         'language_version': {'type': 'string'},
                         'args': {
                             'type': 'array',
-                            'default': [],
                             'items': {'type': 'string'},
                         },
                     },

--- a/pre_commit/clientlib/validate_manifest.py
+++ b/pre_commit/clientlib/validate_manifest.py
@@ -24,6 +24,13 @@ MANIFEST_JSON_SCHEMA = {
             'language_version': {'type': 'string', 'default': 'default'},
             'files': {'type': 'string'},
             'expected_return_value': {'type': 'number', 'default': 0},
+            'args': {
+                'type': 'array',
+                'default': [],
+                'items': {
+                    'type': 'string',
+                },
+            },
         },
         'required': ['id', 'name', 'entry', 'language', 'files'],
     },

--- a/testing/resources/arg_per_line_hooks_repo/hooks.yaml
+++ b/testing/resources/arg_per_line_hooks_repo/hooks.yaml
@@ -3,3 +3,4 @@
     entry: bin/hook.sh
     language: script
     files: ''
+    args: [hello, world]

--- a/tests/manifest_test.py
+++ b/tests/manifest_test.py
@@ -19,6 +19,7 @@ def manifest(store, tmpdir_factory):
 def test_manifest_contents(manifest):
     # Should just retrieve the manifest contents
     assert manifest.manifest_contents == [{
+        'args': [],
         'description': '',
         'entry': 'bin/hook.sh',
         'expected_return_value': 0,
@@ -32,6 +33,7 @@ def test_manifest_contents(manifest):
 
 def test_hooks(manifest):
     assert manifest.hooks['bash_hook'] == {
+        'args': [],
         'description': '',
         'entry': 'bin/hook.sh',
         'expected_return_value': 0,

--- a/tests/repository_test.py
+++ b/tests/repository_test.py
@@ -113,7 +113,9 @@ def test_run_a_script_hook(tmpdir_factory, store):
 def test_run_hook_with_spaced_args(tmpdir_factory, store):
     _test_hook_repo(
         tmpdir_factory, store, 'arg_per_line_hooks_repo',
-        'arg-per-line', ['foo bar', 'baz'], 'arg: foo bar\narg: baz\n',
+        'arg-per-line',
+        ['foo bar', 'baz'],
+        'arg: hello\narg: world\narg: foo bar\narg: baz\n',
     )
 
 


### PR DESCRIPTION
This allows (for instance) the `autopep8-wrapper` hook in https://github.com/pre-commit/pre-commit-hooks to default the `args` to `['-i']`