### PR TITLE
Initialize git submodules

### DIFF
--- a/pre_commit/store.py
+++ b/pre_commit/store.py
@@ -123,6 +123,10 @@ class Store(object):
             )
             with cwd(directory):
                 cmd_output('git', 'reset', ref, '--hard', env=no_git_env())
+                cmd_output(
+                    'git', 'submodule', 'update', '--init', '--recursive',
+                    env=no_git_env(),
+                )
 
         return self._new_repo(repo, ref, clone_strategy)
 


### PR DESCRIPTION
Some packages make use of git submodules, and require all of them to be in place to be installed. One example is my libtidy wrapper for node, which depends on the C sources for libtidy (unless a precompiled binary is available for a given platform). I've been asked to add pre-commit support in https://github.com/gagern/node-libtidy/issues/17 but testing that failed because the source tree was lacking its submodules.