### PR TITLE
Improve messaging for missing hook given #480

### DIFF
--- a/pre_commit/repository.py
+++ b/pre_commit/repository.py
@@ -78,9 +78,7 @@ class Repository(object):
                 logger.error(
                     '`{}` is not present in repository {}.  '
                     'Typo? Perhaps it is introduced in a newer version?  '
-                    'Often you can fix this by removing the hook, running '
-                    '`pre-commit autoupdate`, '
-                    'and then adding the hook.'.format(
+                    'Often `pre-commit autoupdate` fixes this.'.format(
                         hook['id'], self.repo_config['repo'],
                     )
                 )

--- a/tests/repository_test.py
+++ b/tests/repository_test.py
@@ -696,9 +696,7 @@ def test_hook_id_not_present(tempdir_factory, store, fake_log_handler):
     assert fake_log_handler.handle.call_args[0][0].msg == (
         '`i-dont-exist` is not present in repository {}.  '
         'Typo? Perhaps it is introduced in a newer version?  '
-        'Often you can fix this by removing the hook, '
-        'running `pre-commit autoupdate`, '
-        'and then adding the hook.'.format(path)
+        'Often `pre-commit autoupdate` fixes this.'.format(path)
     )
 
 


### PR DESCRIPTION
The approach that #480 takes to future-proof autoupdate a little more also improves the case for "hook not present yet".  We originally did some wordy work to suggest a way to upgrade for #386 in #387 but now that's not necessary \o/

CC @matkoniecz
