### PR TITLE
Add a verbose hook option

### DIFF
--- a/pre_commit/clientlib.py
+++ b/pre_commit/clientlib.py
@@ -68,6 +68,7 @@ MANIFEST_HOOK_DICT = schema.Map(
     schema.Optional('log_file', schema.check_string, ''),
     schema.Optional('minimum_pre_commit_version', schema.check_string, '0'),
     schema.Optional('stages', schema.check_array(schema.check_string), []),
+    schema.Optional('verbose', schema.check_bool, False),
 )
 MANIFEST_SCHEMA = schema.Array(MANIFEST_HOOK_DICT)
 

--- a/pre_commit/commands/run.py
+++ b/pre_commit/commands/run.py
@@ -130,7 +130,10 @@ def _run_single_hook(filenames, hook, repo, args, skips, cols):
 
     output.write_line(color.format_color(pass_fail, print_color, args.color))
 
-    if (stdout or stderr or file_modifications) and (retcode or args.verbose):
+    if (
+            (stdout or stderr or file_modifications) and
+            (retcode or args.verbose or hook['verbose'])
+    ):
         output.write_line('hookid: {}\n'.format(hook['id']))
 
         # Print a message if failing due to file modifications

--- a/tests/commands/run_test.py
+++ b/tests/commands/run_test.py
@@ -292,6 +292,23 @@ def test_always_run_alt_config(
     )
 
 
+def test_hook_verbose_enabled(
+        cap_out, repo_with_passing_hook, mock_out_store_directory,
+):
+    with modify_config() as config:
+        config['repos'][0]['hooks'][0]['always_run'] = True
+        config['repos'][0]['hooks'][0]['verbose'] = True
+
+    _test_run(
+        cap_out,
+        repo_with_passing_hook,
+        {},
+        (b'Hello World',),
+        0,
+        stage=False,
+    )
+
+
 @pytest.mark.parametrize(
     ('origin', 'source', 'expect_failure'),
     (

--- a/tests/repository_test.py
+++ b/tests/repository_test.py
@@ -789,4 +789,5 @@ def test_manifest_hooks(tempdir_factory, store):
         'stages': [],
         'types': ['file'],
         'exclude_types': [],
+        'verbose': False,
     }


### PR DESCRIPTION
Relates to #689
It adds a `verbose` flag that can be set per hook and that allows stdout to be printed even when hook returned 0 