### PR TITLE
Fixing bug with local hooks that disappeared during autoupdate

### DIFF
--- a/pre_commit/commands/autoupdate.py
+++ b/pre_commit/commands/autoupdate.py
@@ -69,6 +69,7 @@ def autoupdate(runner):
 
     for repo_config in input_configs:
         if is_local_hooks(repo_config):
+            output_configs.append(repo_config)
             continue
         sys.stdout.write('Updating {0}...'.format(repo_config['repo']))
         sys.stdout.flush()

--- a/testing/fixtures.py
+++ b/testing/fixtures.py
@@ -68,9 +68,11 @@ def make_config_from_repo(repo_path, sha=None, hooks=None, check=True):
 
 
 def write_config(directory, config):
-    assert type(config) is OrderedDict
+    if type(config) is not list:
+        assert type(config) is OrderedDict
+        config = [config]
     with io.open(os.path.join(directory, C.CONFIG_FILE), 'w') as config_file:
-        config_file.write(ordered_dump([config], **C.YAML_DUMP_KWARGS))
+        config_file.write(ordered_dump(config, **C.YAML_DUMP_KWARGS))
 
 
 def add_config_to_repo(git_path, config):


### PR DESCRIPTION
I added a test, `test_autoupdate_local_hooks_with_out_of_date_repo`, that is currently failing without this patch.

The issue typically araise when mixing local & remote hooks : on a successful remote hooks autoupdate, local hooks are simply ignored when the new YAML config is writen to file.