### PR TITLE
Fix error message during pre-push / commit-msg

### DIFF
--- a/pre_commit/resources/hook-tmpl
+++ b/pre_commit/resources/hook-tmpl
@@ -25,7 +25,7 @@ if ((
         (ENV_PYTHON_RETV != 0) &&
         (PYTHON_RETV != 0)
 )); then
-    echo '`{hook_type}` not found.  Did you forget to activate your virtualenv?'
+    echo '`pre-commit` not found.  Did you forget to activate your virtualenv?'
     exit 1
 fi
 


### PR DESCRIPTION
Independent of what hook type is running, the tool is always called `pre-commit`.