### PR TITLE
[WIP] Don't run hooks on submodule roots

### DIFF
--- a/pre_commit/git.py
+++ b/pre_commit/git.py
@@ -10,6 +10,11 @@ from pre_commit.errors import FatalError
 from pre_commit.util import cmd_output
 from pre_commit.util import memoize_by_cwd
 
+# octal constants for git file modes
+GIT_MODE_FILE = 0o100644
+GIT_MODE_EXECUTABLE = 0o100755
+GIT_MODE_SYMLINK = 0o120000
+GIT_MODE_SUBMODULE = 0o160000
 
 logger = logging.getLogger('pre_commit')
 
@@ -69,7 +74,28 @@ def get_staged_files():
 
 @memoize_by_cwd
 def get_all_files():
-    return cmd_output('git', 'ls-files')[1].splitlines()
+    """Return a list of all actual files in the git repository.
+
+    There are some types of content we want to exclude.  In order to exclude
+    submodules, which git tracks similarly to files, we call `git ls-files
+    --stage` and grep out entries with the special submodule file mode.
+
+    http://stackoverflow.com/a/24122304
+    """
+    # The output format of the command is:
+    # [file mode] [object hash] [stage number]\t[file path]
+    split_regex = re.compile('^([0-7]{6}) [0-9a-f]{40} [0-9]+\t(.+)$')
+
+    def split(line):
+        match = split_regex.match(line)
+        return int(match.group(1), 8), match.group(2)
+
+    output = cmd_output('git', 'ls-files', '--stage')[1]
+    return [
+        path for mode, path in [
+            split(line) for line in output.splitlines()
+        ] if mode != GIT_MODE_SUBMODULE
+    ]
 
 
 def get_files_matching(all_file_list_strategy):


### PR DESCRIPTION
git tracks submodules like files. In particular, the roots of submodules appear in the output of `git ls-files`. This means we get weird errors like:

```
ckuehl@anthrax:~/tmp$ git init derp && cd derp
ckuehl@anthrax:~/tmp/derp$ git submodule add git@github.com:chriskuehl/dotfiles herp
ckuehl@anthrax:~/tmp/derp$ cat > .pre-commit-config.yaml
-   repo: https://github.com/pre-commit/pre-commit-hooks.git
    sha: 5dd2605fbe26937c721a8ecc0e53949d3eea4f12
    hooks:
    -   id: detect-private-key
ckuehl@anthrax:~/tmp/derp$ pre-commit run --all-files
Detect Private Key.............................................................Failed
Traceback (most recent call last):
  File "/home/c/ck/ckuehl/.pre-commit/repokqqh2jfj/py_env-default/bin/detect-private-key", line 9, in <module>
    load_entry_point('pre-commit-hooks==0.4.2', 'console_scripts', 'detect-private-key')()
  File "/home/c/ck/ckuehl/.pre-commit/repokqqh2jfj/py_env-default/local/lib/python2.7/site-packages/pre_commit_hooks/detect_private_key.py", line 15, in detect_private_key
    content = open(filename, 'rb').read()
IOError: [Errno 21] Is a directory: 'herp'
```

The only way to avoid this right now is to explicitly exclude submodule paths in you `.pre-commit-config.yaml` (or to modify every hook to check if an input file is actually a file, which seems bad).

We can exclude these with a slightly more complicated `ls-files` command.

I didn't test this extensively or even check if the tests still pass, mostly just looking to see if this looks like a reasonable solution. If it does I'll go ahead and write real tests (and test it on some older git versions to make sure it still works).