### PR TITLE
Recover from invalid python virtualenvs

### DIFF
--- a/pre_commit/languages/all.py
+++ b/pre_commit/languages/all.py
@@ -21,6 +21,9 @@ from pre_commit.languages import system
 #     return 'default' if there is no better option.
 #    """
 #
+# def healthy(repo_cmd_runner, language_version):
+#     """Return whether or not the environment is considered functional."""
+#
 # def install_environment(repo_cmd_runner, version, additional_dependencies):
 #     """Installs a repository in the given repository.  Note that the current
 #     working directory will already be inside the repository.

--- a/pre_commit/languages/docker.py
+++ b/pre_commit/languages/docker.py
@@ -15,6 +15,7 @@ from pre_commit.xargs import xargs
 ENVIRONMENT_DIR = 'docker'
 PRE_COMMIT_LABEL = 'PRE_COMMIT'
 get_default_version = helpers.basic_get_default_version
+healthy = helpers.basic_healthy
 
 
 def md5(s):  # pragma: windows no cover

--- a/pre_commit/languages/golang.py
+++ b/pre_commit/languages/golang.py
@@ -15,6 +15,7 @@ from pre_commit.xargs import xargs
 
 ENVIRONMENT_DIR = 'golangenv'
 get_default_version = helpers.basic_get_default_version
+healthy = helpers.basic_healthy
 
 
 def get_env_patch(venv):

--- a/pre_commit/languages/helpers.py
+++ b/pre_commit/languages/helpers.py
@@ -37,3 +37,7 @@ def assert_no_additional_deps(lang, additional_deps):
 
 def basic_get_default_version():
     return 'default'
+
+
+def basic_healthy(repo_cmd_runner, language_version):
+    return True

--- a/pre_commit/languages/node.py
+++ b/pre_commit/languages/node.py
@@ -13,6 +13,7 @@ from pre_commit.xargs import xargs
 
 ENVIRONMENT_DIR = 'node_env'
 get_default_version = helpers.basic_get_default_version
+healthy = helpers.basic_healthy
 
 
 def get_env_patch(venv):  # pragma: windows no cover

--- a/pre_commit/languages/pcre.py
+++ b/pre_commit/languages/pcre.py
@@ -9,6 +9,7 @@ from pre_commit.xargs import xargs
 ENVIRONMENT_DIR = None
 GREP = 'ggrep' if sys.platform == 'darwin' else 'grep'
 get_default_version = helpers.basic_get_default_version
+healthy = helpers.basic_healthy
 
 
 def install_environment(repo_cmd_runner, version, additional_dependencies):

--- a/pre_commit/languages/python.py
+++ b/pre_commit/languages/python.py
@@ -10,11 +10,11 @@ from pre_commit.envcontext import Var
 from pre_commit.languages import helpers
 from pre_commit.parse_shebang import find_executable
 from pre_commit.util import clean_path_on_failure
+from pre_commit.util import cmd_output
 from pre_commit.xargs import xargs
 
 
 ENVIRONMENT_DIR = 'py_env'
-get_default_version = helpers.basic_get_default_version
 
 
 def bin_dir(venv):
@@ -81,6 +81,14 @@ def get_default_version():
     except AttributeError:
         get_default_version.cached_version = _get_default_version()
         return get_default_version()
+
+
+def healthy(repo_cmd_runner, language_version):
+    with in_env(repo_cmd_runner, language_version):
+        retcode, _, _ = cmd_output(
+            'python', '-c', 'import datetime, io, os, weakref', retcode=None,
+        )
+    return retcode == 0
 
 
 def norm_version(version):

--- a/pre_commit/languages/ruby.py
+++ b/pre_commit/languages/ruby.py
@@ -17,6 +17,7 @@ from pre_commit.xargs import xargs
 
 ENVIRONMENT_DIR = 'rbenv'
 get_default_version = helpers.basic_get_default_version
+healthy = helpers.basic_healthy
 
 
 def get_env_patch(venv, language_version):  # pragma: windows no cover

--- a/pre_commit/languages/script.py
+++ b/pre_commit/languages/script.py
@@ -6,6 +6,7 @@ from pre_commit.xargs import xargs
 
 ENVIRONMENT_DIR = None
 get_default_version = helpers.basic_get_default_version
+healthy = helpers.basic_healthy
 
 
 def install_environment(repo_cmd_runner, version, additional_dependencies):

--- a/pre_commit/languages/swift.py
+++ b/pre_commit/languages/swift.py
@@ -11,6 +11,7 @@ from pre_commit.xargs import xargs
 
 ENVIRONMENT_DIR = 'swift_env'
 get_default_version = helpers.basic_get_default_version
+healthy = helpers.basic_healthy
 BUILD_DIR = '.build'
 BUILD_CONFIG = 'release'
 

--- a/pre_commit/languages/system.py
+++ b/pre_commit/languages/system.py
@@ -6,6 +6,7 @@ from pre_commit.xargs import xargs
 
 ENVIRONMENT_DIR = None
 get_default_version = helpers.basic_get_default_version
+healthy = helpers.basic_healthy
 
 
 def install_environment(repo_cmd_runner, version, additional_dependencies):

--- a/pre_commit/repository.py
+++ b/pre_commit/repository.py
@@ -36,7 +36,7 @@ def _state_filename(cmd_runner, venv):
     )
 
 
-def _read_installed_state(cmd_runner, venv):
+def _read_state(cmd_runner, venv):
     filename = _state_filename(cmd_runner, venv)
     if not os.path.exists(filename):
         return None
@@ -44,7 +44,7 @@ def _read_installed_state(cmd_runner, venv):
         return json.loads(io.open(filename).read())
 
 
-def _write_installed_state(cmd_runner, venv, state):
+def _write_state(cmd_runner, venv, state):
     state_filename = _state_filename(cmd_runner, venv)
     staging = state_filename + 'staging'
     with io.open(staging, 'w') as state_file:
@@ -57,8 +57,10 @@ def _installed(cmd_runner, language_name, language_version, additional_deps):
     language = languages[language_name]
     venv = environment_dir(language.ENVIRONMENT_DIR, language_version)
     return (
-        venv is None or
-        _read_installed_state(cmd_runner, venv) == _state(additional_deps)
+        venv is None or (
+            _read_state(cmd_runner, venv) == _state(additional_deps) and
+            language.healthy(cmd_runner, language_version)
+        )
     )
 
 
@@ -89,7 +91,7 @@ def _install_all(venvs, repo_url):
         language.install_environment(cmd_runner, version, deps)
         # Write our state to indicate we're installed
         state = _state(deps)
-        _write_installed_state(cmd_runner, venv, state)
+        _write_state(cmd_runner, venv, state)
 
 
 def _validate_minimum_version(hook):

--- a/tests/languages/all_test.py
+++ b/tests/languages/all_test.py
@@ -40,3 +40,13 @@ def test_get_default_version_argspec(language):
     )
     argspec = inspect.getargspec(languages[language].get_default_version)
     assert argspec == expected_argspec
+
+
+@pytest.mark.parametrize('language', all_languages)
+def test_healthy_argspec(language):
+    expected_argspec = inspect.ArgSpec(
+        args=['repo_cmd_runner', 'language_version'],
+        varargs=None, keywords=None, defaults=None,
+    )
+    argspec = inspect.getargspec(languages[language].healthy)
+    assert argspec == expected_argspec

--- a/tests/languages/helpers_test.py
+++ b/tests/languages/helpers_test.py
@@ -1,0 +1,12 @@
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+from pre_commit.languages import helpers
+
+
+def test_basic_get_default_version():
+    assert helpers.basic_get_default_version() == 'default'
+
+
+def test_basic_healthy():
+    assert helpers.basic_healthy(None, None) is True


### PR DESCRIPTION
This will help with travis-ci caches

It's efficient to cache ~/.pre-commit in travis-ci as it makes hook execution fast the next run.  When travis-ci upgrades their system pythons this often causes failures due to libpython going missing

Here's a blurb of what this breakage looks like:

```
Trim Trailing Whitespace.................................................Failed

hookid: trailing-whitespace

/home/travis/.pre-commit/repoxffdwnip/py_env-python3.6/bin/python3.6: error while loading shared libraries: libpython3.6m.so.1.0: cannot open shared object file: No such file or directory
```

I've only implemented `healthy` for python, the others can be written in the future.