### PR TITLE
Keep dependency in order

### DIFF
--- a/pre_commit/repository.py
+++ b/pre_commit/repository.py
@@ -64,7 +64,7 @@ class Repository(object):
 
     @cached_property
     def additional_dependencies(self):
-        dep_dict = defaultdict(lambda: defaultdict(set))
+        dep_dict = defaultdict(lambda: defaultdict(_UniqueList))
         for _, hook in self.hooks:
             dep_dict[hook['language']][hook['language_version']].update(
                 hook.get('additional_dependencies', []),
@@ -222,3 +222,14 @@ class LocalRepository(Repository):
     @cached_property
     def manifest(self):
         raise NotImplementedError
+
+
+class _UniqueList(list):
+    def __init__(self):
+        self._set = set()
+
+    def update(self, obj):
+        for item in obj:
+            if item not in self._set:
+                self._set.add(item)
+                self.append(item)


### PR DESCRIPTION
I was investigating https://github.com/pre-commit/pre-commit-mirror-maker/issues/20 and realized running `gem install gem1:version1 gem2:version` can give different result from `gem install gem2:version2 gem1:version1`.

This PR keeps the list of additional dependencies of an hook in the order they appeared in the `.pre-commit-config.yaml`.