### PR TITLE
Allow args for pcre hook

### DIFF
--- a/pre_commit/languages/pcre.py
+++ b/pre_commit/languages/pcre.py
@@ -25,7 +25,9 @@ def run_hook(repo_cmd_runner, hook, file_args):
             'xargs', '-0', 'sh', '-c',
             # Grep usually returns 0 for matches, and nonzero for non-matches
             # so we flip it here.
-            '! {0} {1} $@'.format(grep_command, shell_escape(hook['entry'])),
+            '! {0} {1} {2} $@'.format(
+                grep_command, ' '.join(hook['args']),
+                shell_escape(hook['entry'])),
             '--',
         ],
         stdin=file_args_to_stdin(file_args),

--- a/testing/resources/pcre_hooks_repo/hooks.yaml
+++ b/testing/resources/pcre_hooks_repo/hooks.yaml
@@ -8,3 +8,9 @@
     entry: ^\[INFO\]
     language: pcre
     files: ''
+-   id: regex-with-grep-args
+    name: Regex with grep extra arguments
+    entry: foo\sbar
+    language: pcre
+    files: ''
+    args: [-z]

--- a/tests/repository_test.py
+++ b/tests/repository_test.py
@@ -224,6 +224,21 @@ def test_pcre_hook_matching(tempdir_factory, store):
 
 @xfailif_no_pcre_support
 @pytest.mark.integration
+def test_pcre_hook_extra_multiline_option(tempdir_factory, store):
+    path = git_dir(tempdir_factory)
+    with cwd(path):
+        with io.open('herp', 'w') as herp:
+            herp.write("foo\nbar\n")
+
+        _test_hook_repo(
+            tempdir_factory, store, 'pcre_hooks_repo',
+            'regex-with-grep-args', ['herp'], b"herp:1:foo\nbar\n\x00",
+            expected_return_code=123,
+        )
+
+
+@xfailif_no_pcre_support
+@pytest.mark.integration
 def test_pcre_many_files(tempdir_factory, store):
     # This is intended to simulate lots of passing files and one failing file
     # to make sure it still fails.  This is not the case when naively using


### PR DESCRIPTION
This allows to specify a list of args for pcre hook. I'd like to use pcre hook for multiline match, which can be achieved by adding a `-z` option to `grep`.