### PR TITLE
Fix file stashing with external diff tool

### DIFF
--- a/pre_commit/staged_files_only.py
+++ b/pre_commit/staged_files_only.py
@@ -23,7 +23,7 @@ def staged_files_only(cmd_runner):
     retcode, diff_stdout_binary, _ = cmd_runner.run(
         [
             'git', 'diff', '--ignore-submodules', '--binary', '--exit-code',
-            '--no-color',
+            '--no-color', '--no-ext-diff',
         ],
         retcode=None,
         encoding=None,


### PR DESCRIPTION
When git is configured to use an external diff tool to show diffs
(eg. 'git config diff.external mytool'), the stashing unstaged files
will create an empty file that can't be recovered.

Some modifications are permanently lost...

Just disable the ext-diff of git diff to avoid any issue.

(Question to pre-commit devs: why not using git stash directly ?)