### PR TITLE
Making it possible to invoke `pre-commit run --files some.file` from a subdirectory of the repository

### DIFF
--- a/pre_commit/main.py
+++ b/pre_commit/main.py
@@ -8,6 +8,7 @@ import pkg_resources
 
 from pre_commit import color
 from pre_commit import five
+from pre_commit import git
 from pre_commit.commands.autoupdate import autoupdate
 from pre_commit.commands.clean import clean
 from pre_commit.commands.install_uninstall import install
@@ -110,7 +111,8 @@ def main(argv=None):
         help='Run on all the files in the repo.  Implies --no-stash.',
     )
     run_mutex_group.add_argument(
-        '--files', nargs='*', help='Specific filenames to run hooks on.',
+        '--files', nargs='*', default=[],
+        help='Specific filenames to run hooks on.',
     )
 
     help = subparsers.add_parser(
@@ -122,6 +124,11 @@ def main(argv=None):
     if len(argv) == 0:
         argv = ['run']
     args = parser.parse_args(argv)
+    if args.command == 'run':
+        args.files = [
+            os.path.relpath(os.path.abspath(filename), git.get_root())
+            for filename in args.files
+        ]
 
     if args.command == 'help':
         if args.help_cmd:

--- a/pre_commit/runner.py
+++ b/pre_commit/runner.py
@@ -24,7 +24,7 @@ class Runner(object):
     def create(cls):
         """Creates a PreCommitRunner by doing the following:
             - Finds the root of the current git repository
-            - chdirs to that directory
+            - chdir to that directory
         """
         root = git.get_root()
         os.chdir(root)

--- a/testing/fixtures.py
+++ b/testing/fixtures.py
@@ -110,8 +110,14 @@ def add_config_to_repo(git_path, config):
     return git_path
 
 
-def make_consuming_repo(tempdir_factory, repo_source):
+def make_consuming_repo(tempdir_factory, repo_source, local_hooks=None):
     path = make_repo(tempdir_factory, repo_source)
-    config = make_config_from_repo(path)
+    if local_hooks:
+        config = OrderedDict((
+            ('repo', 'local'),
+            ('hooks', local_hooks),
+        ))
+    else:
+        config = make_config_from_repo(path)
     git_path = git_dir(tempdir_factory)
     return add_config_to_repo(git_path, config)


### PR DESCRIPTION
I included a new test (that does not pass with `pre-commit` current version) to illustrate the problem