### PR TITLE
Warn on cygwin python/git mismatch.  Resolves #354

### DIFF
--- a/pre_commit/main.py
+++ b/pre_commit/main.py
@@ -152,6 +152,7 @@ def main(argv=None):
 
     with error_handler():
         add_logging_handler(args.color)
+        git.check_for_cygwin_mismatch()
         runner = Runner.create()
 
         if args.command == 'install':


### PR DESCRIPTION
## With cygwin git:

```
$ ../pre-commit/venv_windows_python/Scripts/pre-commit
[WARNING] pre-commit has detected a mix of cygwin python / git
This combination is not supported, it is likely you will receive an error later in the program.
Make sure to use cygwin git+python while using cygwin
These can be installed through the cygwin installer.
 - python (windows)
 - git (cygwin)

An unexpected error has occurred: WindowsError: [Error 3] The system cannot find the path specified: u'/tmp/empty'
Check the log at ~/.pre-commit/pre-commit.log
```

```
$ ../pre-commit/venv_cygwin_python/bin/pre-commit
Flake8...............................................(no files to check)Skipped
```

## Without cygwin git:

```
$ ../pre-commit/venv_cygwin_python/bin/pre-commit
[WARNING] pre-commit has detected a mix of cygwin python / git
This combination is not supported, it is likely you will receive an error later in the program.
Make sure to use cygwin git+python while using cygwin
These can be installed through the cygwin installer.
 - python (cygwin)
 - git (windows)

[INFO] Initializing environment for https://github.com/pre-commit/pre-commit-hooks.git.
An unexpected error has occurred: CalledProcessError: Command: ('/cygdrive/c/Users/Anthony/AppData/Local/Programs/Git/cmd/git', 'reset', 'cf550fcab3f12015f8676b8278b30e1a5bc10e70', '--hard')
Return code: 128
Expected return code: 0
Output: (none)
Errors:
    fatal: Not a git repository (or any of the parent directories): .git


Check the log at ~/.pre-commit/pre-commit.log
```

```
$ ../pre-commit/venv_windows_python/Scripts/pre-commit
Flake8...............................................(no files to check)Skipped
```