### PR TITLE
Add --version option to validator binaries

### DIFF
--- a/pre_commit/clientlib/validate_base.py
+++ b/pre_commit/clientlib/validate_base.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 
 import argparse
 import os.path
+import pkg_resources
 import re
 import sys
 
@@ -71,6 +72,14 @@ def get_run_function(filenames_help, validate_strategy, exception_cls):
         argv = argv if argv is not None else sys.argv[1:]
         parser = argparse.ArgumentParser()
         parser.add_argument('filenames', nargs='*', help=filenames_help)
+        parser.add_argument(
+            '-V', '--version',
+            action='version',
+            version='%(prog)s {0}'.format(
+                pkg_resources.get_distribution('pre-commit').version
+            )
+        )
+
         args = parser.parse_args(argv)
 
         retval = 0


### PR DESCRIPTION
It would be nice if these binaries had a `--version` option as well as the `--help` option they already have.

They could use the same copy-pasted-from-stackoverflow snippet we use for the main pre-commit.

One benefit is that you can use help2man to generate man pages automatically for these validators.

(Normally these are only used as pre-commit hooks, but they can be used standalone as well. Debian wants manpages for any binaries, and we can generate them easily given `--help` and `--version`. The alternative is to not ship them with the Debian package, or to apply this patch only in the Debian package and not upstream.)