### PR TITLE
Add option to run from alternate config file

### DIFF
--- a/pre_commit/main.py
+++ b/pre_commit/main.py
@@ -34,6 +34,10 @@ def _add_color_option(parser):
     )
 
 
+def _add_config_option(parser):
+    parser.add_argument('-c', '--config', help='Path to alternate config file')
+
+
 def main(argv=None):
     argv = argv if argv is not None else sys.argv[1:]
     argv = [five.to_text(arg) for arg in argv]
@@ -89,6 +93,7 @@ def main(argv=None):
         help="Auto-update pre-commit config to the latest repos' versions.",
     )
     _add_color_option(autoupdate_parser)
+    _add_config_option(autoupdate_parser)
 
     run_parser = subparsers.add_parser('run', help='Run hooks.')
     _add_color_option(run_parser)
@@ -119,6 +124,7 @@ def main(argv=None):
         '--hook-stage', choices=('commit', 'push'), default='commit',
         help='The stage during which the hook is fired e.g. commit or push.',
     )
+    _add_config_option(run_parser)
     run_mutex_group = run_parser.add_mutually_exclusive_group(required=False)
     run_mutex_group.add_argument(
         '--all-files', '-a', action='store_true', default=False,
@@ -152,7 +158,10 @@ def main(argv=None):
 
     with error_handler():
         add_logging_handler(args.color)
-        runner = Runner.create()
+        runner_kwargs = {}
+        if hasattr(args, 'config_file'):
+            runner_kwargs['config_file'] = args.config_file
+        runner = Runner.create(**runner_kwargs)
         git.check_for_cygwin_mismatch()
 
         if args.command == 'install':

--- a/pre_commit/main.py
+++ b/pre_commit/main.py
@@ -35,7 +35,10 @@ def _add_color_option(parser):
 
 
 def _add_config_option(parser):
-    parser.add_argument('-c', '--config', help='Path to alternate config file')
+    parser.add_argument(
+        '-c', '--config', default='.pre-commit-config.yaml',
+        help='Path to alternate config file'
+    )
 
 
 def main(argv=None):
@@ -43,6 +46,7 @@ def main(argv=None):
     argv = [five.to_text(arg) for arg in argv]
     parser = argparse.ArgumentParser()
 
+    parser.set_defaults(config='.pre-commit-config.yaml')
     # http://stackoverflow.com/a/8521644/812183
     parser.add_argument(
         '-V', '--version',
@@ -58,6 +62,7 @@ def main(argv=None):
         'install', help='Install the pre-commit script.',
     )
     _add_color_option(install_parser)
+    _add_config_option(install_parser)
     install_parser.add_argument(
         '-f', '--overwrite', action='store_true',
         help='Overwrite existing hooks / remove migration mode.',
@@ -78,6 +83,7 @@ def main(argv=None):
         'uninstall', help='Uninstall the pre-commit script.',
     )
     _add_color_option(uninstall_parser)
+    _add_config_option(uninstall_parser)
     uninstall_parser.add_argument(
         '-t', '--hook-type', choices=('pre-commit', 'pre-push'),
         default='pre-commit',
@@ -87,7 +93,7 @@ def main(argv=None):
         'clean', help='Clean out pre-commit files.',
     )
     _add_color_option(clean_parser)
-
+    _add_config_option(clean_parser)
     autoupdate_parser = subparsers.add_parser(
         'autoupdate',
         help="Auto-update pre-commit config to the latest repos' versions.",
@@ -97,6 +103,7 @@ def main(argv=None):
 
     run_parser = subparsers.add_parser('run', help='Run hooks.')
     _add_color_option(run_parser)
+    _add_config_option(run_parser)
     run_parser.add_argument('hook', nargs='?', help='A single hook-id to run')
     run_parser.add_argument(
         '--no-stash', default=False, action='store_true',
@@ -124,7 +131,6 @@ def main(argv=None):
         '--hook-stage', choices=('commit', 'push'), default='commit',
         help='The stage during which the hook is fired e.g. commit or push.',
     )
-    _add_config_option(run_parser)
     run_mutex_group = run_parser.add_mutually_exclusive_group(required=False)
     run_mutex_group.add_argument(
         '--all-files', '-a', action='store_true', default=False,
@@ -158,10 +164,7 @@ def main(argv=None):
 
     with error_handler():
         add_logging_handler(args.color)
-        runner_kwargs = {}
-        if hasattr(args, 'config_file'):
-            runner_kwargs['config_file'] = args.config_file
-        runner = Runner.create(**runner_kwargs)
+        runner = Runner.create(args.config)
         git.check_for_cygwin_mismatch()
 
         if args.command == 'install':

--- a/pre_commit/main.py
+++ b/pre_commit/main.py
@@ -46,7 +46,6 @@ def main(argv=None):
     argv = [five.to_text(arg) for arg in argv]
     parser = argparse.ArgumentParser()
 
-    parser.set_defaults(config='.pre-commit-config.yaml')
     # http://stackoverflow.com/a/8521644/812183
     parser.add_argument(
         '-V', '--version',

--- a/pre_commit/runner.py
+++ b/pre_commit/runner.py
@@ -4,7 +4,6 @@ import os.path
 
 from cached_property import cached_property
 
-import pre_commit.constants as C
 from pre_commit import git
 from pre_commit.clientlib.validate_config import load_config
 from pre_commit.repository import Repository
@@ -16,19 +15,19 @@ class Runner(object):
     repository under test.
     """
 
-    def __init__(self, git_root, config_file=None):
+    def __init__(self, git_root, config_file):
         self.git_root = git_root
-        self.config_file = config_file or C.CONFIG_FILE
+        self.config_file = config_file
 
     @classmethod
-    def create(cls, config_file=None):
+    def create(cls, config_file):
         """Creates a PreCommitRunner by doing the following:
             - Finds the root of the current git repository
             - chdir to that directory
         """
         root = git.get_root()
         os.chdir(root)
-        return cls(root, config_file=config_file)
+        return cls(root, config_file)
 
     @cached_property
     def git_dir(self):

--- a/pre_commit/runner.py
+++ b/pre_commit/runner.py
@@ -16,18 +16,19 @@ class Runner(object):
     repository under test.
     """
 
-    def __init__(self, git_root):
+    def __init__(self, git_root, config_file=None):
         self.git_root = git_root
+        self.config_file = config_file or C.CONFIG_FILE
 
     @classmethod
-    def create(cls):
+    def create(cls, config_file=None):
         """Creates a PreCommitRunner by doing the following:
             - Finds the root of the current git repository
             - chdir to that directory
         """
         root = git.get_root()
         os.chdir(root)
-        return cls(root)
+        return cls(root, config_file=config_file)
 
     @cached_property
     def git_dir(self):
@@ -35,7 +36,7 @@ class Runner(object):
 
     @cached_property
     def config_file_path(self):
-        return os.path.join(self.git_root, C.CONFIG_FILE)
+        return os.path.join(self.git_root, self.config_file)
 
     @cached_property
     def repositories(self):

--- a/testing/fixtures.py
+++ b/testing/fixtures.py
@@ -94,18 +94,24 @@ def make_config_from_repo(repo_path, sha=None, hooks=None, check=True):
         return config
 
 
-def write_config(directory, config):
+def read_config(directory, config_file=C.CONFIG_FILE):
+    config_path = os.path.join(directory, config_file)
+    config = ordered_load(io.open(config_path).read())
+    return config
+
+
+def write_config(directory, config, config_file=C.CONFIG_FILE):
     if type(config) is not list:
         assert type(config) is OrderedDict
         config = [config]
-    with io.open(os.path.join(directory, C.CONFIG_FILE), 'w') as config_file:
-        config_file.write(ordered_dump(config, **C.YAML_DUMP_KWARGS))
+    with io.open(os.path.join(directory, config_file), 'w') as outfile:
+        outfile.write(ordered_dump(config, **C.YAML_DUMP_KWARGS))
 
 
-def add_config_to_repo(git_path, config):
-    write_config(git_path, config)
+def add_config_to_repo(git_path, config, config_file=C.CONFIG_FILE):
+    write_config(git_path, config, config_file=config_file)
     with cwd(git_path):
-        cmd_output('git', 'add', C.CONFIG_FILE)
+        cmd_output('git', 'add', config_file)
         cmd_output('git', 'commit', '-m', 'Add hooks config')
     return git_path
 

--- a/tests/commands/autoupdate_test.py
+++ b/tests/commands/autoupdate_test.py
@@ -45,7 +45,7 @@ def test_autoupdate_up_to_date_repo(
 
     before = open(C.CONFIG_FILE).read()
     assert '^$' not in before
-    runner = Runner('.')
+    runner = Runner('.', C.CONFIG_FILE)
     ret = autoupdate(runner)
     after = open(C.CONFIG_FILE).read()
     assert ret == 0
@@ -86,7 +86,7 @@ def test_autoupdate_out_of_date_repo(
     write_config('.', config)
 
     before = open(C.CONFIG_FILE).read()
-    runner = Runner('.')
+    runner = Runner('.', C.CONFIG_FILE)
     ret = autoupdate(runner)
     after = open(C.CONFIG_FILE).read()
     assert ret == 0
@@ -111,7 +111,7 @@ def test_autoupdate_tagged_repo(
     )
     write_config('.', config)
 
-    ret = autoupdate(Runner('.'))
+    ret = autoupdate(Runner('.', C.CONFIG_FILE))
     assert ret == 0
     assert 'v1.2.3' in open(C.CONFIG_FILE).read()
 
@@ -156,7 +156,7 @@ def test_autoupdate_hook_disappearing_repo(
     write_config('.', config)
 
     before = open(C.CONFIG_FILE).read()
-    runner = Runner('.')
+    runner = Runner('.', C.CONFIG_FILE)
     ret = autoupdate(runner)
     after = open(C.CONFIG_FILE).read()
     assert ret == 1
@@ -167,7 +167,7 @@ def test_autoupdate_local_hooks(tempdir_factory):
     git_path = git_dir(tempdir_factory)
     config = config_with_local_hooks()
     path = add_config_to_repo(git_path, config)
-    runner = Runner(path)
+    runner = Runner(path, C.CONFIG_FILE)
     assert autoupdate(runner) == 0
     new_config_writen = load_config(runner.config_file_path)
     assert len(new_config_writen) == 1
@@ -183,7 +183,7 @@ def test_autoupdate_local_hooks_with_out_of_date_repo(
     local_config = config_with_local_hooks()
     config = [local_config, stale_config]
     write_config('.', config)
-    runner = Runner('.')
+    runner = Runner('.', C.CONFIG_FILE)
     assert autoupdate(runner) == 0
     new_config_writen = load_config(runner.config_file_path)
     assert len(new_config_writen) == 2

--- a/tests/commands/run_test.py
+++ b/tests/commands/run_test.py
@@ -75,7 +75,7 @@ def _get_opts(
 
 
 def _do_run(cap_out, repo, args, environ={}):
-    runner = Runner(repo)
+    runner = Runner(repo, C.CONFIG_FILE)
     with cwd(runner.git_root):  # replicates Runner.create behaviour
         ret = run(runner, args, environ=environ)
     printed = cap_out.get_bytes()
@@ -375,7 +375,7 @@ def test_non_ascii_hook_id(
         repo_with_passing_hook, mock_out_store_directory, tempdir_factory,
 ):
     with cwd(repo_with_passing_hook):
-        install(Runner(repo_with_passing_hook))
+        install(Runner(repo_with_passing_hook, C.CONFIG_FILE))
         _, stdout, _ = cmd_output_mocked_pre_commit_home(
             sys.executable, '-m', 'pre_commit.main', 'run', '☃',
             retcode=None, tempdir_factory=tempdir_factory,
@@ -393,7 +393,7 @@ def test_stdout_write_bug_py26(
             config[0]['hooks'][0]['args'] = ['☃']
         stage_a_file()
 
-        install(Runner(repo_with_failing_hook))
+        install(Runner(repo_with_failing_hook, C.CONFIG_FILE))
 
         # Have to use subprocess because pytest monkeypatches sys.stdout
         _, stdout, _ = cmd_output_mocked_pre_commit_home(
@@ -411,7 +411,7 @@ def test_stdout_write_bug_py26(
 def test_hook_install_failure(mock_out_store_directory, tempdir_factory):
     git_path = make_consuming_repo(tempdir_factory, 'not_installable_repo')
     with cwd(git_path):
-        install(Runner(git_path))
+        install(Runner(git_path, C.CONFIG_FILE))
 
         _, stdout, _ = cmd_output_mocked_pre_commit_home(
             'git', 'commit', '-m', 'Commit!',
@@ -460,7 +460,7 @@ def test_lots_of_files(mock_out_store_directory, tempdir_factory):
             open(filename, 'w').close()
 
         cmd_output('bash', '-c', 'git add .')
-        install(Runner(git_path))
+        install(Runner(git_path, C.CONFIG_FILE))
 
         cmd_output_mocked_pre_commit_home(
             'git', 'commit', '-m', 'Commit!',
@@ -646,7 +646,7 @@ def test_files_running_subdir(
         repo_with_passing_hook, mock_out_store_directory, tempdir_factory,
 ):
     with cwd(repo_with_passing_hook):
-        install(Runner(repo_with_passing_hook))
+        install(Runner(repo_with_passing_hook, C.CONFIG_FILE))
 
         os.mkdir('subdir')
         open('subdir/foo.py', 'w').close()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,7 @@ import os.path
 import mock
 import pytest
 
+import pre_commit.constants as C
 from pre_commit import five
 from pre_commit import output
 from pre_commit.logging_handler import add_logging_handler
@@ -136,7 +137,7 @@ def cmd_runner(tempdir_factory):
 
 @pytest.yield_fixture
 def runner_with_mocked_store(mock_out_store_directory):
-    yield Runner('/')
+    yield Runner('/', C.CONFIG_FILE)
 
 
 @pytest.yield_fixture

--- a/tests/runner_test.py
+++ b/tests/runner_test.py
@@ -79,6 +79,38 @@ def test_local_hooks(tempdir_factory, mock_out_store_directory):
     assert len(runner.repositories[0].hooks) == 2
 
 
+def test_local_hooks_alt_config(tempdir_factory, mock_out_store_directory):
+    config = OrderedDict((
+        ('repo', 'local'),
+        ('hooks', (OrderedDict((
+            ('id', 'arg-per-line'),
+            ('name', 'Args per line hook'),
+            ('entry', 'bin/hook.sh'),
+            ('language', 'script'),
+            ('files', ''),
+            ('args', ['hello', 'world']),
+        )), OrderedDict((
+            ('id', 'ugly-format-json'),
+            ('name', 'Ugly format json'),
+            ('entry', 'ugly-format-json'),
+            ('language', 'python'),
+            ('files', ''),
+        )), OrderedDict((
+            ('id', 'do_not_commit'),
+            ('name', 'Block if "DO NOT COMMIT" is found'),
+            ('entry', 'DO NOT COMMIT'),
+            ('language', 'pcre'),
+            ('files', '^(.*)$'),
+        ))))
+    ))
+    git_path = git_dir(tempdir_factory)
+    alt_config_file = 'alternate_config.yaml'
+    add_config_to_repo(git_path, config, config_file=alt_config_file)
+    runner = Runner(git_path, alt_config_file)
+    assert len(runner.repositories) == 1
+    assert len(runner.repositories[0].hooks) == 3
+
+
 def test_pre_commit_path(in_tmpdir):
     path = os.path.join('foo', 'bar')
     cmd_output('git', 'init', path)

--- a/tests/runner_test.py
+++ b/tests/runner_test.py
@@ -15,7 +15,7 @@ from testing.fixtures import make_consuming_repo
 
 def test_init_has_no_side_effects(tmpdir):
     current_wd = os.getcwd()
-    runner = Runner(tmpdir.strpath)
+    runner = Runner(tmpdir.strpath, C.CONFIG_FILE)
     assert runner.git_root == tmpdir.strpath
     assert os.getcwd() == current_wd
 
@@ -23,7 +23,7 @@ def test_init_has_no_side_effects(tmpdir):
 def test_create_sets_correct_directory(tempdir_factory):
     path = git_dir(tempdir_factory)
     with cwd(path):
-        runner = Runner.create()
+        runner = Runner.create(C.CONFIG_FILE)
         assert os.path.normcase(runner.git_root) == os.path.normcase(path)
         assert os.path.normcase(os.getcwd()) == os.path.normcase(path)
 
@@ -37,20 +37,20 @@ def test_create_changes_to_git_root(tempdir_factory):
         os.chdir(foo_path)
         assert os.getcwd() != path
 
-        runner = Runner.create()
+        runner = Runner.create(C.CONFIG_FILE)
         assert os.path.normcase(runner.git_root) == os.path.normcase(path)
         assert os.path.normcase(os.getcwd()) == os.path.normcase(path)
 
 
 def test_config_file_path():
-    runner = Runner(os.path.join('foo', 'bar'))
+    runner = Runner(os.path.join('foo', 'bar'), C.CONFIG_FILE)
     expected_path = os.path.join('foo', 'bar', C.CONFIG_FILE)
     assert runner.config_file_path == expected_path
 
 
 def test_repositories(tempdir_factory, mock_out_store_directory):
     path = make_consuming_repo(tempdir_factory, 'script_hooks_repo')
-    runner = Runner(path)
+    runner = Runner(path, C.CONFIG_FILE)
     assert len(runner.repositories) == 1
 
 
@@ -74,7 +74,7 @@ def test_local_hooks(tempdir_factory, mock_out_store_directory):
     ))
     git_path = git_dir(tempdir_factory)
     add_config_to_repo(git_path, config)
-    runner = Runner(git_path)
+    runner = Runner(git_path, C.CONFIG_FILE)
     assert len(runner.repositories) == 1
     assert len(runner.repositories[0].hooks) == 2
 
@@ -82,7 +82,7 @@ def test_local_hooks(tempdir_factory, mock_out_store_directory):
 def test_pre_commit_path(in_tmpdir):
     path = os.path.join('foo', 'bar')
     cmd_output('git', 'init', path)
-    runner = Runner(path)
+    runner = Runner(path, C.CONFIG_FILE)
     expected_path = os.path.join(path, '.git', 'hooks', 'pre-commit')
     assert runner.pre_commit_path == expected_path
 
@@ -90,12 +90,12 @@ def test_pre_commit_path(in_tmpdir):
 def test_pre_push_path(in_tmpdir):
     path = os.path.join('foo', 'bar')
     cmd_output('git', 'init', path)
-    runner = Runner(path)
+    runner = Runner(path, C.CONFIG_FILE)
     expected_path = os.path.join(path, '.git', 'hooks', 'pre-push')
     assert runner.pre_push_path == expected_path
 
 
 def test_cmd_runner(mock_out_store_directory):
-    runner = Runner(os.path.join('foo', 'bar'))
+    runner = Runner(os.path.join('foo', 'bar'), C.CONFIG_FILE)
     ret = runner.cmd_runner
     assert ret.prefix_dir == os.path.join(mock_out_store_directory) + os.sep


### PR DESCRIPTION
This PR is to add support for alternate config files as discussed in #432. I'm intentionally adding functionality  to the run and autoupdate commands and not install or uninstall as I imagine .pre-commit-config.yaml will always exist.

I think this may be all that's necessary for --config to work? If this approach looks good, I plan to add unit tests as well as run some manual smoke tests myself. Thought it would be prudent to sanity check these changes first, though.

Thanks!