### PR TITLE
Make hook-tmpl resilient to future changes

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,6 +4,7 @@ coverage
 flake8
 mock
 pytest
+pytest-env
 
 # setuptools breaks pypy3 with extraneous output
 setuptools<18.5

--- a/tests/commands/install_uninstall_test.py
+++ b/tests/commands/install_uninstall_test.py
@@ -11,12 +11,11 @@ import sys
 import mock
 
 import pre_commit.constants as C
-from pre_commit.commands.install_uninstall import IDENTIFYING_HASH
+from pre_commit.commands.install_uninstall import CURRENT_HASH
 from pre_commit.commands.install_uninstall import install
 from pre_commit.commands.install_uninstall import install_hooks
-from pre_commit.commands.install_uninstall import is_our_pre_commit
-from pre_commit.commands.install_uninstall import is_previous_pre_commit
-from pre_commit.commands.install_uninstall import PREVIOUS_IDENTIFYING_HASHES
+from pre_commit.commands.install_uninstall import is_our_script
+from pre_commit.commands.install_uninstall import PRIOR_HASHES
 from pre_commit.commands.install_uninstall import uninstall
 from pre_commit.runner import Runner
 from pre_commit.util import cmd_output
@@ -30,27 +29,18 @@ from testing.util import cmd_output_mocked_pre_commit_home
 from testing.util import xfailif_no_symlink
 
 
-def test_is_not_our_pre_commit():
-    assert is_our_pre_commit('setup.py') is False
+def test_is_not_script():
+    assert is_our_script('setup.py') is False
 
 
-def test_is_our_pre_commit():
-    assert is_our_pre_commit(resource_filename('hook-tmpl'))
+def test_is_script():
+    assert is_our_script(resource_filename('hook-tmpl'))
 
 
-def test_is_not_previous_pre_commit():
-    assert is_previous_pre_commit('setup.py') is False
-
-
-def test_is_also_not_previous_pre_commit():
-    assert not is_previous_pre_commit(resource_filename('hook-tmpl'))
-
-
-def test_is_previous_pre_commit(in_tmpdir):
-    with io.open('foo', 'w') as foo_file:
-        foo_file.write(PREVIOUS_IDENTIFYING_HASHES[0])
-
-    assert is_previous_pre_commit('foo')
+def test_is_previous_pre_commit(tmpdir):
+    f = tmpdir.join('foo')
+    f.write(PRIOR_HASHES[0] + '\n')
+    assert is_our_script(f.strpath)
 
 
 def test_install_pre_commit(tempdir_factory):
@@ -408,7 +398,7 @@ def test_replace_old_commit_script(tempdir_factory):
             resource_filename('hook-tmpl'),
         ).read()
         new_contents = pre_commit_contents.replace(
-            IDENTIFYING_HASH, PREVIOUS_IDENTIFYING_HASHES[-1],
+            CURRENT_HASH, PRIOR_HASHES[-1],
         )
 
         mkdirp(os.path.dirname(runner.pre_commit_path))

--- a/tox.ini
+++ b/tox.ini
@@ -6,12 +6,6 @@ envlist = py27,py34,py35,pypy
 [testenv]
 deps = -rrequirements-dev.txt
 passenv = GOROOT HOME HOMEPATH PROGRAMDATA TERM
-setenv =
-    VIRTUALENV_NO_DOWNLOAD = 1
-    GIT_AUTHOR_NAME = "test"
-    GIT_COMMITTER_NAME = "test"
-    GIT_AUTHOR_EMAIL = "test@example.com"
-    GIT_COMMITTER_EMAIL = "test@example.com"
 commands =
     coverage erase
     coverage run -m pytest {posargs:tests}
@@ -25,3 +19,11 @@ commands =
 
 [pep8]
 ignore = E265,E309,E501
+
+[pytest]
+env =
+    GIT_AUTHOR_NAME=test
+    GIT_COMMITTER_NAME=test
+    GIT_AUTHOR_EMAIL=test@example.com
+    GIT_COMMITTER_EMAIL=test@example.com
+    VIRTUALENV_NO_DOWNLOAD=1


### PR DESCRIPTION
I realized this wasn't necessarily rollback safe.  This makes it slightly more future-proof.

This feature really isn't used too much anyway (we usually run install with `--force`)

Perhaps the default behaviour of install should be changed as well?