### PR TITLE
Add new docker_image language type.

### DIFF
--- a/pre_commit/languages/all.py
+++ b/pre_commit/languages/all.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 
 from pre_commit.languages import docker
+from pre_commit.languages import docker_image
 from pre_commit.languages import golang
 from pre_commit.languages import node
 from pre_commit.languages import pcre
@@ -49,6 +50,7 @@ from pre_commit.languages import system
 
 languages = {
     'docker': docker,
+    'docker_image': docker_image,
     'golang': golang,
     'node': node,
     'pcre': pcre,

--- a/pre_commit/languages/docker_image.py
+++ b/pre_commit/languages/docker_image.py
@@ -1,6 +1,9 @@
+from __future__ import absolute_import
 from __future__ import unicode_literals
 
 from pre_commit.languages import helpers
+from pre_commit.languages.docker import assert_docker_available
+from pre_commit.languages.docker import docker_cmd
 from pre_commit.xargs import xargs
 
 
@@ -10,7 +13,7 @@ healthy = helpers.basic_healthy
 install_environment = helpers.no_install
 
 
-def run_hook(repo_cmd_runner, hook, file_args):
-    cmd = helpers.to_cmd(hook)
-    cmd = (repo_cmd_runner.prefix_dir + cmd[0],) + cmd[1:]
+def run_hook(repo_cmd_runner, hook, file_args):  # pragma: windows no cover
+    assert_docker_available()
+    cmd = docker_cmd() + helpers.to_cmd(hook)
     return xargs(cmd, file_args)

--- a/pre_commit/languages/helpers.py
+++ b/pre_commit/languages/helpers.py
@@ -41,3 +41,7 @@ def basic_get_default_version():
 
 def basic_healthy(repo_cmd_runner, language_version):
     return True
+
+
+def no_install(repo_cmd_runner, version, additional_dependencies):
+    raise AssertionError('This type is not installable')

--- a/pre_commit/languages/pcre.py
+++ b/pre_commit/languages/pcre.py
@@ -10,11 +10,7 @@ ENVIRONMENT_DIR = None
 GREP = 'ggrep' if sys.platform == 'darwin' else 'grep'
 get_default_version = helpers.basic_get_default_version
 healthy = helpers.basic_healthy
-
-
-def install_environment(repo_cmd_runner, version, additional_dependencies):
-    """Installation for pcre type is a noop."""
-    raise AssertionError('Cannot install pcre repo.')
+install_environment = helpers.no_install
 
 
 def run_hook(repo_cmd_runner, hook, file_args):

--- a/pre_commit/languages/system.py
+++ b/pre_commit/languages/system.py
@@ -7,11 +7,7 @@ from pre_commit.xargs import xargs
 ENVIRONMENT_DIR = None
 get_default_version = helpers.basic_get_default_version
 healthy = helpers.basic_healthy
-
-
-def install_environment(repo_cmd_runner, version, additional_dependencies):
-    """Installation for system type is a noop."""
-    raise AssertionError('Cannot install system repo.')
+install_environment = helpers.no_install
 
 
 def run_hook(repo_cmd_runner, hook, file_args):

--- a/pre_commit/repository.py
+++ b/pre_commit/repository.py
@@ -202,8 +202,8 @@ class LocalRepository(Repository):
     def _cmd_runner_from_deps(self, language_name, deps):
         """local repositories have a cmd runner per hook"""
         language = languages[language_name]
-        # pcre / script / system do not have environments so they work out
-        # of the current directory
+        # pcre / script / system / docker_image do not have environments so
+        # they work out of the current directory
         if language.ENVIRONMENT_DIR is None:
             return PrefixedCommandRunner(git.get_root())
         else:

--- a/testing/resources/docker_image_hooks_repo/.pre-commit-hooks.yaml
+++ b/testing/resources/docker_image_hooks_repo/.pre-commit-hooks.yaml
@@ -1,0 +1,8 @@
+-   id: echo-entrypoint
+    name: echo (via --entrypoint)
+    language: docker_image
+    entry: --entrypoint echo cogniteev/echo
+-   id: echo-cmd
+    name: echo (via cmd)
+    language: docker_image
+    entry: cogniteev/echo echo

--- a/tests/repository_test.py
+++ b/tests/repository_test.py
@@ -165,6 +165,18 @@ def test_run_a_failing_docker_hook(tempdir_factory, store):
 
 
 @skipif_slowtests_false
+@skipif_cant_run_docker
+@pytest.mark.integration
+@pytest.mark.parametrize('hook_id', ('echo-entrypoint', 'echo-cmd'))
+def test_run_a_docker_image_hook(tempdir_factory, store, hook_id):
+    _test_hook_repo(
+        tempdir_factory, store, 'docker_image_hooks_repo',
+        hook_id,
+        ['Hello World from docker'], b'Hello World from docker\n',
+    )
+
+
+@skipif_slowtests_false
 @xfailif_windows_no_node
 @pytest.mark.integration
 def test_run_a_node_hook(tempdir_factory, store):


### PR DESCRIPTION
`docker_image` is intended to be a lightweight hook type similar to system /
script which allows one to use an existing docker image which provides a
hook.

Resolves #597 