### PR TITLE
Clarify/correct error message

### DIFF
--- a/pre_commit/git.py
+++ b/pre_commit/git.py
@@ -20,7 +20,8 @@ def get_root():
         return cmd_output('git', 'rev-parse', '--show-toplevel')[1].strip()
     except CalledProcessError:
         raise FatalError(
-            'Called from outside of the gits.  Please cd to a git repository.'
+            'git failed. Is it installed, and are you in a Git repository '
+            'directory?'
         )
 
 


### PR DESCRIPTION
The error also occurs if the `git` utility isn't available.