### PR TITLE
Adds support for 'log_file' in hook config

### DIFF
--- a/pre_commit/clientlib.py
+++ b/pre_commit/clientlib.py
@@ -53,6 +53,7 @@ MANIFEST_HOOK_DICT = schema.Map(
         '^$',
     ),
     schema.Optional('language_version', schema.check_string, 'default'),
+    schema.OptionalNoDefault('log_file', schema.check_string),
     schema.Optional('minimum_pre_commit_version', schema.check_string, '0'),
     schema.Optional('stages', schema.check_array(schema.check_string), []),
 )

--- a/pre_commit/commands/run.py
+++ b/pre_commit/commands/run.py
@@ -121,7 +121,10 @@ def _run_single_hook(hook, repo, args, skips, cols):
         for out in (stdout, stderr):
             assert type(out) is bytes, type(out)
             if out.strip():
-                output.write_line(out.strip())
+                output.write_line(
+                    out.strip(),
+                    logfile_name=hook.get('log_file'),
+                )
         output.write_line()
 
     return retcode

--- a/pre_commit/output.py
+++ b/pre_commit/output.py
@@ -71,8 +71,17 @@ def write(s, stream=stdout_byte_stream):
     stream.flush()
 
 
-def write_line(s=None, stream=stdout_byte_stream):
-    if s is not None:
-        stream.write(five.to_bytes(s))
-    stream.write(b'\n')
-    stream.flush()
+def write_line(s=None, stream=stdout_byte_stream, logfile_name=None):
+    def output_streams():
+        yield stream
+        try:
+            with open(logfile_name, 'ab') as logfile:
+                yield logfile
+        except (TypeError, IOError):
+            pass
+
+    for output_stream in output_streams():
+        if s is not None:
+            output_stream.write(five.to_bytes(s))
+        output_stream.write(b'\n')
+        output_stream.flush()

--- a/testing/resources/logfile_repo/.pre-commit-hooks.yaml
+++ b/testing/resources/logfile_repo/.pre-commit-hooks.yaml
@@ -1,0 +1,6 @@
+-   id: logfile test hook
+    name: Logfile test hook
+    entry: bin/hook.sh
+    language: script
+    files: .
+    log_file: test.log

--- a/testing/resources/logfile_repo/bin/hook.sh
+++ b/testing/resources/logfile_repo/bin/hook.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+echo "This is STDOUT output"
+echo "This is STDERR output" 1>&2
+
+exit 1

--- a/tests/commands/run_test.py
+++ b/tests/commands/run_test.py
@@ -211,6 +211,35 @@ def test_run(
     )
 
 
+def test_run_output_logfile(
+        cap_out,
+        tempdir_factory,
+        mock_out_store_directory,
+):
+
+    expected_output = (
+        b'This is STDOUT output\n',
+        b'This is STDERR output\n',
+    )
+
+    git_path = make_consuming_repo(tempdir_factory, 'logfile_repo')
+    with cwd(git_path):
+        _test_run(
+            cap_out,
+            git_path, {},
+            expected_output,
+            expected_ret=1,
+            stage=True
+        )
+    logfile_path = os.path.join(git_path, 'test.log')
+    assert os.path.exists(logfile_path)
+    with open(logfile_path, 'rb') as logfile:
+        logfile_content = logfile.readlines()
+
+    for expected_output_part in expected_output:
+        assert expected_output_part in logfile_content
+
+
 def test_always_run(
         cap_out, repo_with_passing_hook, mock_out_store_directory,
 ):


### PR DESCRIPTION
Specify a filename on a per hook basis and
pre-commit will write the STDOUT and STDERR
of that hook into the file. Useful for CI.

Resolves #499.