### PR TITLE
pre-commit migrate-config should not return nonzero when successful

### DIFF
--- a/pre_commit/commands/autoupdate.py
+++ b/pre_commit/commands/autoupdate.py
@@ -104,8 +104,8 @@ def _write_new_config_file(path, output):
 
 def autoupdate(runner, tags_only):
     """Auto-update the pre-commit config to the latest versions of repos."""
+    migrate_config(runner, quiet=True)
     retv = 0
-    retv |= migrate_config(runner, quiet=True)
     output_repos = []
     changed = False
 

--- a/pre_commit/commands/migrate_config.py
+++ b/pre_commit/commands/migrate_config.py
@@ -17,8 +17,6 @@ def _is_header_line(line):
 
 
 def migrate_config(runner, quiet=False):
-    retv = 0
-
     with io.open(runner.config_file_path) as f:
         contents = f.read()
 
@@ -45,8 +43,5 @@ def migrate_config(runner, quiet=False):
             f.write(contents)
 
         print('Configuration has been migrated.')
-        retv = 1
     elif not quiet:
         print('Configuration is already migrated.')
-
-    return retv

--- a/tests/commands/autoupdate_test.py
+++ b/tests/commands/autoupdate_test.py
@@ -306,7 +306,7 @@ def test_updates_old_format_to_new_format(tmpdir, capsys):
         '        language: script\n',
     )
     ret = autoupdate(Runner(tmpdir.strpath, C.CONFIG_FILE), tags_only=True)
-    assert ret == 1
+    assert ret == 0
     contents = cfg.read()
     assert contents == (
         'repos:\n'

--- a/tests/commands/migrate_config_test.py
+++ b/tests/commands/migrate_config_test.py
@@ -33,7 +33,7 @@ def test_migrate_config_normal_format(tmpdir, capsys):
         '        entry: ./bin/foo.sh\n'
         '        language: script\n',
     )
-    assert migrate_config(Runner(tmpdir.strpath, C.CONFIG_FILE)) == 1
+    assert not migrate_config(Runner(tmpdir.strpath, C.CONFIG_FILE))
     out, _ = capsys.readouterr()
     assert out == 'Configuration has been migrated.\n'
     contents = cfg.read()
@@ -61,7 +61,7 @@ def test_migrate_config_document_marker(tmpdir):
         '        entry: ./bin/foo.sh\n'
         '        language: script\n',
     )
-    assert migrate_config(Runner(tmpdir.strpath, C.CONFIG_FILE)) == 1
+    assert not migrate_config(Runner(tmpdir.strpath, C.CONFIG_FILE))
     contents = cfg.read()
     assert contents == (
         '# comment\n'
@@ -88,7 +88,7 @@ def test_migrate_config_list_literal(tmpdir):
         '    }]\n'
         '}]',
     )
-    assert migrate_config(Runner(tmpdir.strpath, C.CONFIG_FILE)) == 1
+    assert not migrate_config(Runner(tmpdir.strpath, C.CONFIG_FILE))
     contents = cfg.read()
     assert contents == (
         'repos:\n'


### PR DESCRIPTION
This fixes an unintentional regression in https://github.com/pre-commit/pre-commit/pull/610 introduced in 1.0.0