### PR TITLE
Adding "--no-document" argument to "gem install" command for ruby-based hooks to fix issue with Cygwin

### DIFF
--- a/pre_commit/languages/ruby.py
+++ b/pre_commit/languages/ruby.py
@@ -88,7 +88,8 @@ def install_environment(repo_cmd_runner, version='default'):
             if version != 'default':
                 _install_ruby(ruby_env, version)
             ruby_env.run(
-                'cd {prefix} && gem build *.gemspec && gem install *.gem',
+                'cd {prefix} && gem build *.gemspec'
+                ' && gem install --no-document *.gem',
             )
 
 


### PR DESCRIPTION
A bit more details on this "Cygwin issue":
```
$ pre-commit run
[INFO] Installing environment for git://github.com/pre-commit/mirrors-puppet-lint.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
An unexpected error has occurred: CalledProcessError: Command: ['bash', '-c', '. /home/lucas_cimon/.pre-commit/repoiGcWZt/rbenv-default/bin/activate && cd /home/lucas_cimon/.pre-commit/repoiGcWZt/ && gem build *.gemspec && gem install *.gem']
Return code: 1
Expected return code: 0
Output:
      Successfully built RubyGem
      Name: __fake_gem
      Version: 0.0.0
      File: __fake_gem-0.0.0.gem
    Successfully installed __fake_gem-0.0.0

Errors:
    WARNING:  licenses is empty, but is recommended.  Use a license abbreviation from:
    http://opensource.org/licenses/alphabetical
    WARNING:  no email specified
    WARNING:  no homepage specified
    WARNING:  description and summary are identical
    WARNING:  See http://guides.rubygems.org/specification-reference/ for help
    ERROR:  While executing gem ... (Gem::DocumentError)
        RDoc is not installed: cannot load such file -- rdoc/rdoc


Check the log at ~/.pre-commit/pre-commit.log
```

I first tried to install the rdoc gem:
```
$ gem install rdoc
Fetching: json-1.8.3.gem (100%)
Building native extensions.  This could take a while...
ERROR:  Error installing rdoc:
        ERROR: Failed to build gem native extension.
...
/usr/lib/gcc/x86_64-pc-cygwin/4.9.2/../../../../x86_64-pc-cygwin/bin/ld: ne peut trouver -lcrypt
```

I solved that last error with `apt-cyg install libcrypt-devel`, but the initial issue in the pre-commit repo initialization was still present. Then it occured to me that simply passing the `--no-document` flag would make this fade away AND reduce the repo initialization phase for every user without any drawback (nobody will read that doc).