### PR TITLE
Each set of additional dependencies gets its own env

### DIFF
--- a/pre_commit/commands/autoupdate.py
+++ b/pre_commit/commands/autoupdate.py
@@ -33,9 +33,9 @@ def _update_repo(repo_config, runner, tags_only):
     Args:
         repo_config - A config for a repository
     """
-    repo = Repository.create(repo_config, runner.store)
+    repo_path = runner.store.clone(repo_config['repo'], repo_config['sha'])
 
-    with cwd(repo._repo_path):
+    with cwd(repo_path):
         cmd_output('git', 'fetch')
         tag_cmd = ('git', 'describe', 'origin/master', '--tags')
         if tags_only:
@@ -57,7 +57,7 @@ def _update_repo(repo_config, runner, tags_only):
     new_repo = Repository.create(new_config, runner.store)
 
     # See if any of our hooks were deleted with the new commits
-    hooks = {hook['id'] for hook in repo.repo_config['hooks']}
+    hooks = {hook['id'] for hook in repo_config['hooks']}
     hooks_missing = hooks - (hooks & set(new_repo.manifest_hooks))
     if hooks_missing:
         raise RepositoryCannotBeUpdatedError(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -165,12 +165,6 @@ def log_info_mock():
         yield mck
 
 
-@pytest.fixture
-def log_warning_mock():
-    with mock.patch.object(logging.getLogger('pre_commit'), 'warning') as mck:
-        yield mck
-
-
 class FakeStream(object):
     def __init__(self):
         self.data = io.BytesIO()


### PR DESCRIPTION
Resolves #590

There's one "questionable" change which is moving `CHAR(255)` => `TEXT` -- though in `sqlite` the width specifiers [are dropped](https://www.sqlite.org/datatype3.html#affinity_name_examples) so this is safe.

In addition to the regression test, I tested this manually:

### config

```yaml
repos:
-   repo: https://github.com/pre-commit/pre-commit-hooks
    sha: v1.2.1
    hooks:
    -   id: flake8
        additional_dependencies: [flake8-coding]
-   repo: https://github.com/pre-commit/pre-commit-hooks
    sha: v1.2.1
    hooks:
    -   id: flake8
        additional_dependencies: [flake8-quotes]
```

### before

```console
$ pre-commit run --all-files
[INFO] Installing environment for https://github.com/pre-commit/pre-commit-hooks.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/pre-commit/pre-commit-hooks.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
Flake8...................................................................Failed
hookid: flake8

test.py:0:1: C101 Coding magic comment not found

Flake8...................................................................Failed
hookid: flake8

test.py:0:1: C101 Coding magic comment not found

$ pre-commit run --all-files
[INFO] Installing environment for https://github.com/pre-commit/pre-commit-hooks.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/pre-commit/pre-commit-hooks.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
Flake8...................................................................Failed
hookid: flake8

test.py:0:1: C101 Coding magic comment not found

Flake8...................................................................Failed
hookid: flake8

test.py:0:1: C101 Coding magic comment not found

```

### after

```console
$ ~/workspace/pre-commit/venv/bin/pre-commit run --all-files
[INFO] Initializing environment for https://github.com/pre-commit/pre-commit-hooks:flake8-coding.
[INFO] Installing environment for https://github.com/pre-commit/pre-commit-hooks.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Initializing environment for https://github.com/pre-commit/pre-commit-hooks:flake8-quotes.
[INFO] Installing environment for https://github.com/pre-commit/pre-commit-hooks.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
Flake8...................................................................Failed
hookid: flake8

test.py:0:1: C101 Coding magic comment not found

Flake8...................................................................Failed
hookid: flake8

test.py:2:12: Q000 Remove bad quotes

```