### PR TITLE
Windows: enable ANSI escape support in console

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -8,6 +8,7 @@ omit =
     setup.py
     # Don't complain if non-runnable code isn't run
     */__main__.py
+    pre_commit/color_windows.py
 
 [report]
 show_missing = True

--- a/pre_commit/color.py
+++ b/pre_commit/color.py
@@ -1,6 +1,14 @@
 from __future__ import unicode_literals
 
+import os
 import sys
+
+if os.name == 'nt':  # pragma: no cover (windows)
+    from pre_commit.color_windows import enable_virtual_terminal_processing
+    try:
+        enable_virtual_terminal_processing()
+    except WindowsError:
+        pass
 
 RED = '\033[41m'
 GREEN = '\033[42m'

--- a/pre_commit/color_windows.py
+++ b/pre_commit/color_windows.py
@@ -1,0 +1,49 @@
+from __future__ import unicode_literals
+
+from ctypes import POINTER
+from ctypes import windll
+from ctypes import WinError
+from ctypes import WINFUNCTYPE
+from ctypes.wintypes import BOOL
+from ctypes.wintypes import DWORD
+from ctypes.wintypes import HANDLE
+
+STD_OUTPUT_HANDLE = -11
+ENABLE_VIRTUAL_TERMINAL_PROCESSING = 4
+
+
+def bool_errcheck(result, func, args):
+    if not result:
+        raise WinError()
+    return args
+
+
+GetStdHandle = WINFUNCTYPE(HANDLE, DWORD)(
+    ("GetStdHandle", windll.kernel32),
+    ((1, "nStdHandle"), )
+)
+
+GetConsoleMode = WINFUNCTYPE(BOOL, HANDLE, POINTER(DWORD))(
+    ("GetConsoleMode", windll.kernel32),
+    ((1, "hConsoleHandle"), (2, "lpMode"))
+)
+GetConsoleMode.errcheck = bool_errcheck
+
+SetConsoleMode = WINFUNCTYPE(BOOL, HANDLE, DWORD)(
+    ("SetConsoleMode", windll.kernel32),
+    ((1, "hConsoleHandle"), (1, "dwMode"))
+)
+SetConsoleMode.errcheck = bool_errcheck
+
+
+def enable_virtual_terminal_processing():
+    """As of Windows 10, the Windows console supports (some) ANSI escape
+    sequences, but it needs to be enabled using `SetConsoleMode` first.
+
+    More info on the escape sequences supported:
+    https://msdn.microsoft.com/en-us/library/windows/desktop/mt638032(v=vs.85).aspx
+
+    """
+    stdout = GetStdHandle(STD_OUTPUT_HANDLE)
+    flags = GetConsoleMode(stdout)
+    SetConsoleMode(stdout, flags | ENABLE_VIRTUAL_TERMINAL_PROCESSING)


### PR DESCRIPTION
As of Windows 10, the Windows console supports (some) ANSI escape sequences, but it nees to be enabled using [`SetConsoleMode`](https://msdn.microsoft.com/en-us/library/windows/desktop/mt638032(v=vs.85).aspx) first.

If more extensive support is needed, or you want this to work on earlier versions of Windows, it would be probably be better to use a package like [colorama](https://pypi.python.org/pypi/colorama) instead, which automatically translates ANSI escape sequences to the equivalent Windows API calls. It also contains functions to format colored text.

This fixes #198.