### PR TITLE
Allow specifying python version relative to user's home directory.

### DIFF
--- a/pre_commit/languages/python.py
+++ b/pre_commit/languages/python.py
@@ -31,8 +31,11 @@ def in_env(repo_cmd_runner, language_version):
 
 
 def norm_version(version):
+    version = os.path.expanduser(version)
     if os.name == 'nt':  # pragma: no cover (windows)
         if not distutils.spawn.find_executable(version):
+            # expanduser introduces a leading slash
+            version = version.strip('\\')
             # The default place for python on windows is:
             # C:\PythonXX\python.exe
             version = r'C:\{0}\python.exe'.format(version.replace('.', ''))

--- a/tests/repository_test.py
+++ b/tests/repository_test.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 import io
+import os
 import os.path
 import shutil
 
@@ -12,6 +13,7 @@ from pre_commit import five
 from pre_commit.clientlib.validate_config import CONFIG_JSON_SCHEMA
 from pre_commit.clientlib.validate_config import validate_config_extra
 from pre_commit.jsonschema_extensions import apply_defaults
+from pre_commit.languages.python import norm_version
 from pre_commit.languages.python import PythonEnv
 from pre_commit.repository import Repository
 from pre_commit.util import cmd_output
@@ -414,3 +416,15 @@ def test_local_repository():
     with pytest.raises(NotImplementedError):
         local_repo.manifest
     assert len(local_repo.hooks) == 1
+
+
+def test_norm_version_expanduser():  # pragma: no cover
+    home = os.path.expanduser('~')
+    if os.name == 'nt':
+        path = r'~\python343'
+        expected_path = r'C:{0}\python343\python.exe'.format(home)
+    else:
+        path = '~/.pyenv/versions/3.4.3/bin/python'
+        expected_path = home + '/.pyenv/versions/3.4.3/bin/python'
+    result = norm_version(path)
+    assert result == expected_path


### PR DESCRIPTION
The main use case for this PR is to more easily work with user-local python installations, particularly pyenv's. This way a user can specify `~/.pyenv/versions/3.4.3/bin/python`. This is particularly useful when working with projects across many python versions, where it doesn't make sense to have them all available on your PATH, while still keeping the .pre-commit-config.yaml portable by not specifying an absolute path.