### PR TITLE
Output a message when a hook fails due to file modification

### DIFF
--- a/testing/resources/modified_file_returns_zero_repo/bin/hook3.sh
+++ b/testing/resources/modified_file_returns_zero_repo/bin/hook3.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+for f in $@; do
+    # Non UTF-8 bytes
+    echo -e '\x01\x97' > "$f"
+done

--- a/testing/resources/modified_file_returns_zero_repo/hooks.yaml
+++ b/testing/resources/modified_file_returns_zero_repo/hooks.yaml
@@ -2,9 +2,14 @@
     name: Bash hook
     entry: bin/hook.sh
     language: script
-    files: ''
+    files: 'foo.py'
 -   id: bash_hook2
     name: Bash hook
     entry: bin/hook2.sh
     language: script
     files: ''
+-   id: bash_hook3
+    name: Bash hook
+    entry: bin/hook3.sh
+    language: script
+    files: 'bar.py'

--- a/tests/commands/run_test.py
+++ b/tests/commands/run_test.py
@@ -40,9 +40,9 @@ def repo_with_failing_hook(tempdir_factory):
         yield git_path
 
 
-def stage_a_file():
-    cmd_output('touch', 'foo.py')
-    cmd_output('git', 'add', 'foo.py')
+def stage_a_file(filename='foo.py'):
+    cmd_output('touch', filename)
+    cmd_output('git', 'add', filename)
 
 
 def get_write_mock_output(write_mock):
@@ -127,16 +127,22 @@ def test_hook_that_modifies_but_returns_zero(
         tempdir_factory, 'modified_file_returns_zero_repo',
     )
     with cwd(git_path):
+        stage_a_file('bar.py')
         _test_run(
             git_path,
             {},
             (
                 # The first should fail
                 b'Failed',
-                # With a modified file (the hook's output)
+                # With a modified file (default message + the hook's output)
+                b'Files were modified by this hook. Additional output:\n\n'
                 b'Modified: foo.py',
                 # The next hook should pass despite the first modifying
                 b'Passed',
+                # The next hook should fail
+                b'Failed',
+                # bar.py was modified, but provides no additional output
+                b'Files were modified by this hook.\n',
             ),
             1,
             True,


### PR DESCRIPTION
For some linters such as eslint, there is no output on a successful --fix operation. This provides a basic message to the user which indicates that their hook failed due to a file modification.

Feel free to change the text to something better, but I wanted to keep it generic since perhaps some hooks may not be 'fixing' anything - ideally the text for eslint would say 'Files were fixed in this hook' or 'Fixing files...'. Another option here could be 'Modifying files...' to match similar text in hooks such as autopep8 (which uses the same style in 'Fixing ___').