### PR TITLE
Do not run pre-commit if there is no config file

### DIFF
--- a/pre_commit/commands/install_uninstall.py
+++ b/pre_commit/commands/install_uninstall.py
@@ -37,7 +37,10 @@ def is_previous_pre_commit(filename):
     return any(hash in contents for hash in PREVIOUS_IDENTIFYING_HASHES)
 
 
-def install(runner, overwrite=False, hooks=False, hook_type='pre-commit'):
+def install(
+        runner, overwrite=False, hooks=False, hook_type='pre-commit',
+        skip_on_missing_conf=False
+):
     """Install the pre-commit hooks."""
     hook_path = runner.get_hook_path(hook_type)
     legacy_path = hook_path + '.legacy'
@@ -70,10 +73,12 @@ def install(runner, overwrite=False, hooks=False, hook_type='pre-commit'):
         else:
             pre_push_contents = ''
 
+        skip_on_missing_conf = 'true' if skip_on_missing_conf else 'false'
         contents = io.open(resource_filename('hook-tmpl')).read().format(
             sys_executable=sys.executable,
             hook_type=hook_type,
             pre_push=pre_push_contents,
+            skip_on_missing_conf=skip_on_missing_conf
         )
         pre_commit_file_obj.write(contents)
     make_executable(hook_path)

--- a/pre_commit/main.py
+++ b/pre_commit/main.py
@@ -75,6 +75,13 @@ def main(argv=None):
         '-t', '--hook-type', choices=('pre-commit', 'pre-push'),
         default='pre-commit',
     )
+    install_parser.add_argument(
+        '--allow-missing-config', action='store_true', default=False,
+        help=(
+            'Whether to allow a missing `pre-config` configuration file '
+            'or exit with a failure code.'
+        ),
+    )
 
     install_hooks_parser = subparsers.add_parser(
         'install-hooks',
@@ -182,6 +189,7 @@ def main(argv=None):
             return install(
                 runner, overwrite=args.overwrite, hooks=args.install_hooks,
                 hook_type=args.hook_type,
+                skip_on_missing_conf=args.allow_missing_config
             )
         elif args.command == 'install-hooks':
             return install_hooks(runner)

--- a/pre_commit/resources/hook-tmpl
+++ b/pre_commit/resources/hook-tmpl
@@ -10,6 +10,7 @@ retv=0
 args=""
 
 ENV_PYTHON='{sys_executable}'
+SKIP_ON_MISSING_CONF={skip_on_missing_conf}
 
 which pre-commit >& /dev/null
 WHICH_RETV=$?
@@ -35,6 +36,20 @@ if [ -x "$HERE"/{hook_type}.legacy ]; then
     if [ $? -ne 0 ]; then
         retv=1
     fi
+fi
+
+CONF_FILE=$(git rev-parse --show-toplevel)"/.pre-commit-config.yaml"
+if [ ! -f $CONF_FILE  ]; then
+    if [ $SKIP_ON_MISSING_CONF = true ] || [ ! -z $PRE_COMMIT_ALLOW_NO_CONFIG ]; then
+            echo '`.pre-commit-config.yaml` config file not found. Skipping `pre-commit`.'
+            exit $retv
+    else
+        echo 'No .pre-commit-config.yaml file was found\n'\
+             '- To temporarily silence this, run `PRE_COMMIT_ALLOW_NO_CONFIG=1 git ...`\n'\
+             '- To permanently silence this, install pre-commit with the `--allow-missing-config` option\n'\
+             '- To uninstall pre-commit run `pre-commit uninstall`'
+        exit 1
+	fi
 fi
 
 {pre_push}

--- a/testing/fixtures.py
+++ b/testing/fixtures.py
@@ -123,6 +123,14 @@ def add_config_to_repo(git_path, config, config_file=C.CONFIG_FILE):
     return git_path
 
 
+def remove_config_from_repo(git_path, config_file=C.CONFIG_FILE):
+    os.unlink(os.path.join(git_path, config_file))
+    with cwd(git_path):
+        cmd_output('git', 'add', config_file)
+        cmd_output('git', 'commit', '-m', 'Remove hooks config')
+    return git_path
+
+
 def make_consuming_repo(tempdir_factory, repo_source):
     path = make_repo(tempdir_factory, repo_source)
     config = make_config_from_repo(path)


### PR DESCRIPTION
When no '.pre-commit-config.yaml' file exists while `pre-commit` hooks
are enabled, `pre-commit` returns an error and the action is aborted.
This is a very common scenario when pre-commit is added later on a
project and the user wants to work on a previous branch where the
configuration file does not exist.

This commit checks whether a config file exists and runs only the legacy
pre-commit hooks (if any) when it is missing.