### PR TITLE
Fix test error "fatal: empty ident name (for <(null)>) not allowed"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,7 @@ env: # These should match the tox env list
     - TOXENV=py27 LATEST_GIT=1
 install: pip install coveralls tox
 script: tox
-# Special snowflake.  Our tests depend on making real commits.
 before_install:
-    - git config --global user.name "Travis CI"
-    - git config --global user.email "user@example.com"
     # Our tests inspect some of *our* git history
     - git fetch --unshallow
     - git --version

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,8 +13,6 @@ install:
 build: false
 
 before_test:
-  - git config --global user.name "AppVeyor CI"
-  - git config --global user.email "user@example.com"
   # Shut up CRLF messages
   - git config --global core.safecrlf false
 

--- a/tests/commands/install_uninstall_test.py
+++ b/tests/commands/install_uninstall_test.py
@@ -223,16 +223,17 @@ def test_environment_not_sourced(tempdir_factory):
 
         # Use a specific homedir to ignore --user installs
         homedir = tempdir_factory.get()
-        # Need this so we can call git commit without sploding
-        with io.open(os.path.join(homedir, '.gitconfig'), 'w') as gitconfig:
-            gitconfig.write(
-                '[user]\n'
-                '    name = Travis CI\n'
-                '    email = user@example.com\n'
-            )
         ret, stdout, stderr = cmd_output(
             'git', 'commit', '--allow-empty', '-m', 'foo',
-            env={'HOME': homedir, 'PATH': _path_without_us()},
+            env={
+                'HOME': homedir,
+                'PATH': _path_without_us(),
+                # Git needs this to make a commit
+                'GIT_AUTHOR_NAME': os.environ['GIT_AUTHOR_NAME'],
+                'GIT_COMMITTER_NAME': os.environ['GIT_COMMITTER_NAME'],
+                'GIT_AUTHOR_EMAIL': os.environ['GIT_AUTHOR_EMAIL'],
+                'GIT_COMMITTER_EMAIL': os.environ['GIT_COMMITTER_EMAIL'],
+            },
             retcode=None,
         )
         assert ret == 1
@@ -474,6 +475,11 @@ def test_installed_from_venv(tempdir_factory):
                 'SYSTEMROOT': os.environ.get('SYSTEMROOT', ''),
                 # Windows needs this to resolve executables
                 'PATHEXT': os.environ.get('PATHEXT', ''),
+                # Git needs this to make a commit
+                'GIT_AUTHOR_NAME': os.environ['GIT_AUTHOR_NAME'],
+                'GIT_COMMITTER_NAME': os.environ['GIT_COMMITTER_NAME'],
+                'GIT_AUTHOR_EMAIL': os.environ['GIT_AUTHOR_EMAIL'],
+                'GIT_COMMITTER_EMAIL': os.environ['GIT_COMMITTER_EMAIL'],
             },
         )
         assert ret == 0

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,12 @@ envlist = py27,py34,py35,pypy
 [testenv]
 deps = -rrequirements-dev.txt
 passenv = HOME HOMEPATH PROGRAMDATA TERM
-setenv = VIRTUALENV_NO_DOWNLOAD=1
+setenv =
+    VIRTUALENV_NO_DOWNLOAD = 1
+    GIT_AUTHOR_NAME = "test"
+    GIT_COMMITTER_NAME = "test"
+    GIT_AUTHOR_EMAIL = "test@example.com"
+    GIT_COMMITTER_EMAIL = "test@example.com"
 commands =
     coverage erase
     coverage run -m pytest {posargs:tests}


### PR DESCRIPTION
Occurs when tests run with tox not with Travis CI or Appveyor

Changed existing tox setenv statement to use whitespace around `=` as per
http://tox.readthedocs.io/en/latest/example/basic.html#setting-environment-variables

Related to https://github.com/pre-commit/pre-commit-hooks/pull/154 and https://github.com/pre-commit/pre-commit-hooks/pull/155