### PR TITLE
Use file:// protocol for cloning under test

### DIFF
--- a/pre_commit/languages/golang.py
+++ b/pre_commit/languages/golang.py
@@ -37,8 +37,11 @@ def in_env(repo_cmd_runner):
 def guess_go_dir(remote_url):
     if remote_url.endswith('.git'):
         remote_url = remote_url[:-1 * len('.git')]
+    looks_like_url = (
+        not remote_url.startswith('file://') and
+        ('//' in remote_url or '@' in remote_url)
+    )
     remote_url = remote_url.replace(':', '/')
-    looks_like_url = '//' in remote_url or '@' in remote_url
     if looks_like_url:
         _, _, remote_url = remote_url.rpartition('//')
         _, _, remote_url = remote_url.rpartition('@')

--- a/testing/fixtures.py
+++ b/testing/fixtures.py
@@ -83,7 +83,7 @@ def config_with_local_hooks():
 def make_config_from_repo(repo_path, sha=None, hooks=None, check=True):
     manifest = load_manifest(os.path.join(repo_path, C.MANIFEST_FILE))
     config = OrderedDict((
-        ('repo', repo_path),
+        ('repo', 'file://{}'.format(repo_path)),
         ('sha', sha or get_head_sha(repo_path)),
         (
             'hooks',

--- a/tests/languages/golang_test.py
+++ b/tests/languages/golang_test.py
@@ -10,6 +10,7 @@ from pre_commit.languages.golang import guess_go_dir
     ('url', 'expected'),
     (
         ('/im/a/path/on/disk', 'unknown_src_dir'),
+        ('file:///im/a/path/on/disk', 'unknown_src_dir'),
         ('git@github.com:golang/lint', 'github.com/golang/lint'),
         ('git://github.com/golang/lint', 'github.com/golang/lint'),
         ('http://github.com/golang/lint', 'github.com/golang/lint'),

--- a/tests/repository_test.py
+++ b/tests/repository_test.py
@@ -714,7 +714,7 @@ def test_hook_id_not_present(tempdir_factory, store, fake_log_handler):
     with pytest.raises(SystemExit):
         repo.require_installed()
     assert fake_log_handler.handle.call_args[0][0].msg == (
-        '`i-dont-exist` is not present in repository {}.  '
+        '`i-dont-exist` is not present in repository file://{}.  '
         'Typo? Perhaps it is introduced in a newer version?  '
         'Often `pre-commit autoupdate` fixes this.'.format(path)
     )


### PR DESCRIPTION
This is necessary to show that `--depth` + the current approach to autoupdate do not mesh well: #628

This also fixes a microbug:
- `file://` clone paths for golang were being treated as urls