### PR TITLE
Support docker hooks with args

### DIFF
--- a/pre_commit/languages/docker.py
+++ b/pre_commit/languages/docker.py
@@ -89,6 +89,7 @@ def run_hook(repo_cmd_runner, hook, file_args):
     cmd = (
         'docker', 'run',
         '--rm',
+        '-u', '{}:{}'.format(os.getuid(), os.getgid()),
         '-v', '{}:/src:rw'.format(os.getcwd()),
         '--workdir', '/src',
         '--entrypoint', entry_executable,

--- a/pre_commit/languages/docker.py
+++ b/pre_commit/languages/docker.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 
 import hashlib
 import os
+import shlex
 
 from pre_commit import five
 from pre_commit.languages import helpers
@@ -82,7 +83,7 @@ def run_hook(repo_cmd_runner, hook, file_args):
     # automated cleanup of docker images.
     build_docker_image(repo_cmd_runner, pull=False)
 
-    entry_parts = hook['entry'].split(' ')
+    entry_parts = shlex.split(hook['entry'])
     entry_executable, entry_args = entry_parts[0], entry_parts[1:]
 
     cmd = (

--- a/pre_commit/languages/docker.py
+++ b/pre_commit/languages/docker.py
@@ -81,14 +81,17 @@ def run_hook(repo_cmd_runner, hook, file_args):
     # Rebuild the docker image in case it has gone missing, as many people do
     # automated cleanup of docker images.
     build_docker_image(repo_cmd_runner, pull=False)
+
+    entry_parts = hook['entry'].split(' ')
+    entry_executable, entry_args = entry_parts[0], entry_parts[1:]
+
     cmd = (
         'docker', 'run',
         '--rm',
-        '-u', '{}:{}'.format(os.getuid(), os.getgid()),
         '-v', '{}:/src:rw'.format(os.getcwd()),
         '--workdir', '/src',
-        '--entrypoint', hook['entry'],
+        '--entrypoint', entry_executable,
         docker_tag(repo_cmd_runner)
     )
 
-    return xargs(cmd + tuple(hook['args']), file_args)
+    return xargs(cmd + tuple(entry_args) + tuple(hook['args']), file_args)

--- a/testing/resources/docker_hooks_repo/hooks.yaml
+++ b/testing/resources/docker_hooks_repo/hooks.yaml
@@ -4,6 +4,12 @@
     language: docker
     files: \.txt$
 
+-   id: docker-hook-arg
+    name: Docker test hook
+    entry: echo -n
+    language: docker
+    files: \.txt$
+
 -   id: docker-hook-failing
     name: Docker test hook with nonzero exit code
     entry: bork

--- a/tests/repository_test.py
+++ b/tests/repository_test.py
@@ -144,6 +144,17 @@ def test_run_a_docker_hook(tempdir_factory, store):
 @skipif_slowtests_false
 @skipif_cant_run_docker
 @pytest.mark.integration
+def test_run_a_docker_hook_with_entry_args(tempdir_factory, store):
+    _test_hook_repo(
+        tempdir_factory, store, 'docker_hooks_repo',
+        'docker-hook-arg',
+        ['Hello World from docker'], b'Hello World from docker',
+    )
+
+
+@skipif_slowtests_false
+@skipif_cant_run_docker
+@pytest.mark.integration
 def test_run_a_failing_docker_hook(tempdir_factory, store):
     _test_hook_repo(
         tempdir_factory, store, 'docker_hooks_repo',


### PR DESCRIPTION
@asottile  here's a fix for entry args. lmk if there's some corner case that makes .split() not satisfactory

Also, seems optimal to not pass up the user. Couldn't get writes working on my localhost without. Docker will only set permissions to root if it's creating *new* files so... /shrug not sure! People could always pass it as an args? (Or maybe not if we don't expand env vars...). This has sort of always been the most annoying part of docker heh

