### PR TITLE
Remove validate_config hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,6 @@
 -   repo: https://github.com/pre-commit/pre-commit.git
     sha: v0.16.3
     hooks:
-    -   id: validate_config
     -   id: validate_manifest
 -   repo: https://github.com/asottile/reorder_python_imports.git
     sha: v0.3.5

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,9 +1,3 @@
--   id: validate_config
-    name: Validate Pre-Commit Config
-    description: This validator validates a pre-commit hooks config file
-    entry: pre-commit-validate-config
-    language: python
-    files: ^\.pre-commit-config\.yaml$
 -   id: validate_manifest
     name: Validate Pre-Commit Manifest
     description: This validator validates a pre-commit hooks manifest file


### PR DESCRIPTION
Not sure how this never dawned on me, but this hook is entirely useless as pre-commit already has to parse the entire configuration in order to run this hook 😆 

This was one of the first hooks before the entire idea was completely fleshed out so I guess it makes some sense.  Time to sunset this hook though 🌥 