### PR TITLE
Rename validate-{config,manifest} entrypoints

### DIFF
--- a/hooks.yaml
+++ b/hooks.yaml
@@ -1,12 +1,12 @@
 -   id: validate_config
     name: Validate Pre-Commit Config
     description: This validator validates a pre-commit hooks config file
-    entry: validate-config
+    entry: pre-commit-validate-config
     language: python
     files: ^\.pre-commit-config.yaml$
 -   id: validate_manifest
     name: Validate Pre-Commit Manifest
     description: This validator validates a pre-commit hooks manifest file
-    entry: validate-manifest
+    entry: pre-commit-validate-manifest
     language: python
     files: ^hooks.yaml$

--- a/setup.py
+++ b/setup.py
@@ -51,8 +51,8 @@ setup(
     entry_points={
         'console_scripts': [
             'pre-commit = pre_commit.main:main',
-            'validate-config = pre_commit.clientlib.validate_config:run',
-            'validate-manifest = pre_commit.clientlib.validate_manifest:run',
+            'pre-commit-validate-config = pre_commit.clientlib.validate_config:run',  # noqa
+            'pre-commit-validate-manifest = pre_commit.clientlib.validate_manifest:run',  # noqa
         ],
     },
 )


### PR DESCRIPTION
This patch is needed for the Debian package. I'm not sure if you'll be interested in it upstream, but I think it's a reasonable change.

By having these entrypoints, we add the binaries `validate-config` and `validate-manifest` which are super-generic names. If a user installs pre-commit under their user or system-wide, they could end up with these confusingly-named binaries on their PATH.

I think it would be better to rename them to `pre-commit-validate-{config,manifest}` for a less ambiguous (and less generic) name. Since the primary use of these scripts is as a pre-commit hook, we can just change the entrypoint in `hooks.yaml` and won't break anybody's existing config.

The only thing this would break is if anyone is calling these scripts by hand, which seems unlikely.