### PR TITLE
Fix staged-files-only with a non-utf8-trailing-whitespace diff.  Resolves #397

### DIFF
--- a/pre_commit/staged_files_only.py
+++ b/pre_commit/staged_files_only.py
@@ -45,7 +45,7 @@ def staged_files_only(cmd_runner):
         finally:
             # Try to apply the patch we saved
             try:
-                cmd_runner.run(['git', 'apply', patch_filename])
+                cmd_runner.run(('git', 'apply', patch_filename), encoding=None)
             except CalledProcessError:
                 logger.warning(
                     'Stashed changes conflicted with hook auto-fixes... '
@@ -55,7 +55,7 @@ def staged_files_only(cmd_runner):
                 # by hooks.
                 # Roll back the changes made by hooks.
                 cmd_runner.run(['git', 'checkout', '--', '.'])
-                cmd_runner.run(['git', 'apply', patch_filename])
+                cmd_runner.run(('git', 'apply', patch_filename), encoding=None)
             logger.info('Restored changes from {0}.'.format(patch_filename))
     else:
         # There weren't any staged files so we don't need to do anything


### PR DESCRIPTION
CC @Lucas-C 