### PR TITLE
Use SystemExit instead of PreCommitSystemExit

### DIFF
--- a/pre_commit/error_handler.py
+++ b/pre_commit/error_handler.py
@@ -14,11 +14,6 @@ from pre_commit.errors import FatalError
 from pre_commit.store import Store
 
 
-# For testing purposes
-class PreCommitSystemExit(SystemExit):
-    pass
-
-
 def _to_bytes(exc):
     try:
         return bytes(exc)
@@ -39,7 +34,7 @@ def _log_and_exit(msg, exc, formatted):
     with open(os.path.join(store.directory, 'pre-commit.log'), 'wb') as log:
         output.write(error_msg, stream=log)
         output.write_line(formatted, stream=log)
-    raise PreCommitSystemExit(1)
+    raise SystemExit(1)
 
 
 @contextlib.contextmanager

--- a/tests/error_handler_test.py
+++ b/tests/error_handler_test.py
@@ -75,7 +75,7 @@ def test_error_handler_uncaught_error(mocked_log_and_exit):
 
 
 def test_log_and_exit(cap_out, mock_out_store_directory):
-    with pytest.raises(error_handler.PreCommitSystemExit):
+    with pytest.raises(SystemExit):
         error_handler._log_and_exit(
             'msg', FatalError('hai'), "I'm a stacktrace",
         )
@@ -96,7 +96,7 @@ def test_log_and_exit(cap_out, mock_out_store_directory):
 
 
 def test_error_handler_non_ascii_exception(mock_out_store_directory):
-    with pytest.raises(error_handler.PreCommitSystemExit):
+    with pytest.raises(SystemExit):
         with error_handler.error_handler():
             raise ValueError('☃')
 

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -7,7 +7,6 @@ import mock
 import pytest
 
 from pre_commit import main
-from pre_commit.error_handler import PreCommitSystemExit
 from pre_commit.util import cwd
 from testing.auto_namedtuple import auto_namedtuple
 
@@ -120,7 +119,7 @@ def test_expected_fatal_error_no_git_repo(
         tempdir_factory, cap_out, mock_out_store_directory,
 ):
     with cwd(tempdir_factory.get()):
-        with pytest.raises(PreCommitSystemExit):
+        with pytest.raises(SystemExit):
             main.main([])
     assert cap_out.get() == (
         'An error has occurred: FatalError: git failed. '


### PR DESCRIPTION
I want to say this was originally here to work around the testing library at the time, but this seems to work just fine.