### PR TITLE
Allow hooks to be applied to either pre-push or pre-commit

### DIFF
--- a/pre_commit/clientlib/validate_manifest.py
+++ b/pre_commit/clientlib/validate_manifest.py
@@ -25,6 +25,13 @@ MANIFEST_JSON_SCHEMA = {
             'language_version': {'type': 'string', 'default': 'default'},
             'files': {'type': 'string'},
             'expected_return_value': {'type': 'number', 'default': 0},
+            'stages': {
+                'type': 'array',
+                'default': [],
+                'items': {
+                    'type': 'string',
+                },
+            },
             'args': {
                 'type': 'array',
                 'default': [],

--- a/pre_commit/commands/install_uninstall.py
+++ b/pre_commit/commands/install_uninstall.py
@@ -20,10 +20,11 @@ PREVIOUS_IDENTIFYING_HASHES = (
     '4d9958c90bc262f47553e2c073f14cfe',
     'd8ee923c46731b42cd95cc869add4062',
     '49fd668cb42069aa1b6048464be5d395',
+    '79f09a650522a87b0da915d0d983b2de'
 )
 
 
-IDENTIFYING_HASH = '79f09a650522a87b0da915d0d983b2de'
+IDENTIFYING_HASH = 'e358c9dae00eac5d06b38dfdb1e33a8c'
 
 
 def is_our_pre_commit(filename):

--- a/pre_commit/commands/run.py
+++ b/pre_commit/commands/run.py
@@ -175,6 +175,7 @@ def run(runner, args, write=sys_stdout_write_wrapper, environ=os.environ):
 
     with ctx:
         repo_hooks = list(get_repo_hooks(runner))
+
         if args.hook:
             repo_hooks = [
                 (repo, hook) for repo, hook in repo_hooks
@@ -183,4 +184,11 @@ def run(runner, args, write=sys_stdout_write_wrapper, environ=os.environ):
             if not repo_hooks:
                 write('No hook with id `{0}`\n'.format(args.hook))
                 return 1
+
+        # Filter hooks for stages
+        repo_hooks = [
+            (repo, hook) for repo, hook in repo_hooks
+            if not hook['stages'] or args.hook_stage in hook['stages']
+        ]
+
         return _run_hooks(repo_hooks, args, write, environ)

--- a/pre_commit/main.py
+++ b/pre_commit/main.py
@@ -87,7 +87,6 @@ def main(argv=None):
     run_parser.add_argument(
         '--verbose', '-v', action='store_true', default=False,
     )
-
     run_parser.add_argument(
         '--origin', '-o',
         help='The origin branch\'s commit_id when using `git push`',
@@ -100,6 +99,10 @@ def main(argv=None):
         '--allow-unstaged-config', default=False, action='store_true',
         help='Allow an unstaged config to be present.  Note that this will'
         'be stashed before parsing unless --no-stash is specified'
+    )
+    run_parser.add_argument(
+        '--hook-stage', choices=('commit', 'push'), default='commit',
+        help='The stage during which the hook is fired e.g. commit or push'
     )
     run_mutex_group = run_parser.add_mutually_exclusive_group(required=False)
     run_mutex_group.add_argument(

--- a/pre_commit/resources/hook-tmpl
+++ b/pre_commit/resources/hook-tmpl
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # This is a randomish md5 to identify this script
-# 79f09a650522a87b0da915d0d983b2de
+# e358c9dae00eac5d06b38dfdb1e33a8c
 
 pushd `dirname $0` > /dev/null
 HERE=`pwd`

--- a/pre_commit/resources/pre-push-tmpl
+++ b/pre_commit/resources/pre-push-tmpl
@@ -10,3 +10,5 @@ do
         fi
     fi
 done
+
+args="$args --hook-stage push"

--- a/tests/manifest_test.py
+++ b/tests/manifest_test.py
@@ -29,6 +29,7 @@ def test_manifest_contents(manifest):
         'language': 'script',
         'language_version': 'default',
         'name': 'Bash hook',
+        'stages': [],
     }]
 
 
@@ -44,4 +45,5 @@ def test_hooks(manifest):
         'language': 'script',
         'language_version': 'default',
         'name': 'Bash hook',
+        'stages': [],
     }


### PR DESCRIPTION
Solve #255

Allows hooks to be filtered to pre-commit or pre-push. The hooks section in .`pre-commit-config.yaml` can now have a `filter` key, which if defined, can be `pre-push` or `pre-commit`.

I have not written formal tests for this. If whoever is has control over this repo likes the effort, I will very happily add some unit tests and update documentation. Just to note that not only do I need this feature badly, but others (like #255) also need it.