### PR TITLE
Add `pre-commit try-repo`

### DIFF
--- a/pre_commit/commands/try_repo.py
+++ b/pre_commit/commands/try_repo.py
@@ -1,0 +1,44 @@
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+import collections
+import os.path
+
+from aspy.yaml import ordered_dump
+
+import pre_commit.constants as C
+from pre_commit import git
+from pre_commit import output
+from pre_commit.commands.run import run
+from pre_commit.manifest import Manifest
+from pre_commit.runner import Runner
+from pre_commit.store import Store
+from pre_commit.util import tmpdir
+
+
+def try_repo(args):
+    ref = args.ref or git.head_sha(args.repo)
+
+    with tmpdir() as tempdir:
+        if args.hook:
+            hooks = [{'id': args.hook}]
+        else:
+            manifest = Manifest(Store(tempdir).clone(args.repo, ref))
+            hooks = [{'id': hook_id} for hook_id in sorted(manifest.hooks)]
+
+        items = (('repo', args.repo), ('sha', ref), ('hooks', hooks))
+        config = {'repos': [collections.OrderedDict(items)]}
+        config_s = ordered_dump(config, **C.YAML_DUMP_KWARGS)
+
+        config_filename = os.path.join(tempdir, C.CONFIG_FILE)
+        with open(config_filename, 'w') as cfg:
+            cfg.write(config_s)
+
+        output.write_line('=' * 79)
+        output.write_line('Using config:')
+        output.write_line('=' * 79)
+        output.write(config_s)
+        output.write_line('=' * 79)
+
+        runner = Runner('.', config_filename, store_dir=tempdir)
+        return run(runner, args)

--- a/pre_commit/git.py
+++ b/pre_commit/git.py
@@ -97,6 +97,11 @@ def get_changed_files(new, old):
     )[1])
 
 
+def head_sha(remote):
+    _, out, _ = cmd_output('git', 'ls-remote', '--exit-code', remote, 'HEAD')
+    return out.split()[0]
+
+
 def check_for_cygwin_mismatch():
     """See https://github.com/pre-commit/pre-commit/issues/354"""
     if sys.platform in ('cygwin', 'win32'):  # pragma: no cover (windows)

--- a/pre_commit/manifest.py
+++ b/pre_commit/manifest.py
@@ -14,9 +14,8 @@ logger = logging.getLogger('pre_commit')
 
 
 class Manifest(object):
-    def __init__(self, repo_path, repo_url):
+    def __init__(self, repo_path):
         self.repo_path = repo_path
-        self.repo_url = repo_url
 
     @cached_property
     def manifest_contents(self):

--- a/pre_commit/repository.py
+++ b/pre_commit/repository.py
@@ -146,7 +146,7 @@ class Repository(object):
 
     @cached_property
     def manifest(self):
-        return Manifest(self._repo_path, self.repo_config['repo'])
+        return Manifest(self._repo_path)
 
     @cached_property
     def hooks(self):

--- a/pre_commit/runner.py
+++ b/pre_commit/runner.py
@@ -15,13 +15,14 @@ class Runner(object):
     repository under test.
     """
 
-    def __init__(self, git_root, config_file):
+    def __init__(self, git_root, config_file, store_dir=None):
         self.git_root = git_root
         self.config_file = config_file
+        self._store_dir = store_dir
 
     @classmethod
     def create(cls, config_file):
-        """Creates a PreCommitRunner by doing the following:
+        """Creates a Runner by doing the following:
             - Finds the root of the current git repository
             - chdir to that directory
         """
@@ -63,4 +64,4 @@ class Runner(object):
 
     @cached_property
     def store(self):
-        return Store()
+        return Store(self._store_dir)

--- a/testing/fixtures.py
+++ b/testing/fixtures.py
@@ -10,6 +10,7 @@ from aspy.yaml import ordered_dump
 from aspy.yaml import ordered_load
 
 import pre_commit.constants as C
+from pre_commit import git
 from pre_commit.clientlib import CONFIG_SCHEMA
 from pre_commit.clientlib import load_manifest
 from pre_commit.schema import apply_defaults
@@ -17,7 +18,6 @@ from pre_commit.schema import validate
 from pre_commit.util import cmd_output
 from pre_commit.util import copy_tree_to_path
 from pre_commit.util import cwd
-from testing.util import get_head_sha
 from testing.util import get_resource_path
 
 
@@ -84,7 +84,7 @@ def make_config_from_repo(repo_path, sha=None, hooks=None, check=True):
     manifest = load_manifest(os.path.join(repo_path, C.MANIFEST_FILE))
     config = OrderedDict((
         ('repo', 'file://{}'.format(repo_path)),
-        ('sha', sha or get_head_sha(repo_path)),
+        ('sha', sha or git.head_sha(repo_path)),
         (
             'hooks',
             hooks or [OrderedDict((('id', hook['id']),)) for hook in manifest],

--- a/testing/util.py
+++ b/testing/util.py
@@ -8,7 +8,7 @@ from pre_commit import parse_shebang
 from pre_commit.languages.docker import docker_is_running
 from pre_commit.languages.pcre import GREP
 from pre_commit.util import cmd_output
-from pre_commit.util import cwd
+from testing.auto_namedtuple import auto_namedtuple
 
 
 TESTING_DIR = os.path.abspath(os.path.dirname(__file__))
@@ -16,11 +16,6 @@ TESTING_DIR = os.path.abspath(os.path.dirname(__file__))
 
 def get_resource_path(path):
     return os.path.join(TESTING_DIR, 'resources', path)
-
-
-def get_head_sha(dir):
-    with cwd(dir):
-        return cmd_output('git', 'rev-parse', 'HEAD')[1].strip()
 
 
 def cmd_output_mocked_pre_commit_home(*args, **kwargs):
@@ -72,3 +67,31 @@ xfailif_no_symlink = pytest.mark.xfail(
     not hasattr(os, 'symlink'),
     reason='Symlink is not supported on this platform',
 )
+
+
+def run_opts(
+        all_files=False,
+        files=(),
+        color=False,
+        verbose=False,
+        hook=None,
+        origin='',
+        source='',
+        hook_stage='commit',
+        show_diff_on_failure=False,
+        commit_msg_filename='',
+):
+    # These are mutually exclusive
+    assert not (all_files and files)
+    return auto_namedtuple(
+        all_files=all_files,
+        files=files,
+        color=color,
+        verbose=verbose,
+        hook=hook,
+        origin=origin,
+        source=source,
+        hook_stage=hook_stage,
+        show_diff_on_failure=show_diff_on_failure,
+        commit_msg_filename=commit_msg_filename,
+    )

--- a/tests/commands/autoupdate_test.py
+++ b/tests/commands/autoupdate_test.py
@@ -7,6 +7,7 @@ from collections import OrderedDict
 import pytest
 
 import pre_commit.constants as C
+from pre_commit import git
 from pre_commit.clientlib import load_config
 from pre_commit.commands.autoupdate import _update_repo
 from pre_commit.commands.autoupdate import autoupdate
@@ -21,7 +22,6 @@ from testing.fixtures import git_dir
 from testing.fixtures import make_config_from_repo
 from testing.fixtures import make_repo
 from testing.fixtures import write_config
-from testing.util import get_head_sha
 from testing.util import get_resource_path
 
 
@@ -66,10 +66,10 @@ def test_autoupdate_old_revision_broken(
         cmd_output('git', 'mv', C.MANIFEST_FILE, 'nope.yaml')
         cmd_output('git', 'commit', '-m', 'simulate old repo')
         # Assume this is the revision the user's old repository was at
-        rev = get_head_sha(path)
+        rev = git.head_sha(path)
         cmd_output('git', 'mv', 'nope.yaml', C.MANIFEST_FILE)
         cmd_output('git', 'commit', '-m', 'move hooks file')
-        update_rev = get_head_sha(path)
+        update_rev = git.head_sha(path)
 
     config['sha'] = rev
     write_config('.', config)
@@ -84,12 +84,12 @@ def test_autoupdate_old_revision_broken(
 @pytest.yield_fixture
 def out_of_date_repo(tempdir_factory):
     path = make_repo(tempdir_factory, 'python_hooks_repo')
-    original_sha = get_head_sha(path)
+    original_sha = git.head_sha(path)
 
     # Make a commit
     with cwd(path):
         cmd_output('git', 'commit', '--allow-empty', '-m', 'foo')
-    head_sha = get_head_sha(path)
+    head_sha = git.head_sha(path)
 
     yield auto_namedtuple(
         path=path, original_sha=original_sha, head_sha=head_sha,
@@ -225,7 +225,7 @@ def test_autoupdate_tags_only(
 @pytest.yield_fixture
 def hook_disappearing_repo(tempdir_factory):
     path = make_repo(tempdir_factory, 'python_hooks_repo')
-    original_sha = get_head_sha(path)
+    original_sha = git.head_sha(path)
 
     with cwd(path):
         shutil.copy(

--- a/tests/commands/try_repo_test.py
+++ b/tests/commands/try_repo_test.py
@@ -1,0 +1,71 @@
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+import re
+
+from pre_commit.commands.try_repo import try_repo
+from pre_commit.util import cmd_output
+from pre_commit.util import cwd
+from testing.auto_namedtuple import auto_namedtuple
+from testing.fixtures import git_dir
+from testing.fixtures import make_repo
+from testing.util import run_opts
+
+
+def try_repo_opts(repo, ref=None, **kwargs):
+    return auto_namedtuple(repo=repo, ref=ref, **run_opts(**kwargs)._asdict())
+
+
+def _get_out(cap_out):
+    out = cap_out.get().replace('\r\n', '\n')
+    out = re.sub('\[INFO\].+\n', '', out)
+    start, using_config, config, rest = out.split('=' * 79 + '\n')
+    assert start == ''
+    assert using_config == 'Using config:\n'
+    return config, rest
+
+
+def _run_try_repo(tempdir_factory, **kwargs):
+    repo = make_repo(tempdir_factory, 'modified_file_returns_zero_repo')
+    with cwd(git_dir(tempdir_factory)):
+        open('test-file', 'a').close()
+        cmd_output('git', 'add', '.')
+        assert not try_repo(try_repo_opts(repo, **kwargs))
+
+
+def test_try_repo_repo_only(cap_out, tempdir_factory):
+    _run_try_repo(tempdir_factory, verbose=True)
+    config, rest = _get_out(cap_out)
+    assert re.match(
+        '^repos:\n'
+        '-   repo: .+\n'
+        '    sha: .+\n'
+        '    hooks:\n'
+        '    -   id: bash_hook\n'
+        '    -   id: bash_hook2\n'
+        '    -   id: bash_hook3\n$',
+        config,
+    )
+    assert rest == (
+        '[bash_hook] Bash hook................................(no files to check)Skipped\n'  # noqa
+        '[bash_hook2] Bash hook...................................................Passed\n'  # noqa
+        'hookid: bash_hook2\n'
+        '\n'
+        'test-file\n'
+        '\n'
+        '[bash_hook3] Bash hook...............................(no files to check)Skipped\n'  # noqa
+    )
+
+
+def test_try_repo_with_specific_hook(cap_out, tempdir_factory):
+    _run_try_repo(tempdir_factory, hook='bash_hook', verbose=True)
+    config, rest = _get_out(cap_out)
+    assert re.match(
+        '^repos:\n'
+        '-   repo: .+\n'
+        '    sha: .+\n'
+        '    hooks:\n'
+        '    -   id: bash_hook\n$',
+        config,
+    )
+    assert rest == '[bash_hook] Bash hook................................(no files to check)Skipped\n'  # noqa

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -92,10 +92,16 @@ def test_help_other_command(
 
 
 @pytest.mark.parametrize('command', CMDS)
-def test_install_command(command, mock_commands):
+def test_all_cmds(command, mock_commands):
     main.main((command,))
     assert getattr(mock_commands, command.replace('-', '_')).call_count == 1
     assert_only_one_mock_called(mock_commands)
+
+
+def test_try_repo():
+    with mock.patch.object(main, 'try_repo') as patch:
+        main.main(('try-repo', '.'))
+    assert patch.call_count == 1
 
 
 def test_help_cmd_in_empty_directory(

--- a/tests/make_archives_test.py
+++ b/tests/make_archives_test.py
@@ -6,11 +6,11 @@ import tarfile
 
 import pytest
 
+from pre_commit import git
 from pre_commit import make_archives
 from pre_commit.util import cmd_output
 from pre_commit.util import cwd
 from testing.fixtures import git_dir
-from testing.util import get_head_sha
 from testing.util import skipif_slowtests_false
 
 
@@ -23,7 +23,7 @@ def test_make_archive(tempdir_factory):
         cmd_output('git', 'add', '.')
         cmd_output('git', 'commit', '-m', 'foo')
         # We'll use this sha
-        head_sha = get_head_sha('.')
+        head_sha = git.head_sha('.')
         # And check that this file doesn't exist
         open('bar', 'a').close()
         cmd_output('git', 'add', '.')

--- a/tests/manifest_test.py
+++ b/tests/manifest_test.py
@@ -3,16 +3,16 @@ from __future__ import unicode_literals
 
 import pytest
 
+from pre_commit import git
 from pre_commit.manifest import Manifest
 from testing.fixtures import make_repo
-from testing.util import get_head_sha
 
 
 @pytest.yield_fixture
 def manifest(store, tempdir_factory):
     path = make_repo(tempdir_factory, 'script_hooks_repo')
-    repo_path = store.clone(path, get_head_sha(path))
-    yield Manifest(repo_path, path)
+    repo_path = store.clone(path, git.head_sha(path))
+    yield Manifest(repo_path)
 
 
 def test_manifest_contents(manifest):
@@ -62,8 +62,8 @@ def test_hooks(manifest):
 
 def test_default_python_language_version(store, tempdir_factory):
     path = make_repo(tempdir_factory, 'python_hooks_repo')
-    repo_path = store.clone(path, get_head_sha(path))
-    manifest = Manifest(repo_path, path)
+    repo_path = store.clone(path, git.head_sha(path))
+    manifest = Manifest(repo_path)
 
     # This assertion is difficult as it is version dependent, just assert
     # that it is *something*

--- a/tests/store_test.py
+++ b/tests/store_test.py
@@ -9,13 +9,13 @@ import mock
 import pytest
 import six
 
+from pre_commit import git
 from pre_commit.store import _get_default_directory
 from pre_commit.store import Store
 from pre_commit.util import cmd_output
 from pre_commit.util import cwd
 from pre_commit.util import rmtree
 from testing.fixtures import git_dir
-from testing.util import get_head_sha
 
 
 def test_our_session_fixture_works():
@@ -91,7 +91,7 @@ def test_clone(store, tempdir_factory, log_info_mock):
     path = git_dir(tempdir_factory)
     with cwd(path):
         cmd_output('git', 'commit', '--allow-empty', '-m', 'foo')
-        sha = get_head_sha(path)
+        sha = git.head_sha(path)
         cmd_output('git', 'commit', '--allow-empty', '-m', 'bar')
 
     ret = store.clone(path, sha)
@@ -107,7 +107,7 @@ def test_clone(store, tempdir_factory, log_info_mock):
     _, dirname = os.path.split(ret)
     assert dirname.startswith('repo')
     # Should be checked out to the sha we specified
-    assert get_head_sha(ret) == sha
+    assert git.head_sha(ret) == sha
 
     # Assert there's an entry in the sqlite db for this
     with sqlite3.connect(store.db_path) as db:


### PR DESCRIPTION
`try-repo` is useful for:
- Trying out a remote hook repository without needing to configure it.
- Testing a hook repository while developing it.

Refs #589