### PR TITLE
Add pass_filenames hook option

### DIFF
--- a/pre_commit/clientlib.py
+++ b/pre_commit/clientlib.py
@@ -46,6 +46,7 @@ MANIFEST_HOOK_DICT = schema.Map(
     ),
     schema.Optional('args', schema.check_array(schema.check_string), []),
     schema.Optional('always_run', schema.check_bool, False),
+    schema.Optional('pass_filenames', schema.check_bool, True),
     schema.Optional('description', schema.check_string, ''),
     schema.Optional(
         'exclude',

--- a/pre_commit/commands/run.py
+++ b/pre_commit/commands/run.py
@@ -86,7 +86,10 @@ def _run_single_hook(hook, repo, args, skips, cols):
     sys.stdout.flush()
 
     diff_before = cmd_output('git', 'diff', retcode=None, encoding=None)
-    retcode, stdout, stderr = repo.run_hook(hook, tuple(filenames))
+    retcode, stdout, stderr = repo.run_hook(
+        hook,
+        tuple(filenames) if hook['pass_filenames'] else (),
+    )
     diff_after = cmd_output('git', 'diff', retcode=None, encoding=None)
 
     file_modifications = diff_before != diff_after

--- a/tests/commands/run_test.py
+++ b/tests/commands/run_test.py
@@ -731,3 +731,29 @@ def test_files_running_subdir(
                 tempdir_factory=tempdir_factory,
             )
         assert 'subdir/foo.py'.replace('/', os.sep) in stdout
+
+
+@pytest.mark.parametrize(
+    ('pass_filenames', 'hook_args', 'expected_out'),
+    (
+        (True, [], b'foo.py'),
+        (False, [], b''),
+        (True, ['some', 'args'], b'some args foo.py'),
+        (False, ['some', 'args'], b'some args'),
+    )
+)
+def test_pass_filenames(
+        cap_out, repo_with_passing_hook, mock_out_store_directory,
+        pass_filenames,
+        hook_args,
+        expected_out,
+):
+    with modify_config() as config:
+        config[0]['hooks'][0]['pass_filenames'] = pass_filenames
+        config[0]['hooks'][0]['args'] = hook_args
+    stage_a_file()
+    ret, printed = _do_run(
+        cap_out, repo_with_passing_hook, _get_opts(verbose=True),
+    )
+    assert expected_out + b'\nHello World' in printed
+    assert ('foo.py' in printed) == pass_filenames

--- a/tests/commands/run_test.py
+++ b/tests/commands/run_test.py
@@ -756,4 +756,4 @@ def test_pass_filenames(
         cap_out, repo_with_passing_hook, _get_opts(verbose=True),
     )
     assert expected_out + b'\nHello World' in printed
-    assert ('foo.py' in printed) == pass_filenames
+    assert (b'foo.py' in printed) == pass_filenames

--- a/tests/manifest_test.py
+++ b/tests/manifest_test.py
@@ -32,6 +32,7 @@ def test_manifest_contents(manifest):
         'log_file': '',
         'minimum_pre_commit_version': '0',
         'name': 'Bash hook',
+        'pass_filenames': True,
         'stages': [],
     }]
 
@@ -51,6 +52,7 @@ def test_hooks(manifest):
         'log_file': '',
         'minimum_pre_commit_version': '0',
         'name': 'Bash hook',
+        'pass_filenames': True,
         'stages': [],
     }
 


### PR DESCRIPTION
This option controls whether filenames are passed along as arguments to
the hook program.