### PR TITLE
Limit repository creation to one process

### DIFF
--- a/pre_commit/file_lock.py
+++ b/pre_commit/file_lock.py
@@ -1,0 +1,53 @@
+import contextlib
+import errno
+
+
+try:  # pragma: no cover (windows)
+    import msvcrt
+
+    # https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/locking
+
+    # on windows we lock "regions" of files, we don't care about the actual
+    # byte region so we'll just pick *some* number here.
+    _region = 0xffff
+
+    @contextlib.contextmanager
+    def _locked(fileno):
+        while True:
+            try:
+                msvcrt.locking(fileno, msvcrt.LK_LOCK, _region)
+            except OSError as e:
+                # Locking violation. Returned when the _LK_LOCK or _LK_RLCK
+                # flag is specified and the file cannot be locked after 10
+                # attempts.
+                if e.errno != errno.EDEADLOCK:
+                    raise
+            else:
+                break
+
+        try:
+            yield
+        finally:
+            # From cursory testing, it seems to get unlocked when the file is
+            # closed so this may not be necessary.
+            # The documentation however states:
+            # "Regions should be locked only briefly and should be unlocked
+            # before closing a file or exiting the program."
+            msvcrt.locking(fileno, msvcrt.LK_UNLCK, _region)
+except ImportError:  # pragma: no cover (posix)
+    import fcntl
+
+    @contextlib.contextmanager
+    def _locked(fileno):
+        fcntl.flock(fileno, fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(fileno, fcntl.LOCK_UN)
+
+
+@contextlib.contextmanager
+def lock(path):
+    with open(path, 'a+') as f:
+        with _locked(f.fileno()):
+            yield

--- a/tests/commands/install_uninstall_test.py
+++ b/tests/commands/install_uninstall_test.py
@@ -142,7 +142,8 @@ FILES_CHANGED = (
 
 
 NORMAL_PRE_COMMIT_RUN = re.compile(
-    r'^\[INFO\] Initializing environment for .+\.\r?\n'
+    r'^\[INFO\] Locking pre-commit directory\r?\n'
+    r'\[INFO\] Initializing environment for .+\.\r?\n'
     r'Bash hook\.+Passed\r?\n'
     r'\[master [a-f0-9]{7}\] Commit!\r?\n' +
     FILES_CHANGED +
@@ -254,7 +255,8 @@ def test_environment_not_sourced(tempdir_factory):
 
 
 FAILING_PRE_COMMIT_RUN = re.compile(
-    r'^\[INFO\] Initializing environment for .+\.\r?\n'
+    r'^\[INFO\] Locking pre-commit directory\r?\n'
+    r'\[INFO\] Initializing environment for .+\.\r?\n'
     r'Failing hook\.+Failed\r?\n'
     r'hookid: failing_hook\r?\n'
     r'\r?\n'
@@ -332,6 +334,7 @@ def test_install_existing_hook_no_overwrite_idempotent(tempdir_factory):
 
 FAIL_OLD_HOOK = re.compile(
     r'fail!\r?\n'
+    r'\[INFO\] Locking pre-commit directory\r?\n'
     r'\[INFO\] Initializing environment for .+\.\r?\n'
     r'Bash hook\.+Passed\r?\n',
 )

--- a/tests/repository_test.py
+++ b/tests/repository_test.py
@@ -547,8 +547,8 @@ def test_reinstall(tempdir_factory, store, log_info_mock):
     config = make_config_from_repo(path)
     repo = Repository.create(config, store)
     repo.require_installed()
-    # We print some logging during clone (1) + install (3)
-    assert log_info_mock.call_count == 4
+    # We print some logging during clone (2) + install (4)
+    assert log_info_mock.call_count == 6
     log_info_mock.reset_mock()
     # Reinstall with same repo should not trigger another install
     repo.require_installed()

--- a/tests/store_test.py
+++ b/tests/store_test.py
@@ -88,7 +88,7 @@ def test_clone(store, tempdir_factory, log_info_mock):
 
     ret = store.clone(path, sha)
     # Should have printed some stuff
-    assert log_info_mock.call_args_list[0][0][0].startswith(
+    assert log_info_mock.call_args_list[1][0][0].startswith(
         'Initializing environment for ',
     )
 


### PR DESCRIPTION
This attempts to solve #363

I've tested this on windows and linux and it appears to work as intended.  This adds some additional printing of `[INFO] Locking pre-commit directory` when cloning / installing repositories.

I used this script to test this somewhat-thoroughly:

```bash
#!/usr/bin/env bash
set -euxo pipefail

tmpdir="$(mktemp -d)"
cleanup() {
    cat "$tmpdir/pre-commit.log" 2> /dev/null || true
    rm -rf "$tmpdir"
}
trap cleanup EXIT

export PRE_COMMIT_HOME="$tmpdir"
seq 10 |
    xargs -P10 --replace \
        pre-commit run trailing-whitespace --files README.md

echo 'done!'
```

Would definitely love a second set of eyes on this and someone to verify that this approach also works on macos