### PR TITLE
Set up logging handler in autoupdate

### DIFF
--- a/pre_commit/commands/autoupdate.py
+++ b/pre_commit/commands/autoupdate.py
@@ -1,18 +1,18 @@
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import sys
 import logging
+import sys
 
 from aspy.yaml import ordered_dump
 from aspy.yaml import ordered_load
 
 import pre_commit.constants as C
-from pre_commit.logging_handler import LoggingHandler
 from pre_commit.clientlib.validate_config import CONFIG_JSON_SCHEMA
 from pre_commit.clientlib.validate_config import is_local_hooks
 from pre_commit.clientlib.validate_config import load_config
 from pre_commit.jsonschema_extensions import remove_defaults
+from pre_commit.logging_handler import LoggingHandler
 from pre_commit.ordereddict import OrderedDict
 from pre_commit.repository import Repository
 from pre_commit.util import cmd_output

--- a/pre_commit/commands/autoupdate.py
+++ b/pre_commit/commands/autoupdate.py
@@ -2,11 +2,13 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import sys
+import logging
 
 from aspy.yaml import ordered_dump
 from aspy.yaml import ordered_load
 
 import pre_commit.constants as C
+from pre_commit.logging_handler import LoggingHandler
 from pre_commit.clientlib.validate_config import CONFIG_JSON_SCHEMA
 from pre_commit.clientlib.validate_config import is_local_hooks
 from pre_commit.clientlib.validate_config import load_config
@@ -15,6 +17,9 @@ from pre_commit.ordereddict import OrderedDict
 from pre_commit.repository import Repository
 from pre_commit.util import cmd_output
 from pre_commit.util import cwd
+
+
+logger = logging.getLogger('pre_commit')
 
 
 class RepositoryCannotBeUpdatedError(RuntimeError):
@@ -58,6 +63,10 @@ def _update_repository(repo_config, runner):
 
 def autoupdate(runner):
     """Auto-update the pre-commit config to the latest versions of repos."""
+    # Set up our logging handler
+    logger.addHandler(LoggingHandler(False))
+    logger.setLevel(logging.WARNING)
+
     retv = 0
     output_configs = []
     changed = False


### PR DESCRIPTION
When running ```autoupdate``` with a hook in .pre-commit.yaml that does not exist in the current version of the repository there is an error: ```No handlers could be found for logger "pre_commit"```

Before:
```
$ pre-commit autoupdate

Updating git://github.com/pre-commit/pre-commit-hooks...already up to date.
Updating git://github.com/trbs/pre-commit-hooks-trbs.git...No handlers could be found for logger "pre_commit"
```

After:
```
pre-commit autoupdate
Updating git://github.com/pre-commit/pre-commit-hooks...already up to date.
Updating git://github.com/trbs/pre-commit-hooks-trbs.git...[ERROR] `flake8` is not present in repository git://github.com/trbs/pre-commit-hooks-trbs.git.  Typo? Perhaps it is introduced in a newer version?  Often `pre-commit autoupdate` fixes this.
```

The error message is now a tiny bit misleading, since we are actually running ```autoupdate``` while this error is generated. Maybe change the wording a little bit so that it's clearer that the new hook can only be introduced in ```.pre-commit.yaml``` _after_ ```autoupdate``` has been ran.