### PR TITLE
Fix eslint on windows

### DIFF
--- a/pre_commit/parse_shebang.py
+++ b/pre_commit/parse_shebang.py
@@ -53,9 +53,10 @@ def find_executable(exe, _environ=None):
     environ = _environ if _environ is not None else os.environ
 
     if 'PATHEXT' in environ:
-        possible_exe_names = (exe,) + tuple(
+        possible_exe_names = tuple(
             exe + ext.lower() for ext in environ['PATHEXT'].split(os.pathsep)
-        )
+        ) + (exe,)
+
     else:
         possible_exe_names = (exe,)
 


### PR DESCRIPTION
- The bare exe was the first filename attempted to match,
  this change means it will be matched last, allowing other files
  to be matched if they exist. The result is that eslint now works
  on Windows.

- Possibly related to #200 