### PR TITLE
Properly detect if commit is a root commit

### DIFF
--- a/pre_commit/resources/pre-push-tmpl
+++ b/pre_commit/resources/pre-push-tmpl
@@ -8,7 +8,7 @@ do
             if [ -n "$first_ancestor" ]; then
                 # Check that the ancestor has at least one parent
                 git rev-list --max-parents=0 "$local_sha" | grep "$first_ancestor" > /dev/null
-                if [ $? -ne 0 ]; then
+                if [ $? -eq 0 ]; then
                     args="run --all-files"
                 else
                     source=$(git rev-parse "$first_ancestor"^)


### PR DESCRIPTION
Fix a bug in the pre-push template, where the commit was wrongly
identified as a root commit with no parents.