### PR TITLE
Fix windows virtualenv issue

### DIFF
--- a/pre_commit/languages/python.py
+++ b/pre_commit/languages/python.py
@@ -86,8 +86,9 @@ def get_default_version():
 def norm_version(version):
     if os.name == 'nt':  # pragma: no cover (windows)
         # Try looking up by name
-        if find_executable(version) and find_executable(version) != version:
-            return version
+        version_exec = find_executable(version)
+        if version_exec and version_exec != version:
+            return version_exec
 
         # If it is in the form pythonx.x search in the default
         # place on windows


### PR DESCRIPTION
With `v0.15`, I started getting the following bug when running `pre-commit install -f --install-hooks` on my Windows 10 machine:
```
An unexpected error has occurred: CalledProcessError: Command: ('C:\\Users\\Evan\\.pre-commit\\repo8d84nqt_\\py_env-python3.6\\Scripts\\pip.exe', 'install', '.')
Return code: 1
Expected return code: 0
Output: (none)
Errors: (none)
```

I managed to track the bug down to `virtualenv` not actually creating the `py_env-python3.6` directory, and from there to `virtualenv` not having been passed an actual executable on the `-p` option. The reason this was not happening was because `norm_version` was returning `version` instead of `find_executable(version)` when an executable was found. Thus, `find_executable` discovered that `version` had an executable, but then refused to actually pass that executable along.

This PR fixes the `norm_version` logic to return `find_executable(version)` instead of `version`, which completely resolved the issue on my machine.