### PR TITLE
Improving git clone speed: #391

### DIFF
--- a/pre_commit/store.py
+++ b/pre_commit/store.py
@@ -141,7 +141,7 @@ class Store(object):
         """Clone the given url and checkout the specific ref."""
         def clone_strategy(directory):
             cmd_output(
-                'git', 'clone', '--no-checkout', repo, directory,
+                'git', 'clone', '--no-checkout', '--depth', '1', repo, directory,
                 env=no_git_env(),
             )
             with cwd(directory):


### PR DESCRIPTION
I still would like to measure `pre-commit` startup times at some point,
but this a first quick-win improvment to boost `git clone` speed on repos with a big history