### PR TITLE
Preparatory work & clean-up for #219

### DIFF
--- a/pre_commit/clientlib/validate_config.py
+++ b/pre_commit/clientlib/validate_config.py
@@ -37,7 +37,7 @@ CONFIG_JSON_SCHEMA = {
                 }
             }
         },
-        'required': ['repo', 'sha', 'hooks'],
+        'required': ['repo', 'hooks'],
     }
 }
 
@@ -53,6 +53,10 @@ def try_regex(repo, hook, value, field_name):
 
 def validate_config_extra(config):
     for repo in config:
+        if 'sha' not in repo:
+            raise InvalidConfigError(
+                'Missing "sha" field for repository {0}'.format(repo['repo'])
+            )
         for hook in repo['hooks']:
             try_regex(repo, hook['id'], hook.get('files', ''), 'files')
             try_regex(repo, hook['id'], hook['exclude'], 'exclude')


### PR DESCRIPTION
This is an attempt to address #219.
As it is a first draft, it misses some tests and a bit of code cleaning, but I'd like an initial design review before fixing the final glitches.

**Example of valid _ .pre-commit-config.yaml_ using this feature :**
```
- local-hooks:
  - id: no-todo
    name: No TODO allowed in commited files
    entry: grep -iI todo
    expected_return_value: 1
    language: system
    files: ''
```

**Pros / Cons of the solution choosed:**
+ + end-user-friendly: the new "local-hooks" field schema is the same as _hooks.yaml_ schema
+ + nice reuse of MANIFEST_JSON_SCHEMA
+ + no more `_run_hook` / `_run_hooks` code duplication
+ + all the regressions tests pass
- - "local-hooks" and classical repo/sha/hooks objects are mixed together in _.pre-commit-config.yaml_
- - the `hooks_and_invokers` list of tuples is not entirely satisfying. Maybe it'd be worth having a proper `Hook` class ?
