### PR TITLE
Support repos without hooks.yaml by reading a local config

### DIFF
--- a/pre_commit/constants.py
+++ b/pre_commit/constants.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 
 CONFIG_FILE = '.pre-commit-config.yaml'
 
+EXTERNAL_MANIFEST_FILE = '.pre-commit-hooks-config.yaml'
 MANIFEST_FILE = 'hooks.yaml'
 
 YAML_DUMP_KWARGS = {

--- a/pre_commit/manifest.py
+++ b/pre_commit/manifest.py
@@ -8,17 +8,34 @@ import pre_commit.constants as C
 from pre_commit.clientlib.validate_manifest import load_manifest
 
 
-class Manifest(object):
-    def __init__(self, repo_path_getter):
-        self.repo_path_getter = repo_path_getter
+class BaseManifest(object):
+    def __init__(self):
+        pass
 
     @cached_property
     def manifest_contents(self):
-        manifest_path = os.path.join(
-            self.repo_path_getter.repo_path, C.MANIFEST_FILE,
-        )
-        return load_manifest(manifest_path)
+        return load_manifest(self.manifest_path)
 
     @cached_property
     def hooks(self):
         return dict((hook['id'], hook) for hook in self.manifest_contents)
+
+    def exists(self):
+        return os.path.isfile(self.manifest_path)
+
+
+class Manifest(BaseManifest):
+    def __init__(self, repo_path_getter):
+        super(Manifest, self).__init__()
+
+        self.repo_path_getter = repo_path_getter
+        self.manifest_path = os.path.join(
+            self.repo_path_getter.repo_path, C.MANIFEST_FILE,
+        )
+
+
+class ExternalManifest(BaseManifest):
+    def __init__(self, path):
+        super(ExternalManifest, self).__init__()
+        self.path = path
+        self.manifest_path = os.path.join(path, C.EXTERNAL_MANIFEST_FILE)

--- a/pre_commit/repository.py
+++ b/pre_commit/repository.py
@@ -17,7 +17,7 @@ from pre_commit.clientlib.validate_manifest import MANIFEST_JSON_SCHEMA
 from pre_commit.jsonschema_extensions import apply_defaults
 from pre_commit.languages.all import languages
 from pre_commit.languages.helpers import environment_dir
-from pre_commit.manifest import Manifest
+from pre_commit.manifest import ExternalManifest, Manifest
 from pre_commit.prefixed_command_runner import PrefixedCommandRunner
 
 
@@ -102,7 +102,10 @@ class Repository(object):
 
     @cached_property
     def manifest(self):
-        return Manifest(self.repo_path_getter)
+        m = Manifest(self.repo_path_getter)
+        if not m.exists():
+            m = ExternalManifest(git.get_root())
+        return m
 
     @cached_property
     def cmd_runner(self):

--- a/pre_commit/repository.py
+++ b/pre_commit/repository.py
@@ -17,7 +17,8 @@ from pre_commit.clientlib.validate_manifest import MANIFEST_JSON_SCHEMA
 from pre_commit.jsonschema_extensions import apply_defaults
 from pre_commit.languages.all import languages
 from pre_commit.languages.helpers import environment_dir
-from pre_commit.manifest import ExternalManifest, Manifest
+from pre_commit.manifest import ExternalManifest
+from pre_commit.manifest import Manifest
 from pre_commit.prefixed_command_runner import PrefixedCommandRunner
 
 


### PR DESCRIPTION
If a repo does not have a hooks.yaml any hook ids are then looked for in
.pre-commit-hooks-config.yaml in the repo that is under test. It has the same
format as a standard hooks.yaml.

The purpose of this change is to avoid needing to mirror a linter repo just
to call it. Long term, tools could be reference by a URL or other source than
a git repo making having a mirror repo even more of a hassle.