### PR TITLE
only consider forward diff in changed files

### DIFF
--- a/pre_commit/commands/run.py
+++ b/pre_commit/commands/run.py
@@ -51,7 +51,7 @@ def _print_user_skipped(hook, write, args):
 
 def get_changed_files(new, old):
     return cmd_output(
-        'git', 'diff', '--name-only', '{0}..{1}'.format(old, new),
+        'git', 'diff', '--name-only', '{0}...{1}'.format(old, new),
     )[1].splitlines()
 
 

--- a/tests/commands/run_test.py
+++ b/tests/commands/run_test.py
@@ -401,6 +401,10 @@ def test_get_changed_files():
     )
     assert files == ['CHANGELOG.md', 'setup.py']
 
+    # files changed in source but not in origin should not be returned
+    files = get_changed_files('HEAD~10', 'HEAD')
+    assert files == []
+
 
 def test_lots_of_files(mock_out_store_directory, tempdir_factory):
     # windows xargs seems to have a bug, here's a regression test for


### PR DESCRIPTION
Consider we have a branch A.
I create two branches B, C from A and make changes independently.
I merge changes from C into A.
Now if I run pre-commit between A and B, diff shows the changes from branch C also.