### PR TITLE
Support terminal width on windows.  Resolves #199

### DIFF
--- a/pre_commit/output.py
+++ b/pre_commit/output.py
@@ -1,27 +1,15 @@
 from __future__ import unicode_literals
 
-import os
-import subprocess
 import sys
+
+from backports.shutil_get_terminal_size import get_terminal_size
 
 from pre_commit import color
 from pre_commit import five
 
-
 # TODO: smell: import side-effects
-try:
-    if not os.environ.get('TERM'):  # pragma: no cover (dumb terminal)
-        raise OSError('Cannot determine width without TERM')
-    else:  # pragma no cover (windows)
-        COLS = int(
-            subprocess.Popen(
-                ('tput', 'cols'), stdout=subprocess.PIPE,
-            ).communicate()[0] or
-            # Default in the case of no terminal
-            80
-        )
-except OSError:  # pragma: no cover (windows)
-    COLS = 80
+# TODO: https://github.com/chrippa/backports.shutil_get_terminal_size/issues/4
+COLS = get_terminal_size().columns or 80
 
 
 def get_hook_message(

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ setup(
     install_requires=[
         'argparse',
         'aspy.yaml',
+        'backports.shutil_get_terminal_size',
         'cached-property',
         'jsonschema',
         'nodeenv>=0.11.1',


### PR DESCRIPTION
Hit https://github.com/chrippa/backports.shutil_get_terminal_size/issues/4 while implementing.  Should be fixed entirely by my PR there (and worked around by `or 80` in this PR)