### PR TITLE
Invoke `git diff` without a pager

### DIFF
--- a/pre_commit/commands/run.py
+++ b/pre_commit/commands/run.py
@@ -193,7 +193,7 @@ def _run_hooks(config, repo_hooks, args, environ):
             subprocess.call(('git', 'diff', '--quiet', '--no-ext-diff')) != 0
     ):
         print('All changes made by hooks:')
-        subprocess.call(('git', 'diff', '--no-ext-diff'))
+        subprocess.call(('git', '--no-pager', 'diff', '--no-ext-diff'))
     return retval
 
 


### PR DESCRIPTION
On travis-ci which partially implements a tty so scripts spit out colors `git diff` will attempt to use a pager.

```
pyupgrade................................................................Passed
All changes made by hooks:
WARNING: terminal is not fully functional
-  (press RETURN)
No output has been received in the last 10m0s, this potentially indicates a stalled build or something 
```

This forces `git` to not use a pager.