### PR TITLE
Use a different test for grep flags to support old grep

### DIFF
--- a/testing/resources/pcre_hooks_repo/hooks.yaml
+++ b/testing/resources/pcre_hooks_repo/hooks.yaml
@@ -10,7 +10,7 @@
     files: ''
 -   id: regex-with-grep-args
     name: Regex with grep extra arguments
-    entry: foo\sbar
+    entry: foo.+bar
     language: pcre
     files: ''
-    args: [-z]
+    args: [-i]

--- a/tests/repository_test.py
+++ b/tests/repository_test.py
@@ -224,15 +224,15 @@ def test_pcre_hook_matching(tempdir_factory, store):
 
 @xfailif_no_pcre_support
 @pytest.mark.integration
-def test_pcre_hook_extra_multiline_option(tempdir_factory, store):
+def test_pcre_hook_case_insensitive_option(tempdir_factory, store):
     path = git_dir(tempdir_factory)
     with cwd(path):
         with io.open('herp', 'w') as herp:
-            herp.write("foo\nbar\n")
+            herp.write('FoOoOoObar\n')
 
         _test_hook_repo(
             tempdir_factory, store, 'pcre_hooks_repo',
-            'regex-with-grep-args', ['herp'], b"herp:1:foo\nbar\n\x00",
+            'regex-with-grep-args', ['herp'], b'herp:1:FoOoOoObar\n',
             expected_return_code=123,
         )
 


### PR DESCRIPTION
@tdeo @asottile 

This switches to a slightly different grep flag test since on some versions of grep I get an error:

    grep: The -P and -z options cannot be combined

...which causes the tests to fail.