### PR TITLE
More specific symlink testing without checking in a symlink

### DIFF
--- a/testing/test_symlink
+++ b/testing/test_symlink
@@ -1,1 +1,0 @@
-does_not_exist


### PR DESCRIPTION
On windows the "symlink" gets checked out as a normal file [breaking the hooks under test](https://ci.appveyor.com/project/asottile/pre-commit/build/1.0.1022/job/gf88t638f3aff1o9).

This moves the symlink to a test fixture instead