### PR TITLE
Fix bug - pushing on an empty changeset

### DIFF
--- a/pre_commit/commands/install_uninstall.py
+++ b/pre_commit/commands/install_uninstall.py
@@ -21,10 +21,11 @@ PREVIOUS_IDENTIFYING_HASHES = (
     'd8ee923c46731b42cd95cc869add4062',
     '49fd668cb42069aa1b6048464be5d395',
     '79f09a650522a87b0da915d0d983b2de',
+    'e358c9dae00eac5d06b38dfdb1e33a8c',
 )
 
 
-IDENTIFYING_HASH = 'e358c9dae00eac5d06b38dfdb1e33a8c'
+IDENTIFYING_HASH = '138fd403232d2ddd5efb44317e38bf03'
 
 
 def is_our_pre_commit(filename):

--- a/pre_commit/resources/hook-tmpl
+++ b/pre_commit/resources/hook-tmpl
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # This is a randomish md5 to identify this script
-# e358c9dae00eac5d06b38dfdb1e33a8c
+# 138fd403232d2ddd5efb44317e38bf03
 
 pushd `dirname $0` > /dev/null
 HERE=`pwd`

--- a/pre_commit/resources/pre-push-tmpl
+++ b/pre_commit/resources/pre-push-tmpl
@@ -11,4 +11,10 @@ do
     fi
 done
 
-args="$args --hook-stage push"
+if [ "args" != "" ]; then
+    args="$args --hook-stage push"
+else
+    # If args is empty, then an attempt to push on an empty
+    # changeset is being made. In this case, just exit cleanly
+    exit 0
+fi

--- a/pre_commit/resources/pre-push-tmpl
+++ b/pre_commit/resources/pre-push-tmpl
@@ -11,7 +11,7 @@ do
     fi
 done
 
-if [ "args" != "" ]; then
+if [ "$args" != "" ]; then
     args="$args --hook-stage push"
 else
     # If args is empty, then an attempt to push on an empty

--- a/tests/commands/install_uninstall_test.py
+++ b/tests/commands/install_uninstall_test.py
@@ -472,3 +472,15 @@ def test_pre_push_integration_accepted(tempdir_factory):
         assert retc == 0
         assert 'Bash hook' in output
         assert 'Passed' in output
+
+
+def test_pre_push_integration_empty_push(tempdir_factory):
+    upstream = make_consuming_repo(tempdir_factory, 'script_hooks_repo')
+    path = tempdir_factory.get()
+    cmd_output('git', 'clone', upstream, path)
+    with cwd(path):
+        install(Runner(path), hook_type='pre-push')
+        _get_push_output(tempdir_factory)
+        retc, output = _get_push_output(tempdir_factory)
+        assert output == 'Everything up-to-date\n'
+        assert retc == 0


### PR DESCRIPTION
There is a problem when pushing an empty changeset - the command `pre-commit --hook-stage push` will be run. But actually, if the changeset is empty, there is nothing to push (everything is up to date). So we should just exit.