### PR TITLE
--allow-unstaged-config arg

### DIFF
--- a/pre_commit/commands/run.py
+++ b/pre_commit/commands/run.py
@@ -129,6 +129,18 @@ def _has_unmerged_paths(runner):
     return bool(stdout.strip())
 
 
+def _has_unstaged_config(runner):
+    retcode, stdout, stderr = runner.cmd_runner.run(
+        [
+            'git', 'diff', '--exit-code', runner.config_file_path
+        ],
+        retcode=None,
+        encoding=None,
+    )
+    # be explicit, other git errors don't mean it has an unstaged config.
+    return retcode == 1
+
+
 def run(runner, args, write=sys_stdout_write_wrapper, environ=os.environ):
     # Set up our logging handler
     logger.addHandler(LoggingHandler(args.color, write=write))
@@ -141,6 +153,16 @@ def run(runner, args, write=sys_stdout_write_wrapper, environ=os.environ):
     if bool(args.source) != bool(args.origin):
         logger.error('Specify both --origin and --source.')
         return 1
+    if _has_unstaged_config(runner) and not args.no_stash:
+        if args.allow_unstaged_config:
+            logger.warn('You have an unstaged config file and have '
+                        'specified the --allow-unstaged-config option.\n'
+                        'Note that your config will be stashed before the '
+                        'config is parsed unless --no-stash is specified.')
+        else:
+            logger.error('You have an unstaged config file and have not '
+                         'specified the --allow-unstaged-config option.\n')
+            return 1
 
     # Don't stash if specified or files are specified
     if args.no_stash or args.all_files or args.files:

--- a/pre_commit/main.py
+++ b/pre_commit/main.py
@@ -94,6 +94,11 @@ def main(argv=None):
         '--source', '-s',
         help='The remote branch"s commit_id when using `git push`',
     )
+    run_parser.add_argument(
+        '--allow-unstaged-config', default=False, action='store_true',
+        help='Allow an unstaged config to be present.  Note that this will'
+        'be stashed before parsing unless --no-stash is specified'
+    )
     run_mutex_group = run_parser.add_mutually_exclusive_group(required=False)
     run_mutex_group.add_argument(
         '--all-files', '-a', action='store_true', default=False,

--- a/tests/commands/run_test.py
+++ b/tests/commands/run_test.py
@@ -55,6 +55,7 @@ def _get_opts(
         no_stash=False,
         origin='',
         source='',
+        allow_unstaged_config=False,
 ):
     # These are mutually exclusive
     assert not (all_files and files)
@@ -67,6 +68,7 @@ def _get_opts(
         no_stash=no_stash,
         origin=origin,
         source=source,
+        allow_unstaged_config=allow_unstaged_config,
     )
 
 
@@ -397,3 +399,60 @@ def test_local_hook_fails(
         expected_ret=1,
         stage=False
     )
+
+
+def test_allow_unstaged_config_option(repo_with_passing_hook,
+                                      mock_out_store_directory):
+
+    with cwd(repo_with_passing_hook):
+        with io.open(
+            '.pre-commit-config.yaml', 'a+',
+        ) as config_file:
+            # writing a newline should be relatively harmless to get a change
+            config_file.write('\n')
+
+    args = _get_opts(allow_unstaged_config=True)
+    ret, printed = _do_run(repo_with_passing_hook, args)
+    common_msg = 'You have an unstaged config file'
+    warning_msg = 'have specified the --allow-unstaged-config option.'
+
+    assert common_msg in printed
+    assert warning_msg in printed
+    assert ret == 0
+
+
+def test_no_allow_unstaged_config_option(repo_with_passing_hook,
+                                         mock_out_store_directory):
+
+    with cwd(repo_with_passing_hook):
+        with io.open(
+            '.pre-commit-config.yaml', 'a+',
+        ) as config_file:
+            # writing a newline should be relatively harmless to get a change
+            config_file.write('\n')
+
+    args = _get_opts(allow_unstaged_config=False)
+    ret, printed = _do_run(repo_with_passing_hook, args)
+    common_msg = 'You have an unstaged config file'
+    error_msg = 'have not specified the --allow-unstaged-config option.\n'
+
+    assert common_msg in printed
+    assert error_msg in printed
+    assert ret == 1
+
+
+def test_no_stash_suppresses_allow_unstaged_config_option(
+        repo_with_passing_hook, mock_out_store_directory):
+
+    with cwd(repo_with_passing_hook):
+        with io.open(
+            '.pre-commit-config.yaml', 'a+',
+        ) as config_file:
+            # writing a newline should be relatively harmless to get a change
+            config_file.write('\n')
+
+    args = _get_opts(allow_unstaged_config=False, no_stash=True)
+    ret, printed = _do_run(repo_with_passing_hook, args)
+    common_msg = 'You have an unstaged config file'
+
+    assert common_msg not in printed


### PR DESCRIPTION
Change the behaviour for unstaged config per #157 discussion

- if allow unstaged config, puts a warning message that the config will still be stashed, but continues
- if not provided, errors out

stuff I'd expect we might want to change would be the actual content of the messages and perhaps what the "default" is here.  

thanks for the support! @asottile 

