### PR TITLE
Add selinux labelling option to docker_image hook type

### DIFF
--- a/pre_commit/languages/docker.py
+++ b/pre_commit/languages/docker.py
@@ -82,7 +82,7 @@ def docker_cmd():
         'docker', 'run',
         '--rm',
         '-u', '{}:{}'.format(os.getuid(), os.getgid()),
-        '-v', '{}:/src:rw'.format(os.getcwd()),
+        '-v', '{}:/src:rw,Z'.format(os.getcwd()),
         '--workdir', '/src',
     )
 

--- a/pre_commit/languages/docker.py
+++ b/pre_commit/languages/docker.py
@@ -82,6 +82,9 @@ def docker_cmd():
         'docker', 'run',
         '--rm',
         '-u', '{}:{}'.format(os.getuid(), os.getgid()),
+        # https://docs.docker.com/engine/reference/commandline/run/#mount-volumes-from-container-volumes-from
+        # The `Z` option tells Docker to label the content with a private
+        # unshared label. Only the current container can use a private volume.
         '-v', '{}:/src:rw,Z'.format(os.getcwd()),
         '--workdir', '/src',
     )


### PR DESCRIPTION
Without this, the hook fails on envs running with selinux enabled. This option automatically labels mounted volumes correctly.