### PR TITLE
Types

### DIFF
--- a/pre_commit/clientlib.py
+++ b/pre_commit/clientlib.py
@@ -49,7 +49,13 @@ MANIFEST_HOOK_DICT = schema.Map(
         'files', schema.check_and(schema.check_string, schema.check_regex),
         '',
     ),
+    schema.Optional(
+        'exclude',
+        schema.check_and(schema.check_string, schema.check_regex),
+        '^$',
+    ),
     schema.Optional('types', schema.check_array(check_type_tag), ['file']),
+    schema.Optional('exclude_types', schema.check_array(check_type_tag), []),
 
     schema.Optional(
         'additional_dependencies', schema.check_array(schema.check_string), [],
@@ -58,11 +64,6 @@ MANIFEST_HOOK_DICT = schema.Map(
     schema.Optional('always_run', schema.check_bool, False),
     schema.Optional('pass_filenames', schema.check_bool, True),
     schema.Optional('description', schema.check_string, ''),
-    schema.Optional(
-        'exclude',
-        schema.check_and(schema.check_string, schema.check_regex),
-        '^$',
-    ),
     schema.Optional('language_version', schema.check_string, 'default'),
     schema.Optional('log_file', schema.check_string, ''),
     schema.Optional('minimum_pre_commit_version', schema.check_string, '0'),

--- a/pre_commit/clientlib.py
+++ b/pre_commit/clientlib.py
@@ -5,6 +5,7 @@ import argparse
 import functools
 
 from aspy.yaml import ordered_load
+from identify.identify import ALL_TAGS
 
 import pre_commit.constants as C
 from pre_commit import schema
@@ -16,6 +17,14 @@ def check_language(v):
     if v not in all_languages:
         raise schema.ValidationError(
             'Expected {} to be in {!r}'.format(v, all_languages),
+        )
+
+
+def check_type_tag(tag):
+    if tag not in ALL_TAGS:
+        raise schema.ValidationError(
+            'Type tag {!r} is not recognized.  '
+            'Try upgrading identify and pre-commit?'.format(tag),
         )
 
 
@@ -36,10 +45,11 @@ MANIFEST_HOOK_DICT = schema.Map(
         'language', schema.check_and(schema.check_string, check_language),
     ),
 
-    schema.Conditional(
+    schema.Optional(
         'files', schema.check_and(schema.check_string, schema.check_regex),
-        condition_key='always_run', condition_value=False,
+        '',
     ),
+    schema.Optional('types', schema.check_array(check_type_tag), ['file']),
 
     schema.Optional(
         'additional_dependencies', schema.check_array(schema.check_string), [],

--- a/pre_commit/commands/run.py
+++ b/pre_commit/commands/run.py
@@ -58,7 +58,7 @@ NO_FILES = '(no files to check)'
 
 
 def _run_single_hook(hook, repo, args, skips, cols):
-    filenames = get_filenames(args, hook.get('files', '^$'), hook['exclude'])
+    filenames = get_filenames(args, hook['files'], hook['exclude'])
     if hook['id'] in skips:
         output.write(get_hook_message(
             _hook_msg_start(hook, args.verbose),

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ setup(
     install_requires=[
         'aspy.yaml',
         'cached-property',
+        'identify>=1.0.0',
         'nodeenv>=0.11.1',
         'pyyaml',
         'six',

--- a/testing/resources/exclude_types_repo/.pre-commit-hooks.yaml
+++ b/testing/resources/exclude_types_repo/.pre-commit-hooks.yaml
@@ -1,0 +1,6 @@
+-   id: python-files
+    name: Python files
+    entry: bin/hook.sh
+    language: script
+    types: [python]
+    exclude_types: [python3]

--- a/testing/resources/exclude_types_repo/bin/hook.sh
+++ b/testing/resources/exclude_types_repo/bin/hook.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+echo $@
+exit 1

--- a/testing/resources/types_repo/.pre-commit-hooks.yaml
+++ b/testing/resources/types_repo/.pre-commit-hooks.yaml
@@ -1,0 +1,5 @@
+-   id: python-files
+    name: Python files
+    entry: bin/hook.sh
+    language: script
+    types: [python]

--- a/testing/resources/types_repo/bin/hook.sh
+++ b/testing/resources/types_repo/bin/hook.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+echo $@
+exit 1

--- a/tests/clientlib_test.py
+++ b/tests/clientlib_test.py
@@ -4,6 +4,7 @@ import pytest
 
 from pre_commit import schema
 from pre_commit.clientlib import check_language
+from pre_commit.clientlib import check_type_tag
 from pre_commit.clientlib import CONFIG_HOOK_DICT
 from pre_commit.clientlib import CONFIG_SCHEMA
 from pre_commit.clientlib import is_local_repo
@@ -25,6 +26,12 @@ def is_valid_according_to_schema(obj, obj_schema):
 def test_check_language_failures(value):
     with pytest.raises(schema.ValidationError):
         check_language(value)
+
+
+@pytest.mark.parametrize('value', ('definitely-not-a-tag', 'fiel'))
+def test_check_type_tag_failures(value):
+    with pytest.raises(schema.ValidationError):
+        check_type_tag(value)
 
 
 @pytest.mark.parametrize('value', ('python', 'node', 'pcre'))

--- a/tests/commands/run_test.py
+++ b/tests/commands/run_test.py
@@ -153,6 +153,19 @@ def test_hook_that_modifies_but_returns_zero(
         )
 
 
+def test_types_hook_repository(
+        cap_out, tempdir_factory, mock_out_store_directory,
+):
+    git_path = make_consuming_repo(tempdir_factory, 'types_repo')
+    with cwd(git_path):
+        stage_a_file('bar.py')
+        stage_a_file('bar.notpy')
+        ret, printed = _do_run(cap_out, git_path, _get_opts())
+        assert ret == 1
+        assert b'bar.py' in printed
+        assert b'bar.notpy' not in printed
+
+
 def test_show_diff_on_failure(
         capfd, cap_out, tempdir_factory, mock_out_store_directory,
 ):

--- a/tests/manifest_test.py
+++ b/tests/manifest_test.py
@@ -35,6 +35,7 @@ def test_manifest_contents(manifest):
         'pass_filenames': True,
         'stages': [],
         'types': ['file'],
+        'exclude_types': [],
     }]
 
 
@@ -56,6 +57,7 @@ def test_hooks(manifest):
         'pass_filenames': True,
         'stages': [],
         'types': ['file'],
+        'exclude_types': [],
     }
 
 

--- a/tests/manifest_test.py
+++ b/tests/manifest_test.py
@@ -34,6 +34,7 @@ def test_manifest_contents(manifest):
         'name': 'Bash hook',
         'pass_filenames': True,
         'stages': [],
+        'types': ['file'],
     }]
 
 
@@ -54,6 +55,7 @@ def test_hooks(manifest):
         'name': 'Bash hook',
         'pass_filenames': True,
         'stages': [],
+        'types': ['file'],
     }
 
 

--- a/tests/parse_shebang_test.py
+++ b/tests/parse_shebang_test.py
@@ -15,34 +15,8 @@ from pre_commit.envcontext import Var
 from pre_commit.util import make_executable
 
 
-@pytest.mark.parametrize(
-    ('s', 'expected'),
-    (
-        (b'', ()),
-        (b'#!/usr/bin/python', ('/usr/bin/python',)),
-        (b'#!/usr/bin/env python', ('python',)),
-        (b'#! /usr/bin/python', ('/usr/bin/python',)),
-        (b'#!/usr/bin/foo  python', ('/usr/bin/foo', 'python')),
-        (b'\xf9\x93\x01\x42\xcd', ()),
-        (b'#!\xf9\x93\x01\x42\xcd', ()),
-        (b'#!\x00\x00\x00\x00', ()),
-    ),
-)
-def test_parse_bytesio(s, expected):
-    assert parse_shebang.parse_bytesio(io.BytesIO(s)) == expected
-
-
 def test_file_doesnt_exist():
     assert parse_shebang.parse_filename('herp derp derp') == ()
-
-
-@pytest.mark.xfail(
-    sys.platform == 'win32', reason='Windows says everything is X_OK',
-)
-def test_file_not_executable(tmpdir):
-    x = tmpdir.join('f')
-    x.write_text('#!/usr/bin/env python', encoding='UTF-8')
-    assert parse_shebang.parse_filename(x.strpath) == ()
 
 
 def test_simple_case(tmpdir):


### PR DESCRIPTION
This is the big one!

Should resolve the following issues:
- [pre-commit should ignore symlinks by default](https://github.com/pre-commit/pre-commit/issues/191)
- [pre-commit should ignore submodules by default](https://github.com/pre-commit/pre-commit/issues/191#issuecomment-113249998)
- [A special "text" type for text files](https://github.com/pre-commit/pre-commit/issues/220)
- [Can't match files based on shebangs](https://github.com/pre-commit/pre-commit/issues/257)
- [Run pre-commit-hooks#end-of-file-fixer on all text files](https://github.com/pre-commit/pre-commit-hooks/issues/61)

Some notable things:

- `files` and `types` are now both optional -- I'm not sure if this is ok? I'm considering making these inclusive-or-required (with `always_run`).  `files` defaults to `''` (matching all) and `types` defaults to `['file']` matching only files (this excludes submodules and symlinks)
- `files` and `types` are evaluated with *and*, that is, for a file to be linted it must match *both* the `files` regex and the `types` listed.
- Each tag inside `types` is evaluated with *and* -- that is, for a file to be chosen for linting it must be classified as all of the tags.
- A separate library ([identify](https://github.com/chriskuehl/identify)) was chosen to allow the inevitable rapid updates to classification without encumbering the pre-commit release schedule.
- The implementation allows for extension of "tags" by pre-commit itself, I think something cool that pre-commit could do is a `newly-added` tag (would cut out a lot of boilerplate in several hooks).

Known breaking changes:
- [pre-commit-hooks#check-symlinks](https://github.com/pre-commit/pre-commit-hooks/blob/e9446ff0cc8ffa65309e0a37c247518127a3bf18/.pre-commit-hooks.yaml#L59-L65) - this hook intentionally lints `symlink` "files" and will now need `types: ['symlink']` to work properly
- `always_run` without `files` now defaults to `files: ''` instead of `files: '^$'` -- I think this actually makes more sense given the choices in the rest of the framework and is a "least surprise" outcome here (it also makes the code simple!)

@chriskuehl and I have put a ton of work into this (my branch is roughly based on his prototype branch) :tophat: *hattip*

@Lucas-C is probably interested in this PR so... hi!