### PR TITLE
Get hook path method for submodule

### DIFF
--- a/pre_commit/runner.py
+++ b/pre_commit/runner.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals
 
 import os
 import os.path
+import subprocess
 
 from cached_property import cached_property
 
@@ -44,7 +45,9 @@ class Runner(object):
         return repositories
 
     def get_hook_path(self, hook_type):
-        return os.path.join(self.git_root, '.git', 'hooks', hook_type)
+        git_dir = subprocess.check_output('git rev-parse --git-dir',
+                                          shell=True)
+        return os.path.join(git_dir.strip(), 'hooks', hook_type)
 
     @cached_property
     def pre_commit_path(self):


### PR DESCRIPTION
This fixes the installation of pre-commit in submodules.

It relies on the fact that when working into the submodule, `.git` is not a directory but a file containing somethig like:
```
gitdir: ../../.git/modules/cookbooks/admin-cookbook
```

Before commit, installation gave:
```bash
$ pre-commit install
An unexpected error has occurred: OSError: [Errno 20] Not a directory: '/Users/tdeo/pricematch/chef-repo/cookbooks/admin-cookbook/.git/hooks'
Check the log at ~/.pre-commit/pre-commit.log
$ cat ~/.pre-commit/pre-commit.log
An unexpected error has occurred: OSError: [Errno 20] Not a directory: '/Users/tdeo/pricematch/chef-repo/cookbooks/admin-cookbook/.git/hooks'
Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/pre_commit/error_handler.py", line 34, in error_handler
    yield
  File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/pre_commit/main.py", line 138, in main
    hook_type=args.hook_type,
  File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/pre_commit/commands/install_uninstall.py", line 58, in install
    os.makedirs(os.path.dirname(hook_path))
  File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/os.py", line 157, in makedirs
    mkdir(name, mode)
OSError: [Errno 20] Not a directory: '/Users/tdeo/pricematch/chef-repo/cookbooks/admin-cookbook/.git/hooks'
```

And now:
```bash
$ pre-commit install
pre-commit installed at /Users/tdeo/pricematch/chef-repo/cookbooks/admin-cookbook/../../.git/modules/cookbooks/admin-cookbook/hooks/pre-commit
```

We could use something like `os.path.realpath` to have the path displayed without `../` parts, but I wanted to keep the commit as small as possible