### PR TITLE
Migrate sha -> rev

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,16 +13,16 @@ repos:
     -   id: requirements-txt-fixer
     -   id: flake8
 -   repo: https://github.com/pre-commit/pre-commit.git
-    sha: v0.16.3
+    rev: v0.16.3
     hooks:
     -   id: validate_manifest
 -   repo: https://github.com/asottile/reorder_python_imports.git
-    sha: v0.3.5
+    rev: v0.3.5
     hooks:
     -   id: reorder-python-imports
         language_version: python2.7
 -   repo: https://github.com/asottile/add-trailing-comma
-    sha: v0.6.4
+    rev: v0.6.4
     hooks:
     -   id: add-trailing-comma
 -   repo: meta

--- a/pre_commit/commands/sample_config.py
+++ b/pre_commit/commands/sample_config.py
@@ -12,7 +12,7 @@ SAMPLE_CONFIG = '''\
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    sha: v0.9.2
+    rev: v1.2.1-1
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer

--- a/pre_commit/commands/try_repo.py
+++ b/pre_commit/commands/try_repo.py
@@ -17,7 +17,7 @@ from pre_commit.util import tmpdir
 
 
 def try_repo(args):
-    ref = args.ref or git.head_sha(args.repo)
+    ref = args.ref or git.head_rev(args.repo)
 
     with tmpdir() as tempdir:
         if args.hook:
@@ -28,7 +28,7 @@ def try_repo(args):
             manifest = sorted(manifest, key=lambda hook: hook['id'])
             hooks = [{'id': hook['id']} for hook in manifest]
 
-        items = (('repo', args.repo), ('sha', ref), ('hooks', hooks))
+        items = (('repo', args.repo), ('rev', ref), ('hooks', hooks))
         config = {'repos': [collections.OrderedDict(items)]}
         config_s = ordered_dump(config, **C.YAML_DUMP_KWARGS)
 

--- a/pre_commit/git.py
+++ b/pre_commit/git.py
@@ -97,7 +97,7 @@ def get_changed_files(new, old):
     )[1])
 
 
-def head_sha(remote):
+def head_rev(remote):
     _, out, _ = cmd_output('git', 'ls-remote', '--exit-code', remote, 'HEAD')
     return out.split()[0]
 

--- a/pre_commit/main.py
+++ b/pre_commit/main.py
@@ -200,9 +200,9 @@ def main(argv=None):
         'repo', help='Repository to source hooks from.',
     )
     try_repo_parser.add_argument(
-        '--ref',
+        '--ref', '--rev',
         help=(
-            'Manually select a ref to run against, otherwise the `HEAD` '
+            'Manually select a rev to run against, otherwise the `HEAD` '
             'revision will be used.'
         ),
     )

--- a/pre_commit/repository.py
+++ b/pre_commit/repository.py
@@ -150,8 +150,8 @@ class Repository(object):
 
     @cached_property
     def manifest_hooks(self):
-        repo, sha = self.repo_config['repo'], self.repo_config['sha']
-        repo_path = self.store.clone(repo, sha)
+        repo, rev = self.repo_config['repo'], self.repo_config['rev']
+        repo_path = self.store.clone(repo, rev)
         manifest_path = os.path.join(repo_path, C.MANIFEST_FILE)
         return {hook['id']: hook for hook in load_manifest(manifest_path)}
 
@@ -174,8 +174,8 @@ class Repository(object):
         )
 
     def _prefix_from_deps(self, language_name, deps):
-        repo, sha = self.repo_config['repo'], self.repo_config['sha']
-        return Prefix(self.store.clone(repo, sha, deps))
+        repo, rev = self.repo_config['repo'], self.repo_config['rev']
+        return Prefix(self.store.clone(repo, rev, deps))
 
     def _venvs(self):
         ret = []

--- a/testing/fixtures.py
+++ b/testing/fixtures.py
@@ -78,11 +78,11 @@ def config_with_local_hooks():
     ))
 
 
-def make_config_from_repo(repo_path, sha=None, hooks=None, check=True):
+def make_config_from_repo(repo_path, rev=None, hooks=None, check=True):
     manifest = load_manifest(os.path.join(repo_path, C.MANIFEST_FILE))
     config = OrderedDict((
         ('repo', 'file://{}'.format(repo_path)),
-        ('sha', sha or git.head_sha(repo_path)),
+        ('rev', rev or git.head_rev(repo_path)),
         (
             'hooks',
             hooks or [OrderedDict((('id', hook['id']),)) for hook in manifest],

--- a/tests/commands/migrate_config_test.py
+++ b/tests/commands/migrate_config_test.py
@@ -118,3 +118,30 @@ def test_already_migrated_configuration_noop(tmpdir, capsys):
     out, _ = capsys.readouterr()
     assert out == 'Configuration is already migrated.\n'
     assert cfg.read() == contents
+
+
+def test_migrate_config_sha_to_rev(tmpdir):
+    contents = (
+        'repos:\n'
+        '-   repo: https://github.com/pre-commit/pre-commit-hooks\n'
+        '    sha: v1.2.0\n'
+        '    hooks: []\n'
+        'repos:\n'
+        '-   repo: https://github.com/pre-commit/pre-commit-hooks\n'
+        '    sha: v1.2.0\n'
+        '    hooks: []\n'
+    )
+    cfg = tmpdir.join(C.CONFIG_FILE)
+    cfg.write(contents)
+    assert not migrate_config(Runner(tmpdir.strpath, C.CONFIG_FILE))
+    contents = cfg.read()
+    assert contents == (
+        'repos:\n'
+        '-   repo: https://github.com/pre-commit/pre-commit-hooks\n'
+        '    rev: v1.2.0\n'
+        '    hooks: []\n'
+        'repos:\n'
+        '-   repo: https://github.com/pre-commit/pre-commit-hooks\n'
+        '    rev: v1.2.0\n'
+        '    hooks: []\n'
+    )

--- a/tests/commands/sample_config_test.py
+++ b/tests/commands/sample_config_test.py
@@ -13,7 +13,7 @@ def test_sample_config(capsys):
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    sha: v0.9.2
+    rev: v1.2.1-1
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer

--- a/tests/commands/try_repo_test.py
+++ b/tests/commands/try_repo_test.py
@@ -39,7 +39,7 @@ def test_try_repo_repo_only(cap_out, tempdir_factory):
     assert re.match(
         '^repos:\n'
         '-   repo: .+\n'
-        '    sha: .+\n'
+        '    rev: .+\n'
         '    hooks:\n'
         '    -   id: bash_hook\n'
         '    -   id: bash_hook2\n'
@@ -63,7 +63,7 @@ def test_try_repo_with_specific_hook(cap_out, tempdir_factory):
     assert re.match(
         '^repos:\n'
         '-   repo: .+\n'
-        '    sha: .+\n'
+        '    rev: .+\n'
         '    hooks:\n'
         '    -   id: bash_hook\n$',
         config,

--- a/tests/make_archives_test.py
+++ b/tests/make_archives_test.py
@@ -19,8 +19,8 @@ def test_make_archive(tempdir_factory):
     open(os.path.join(git_path, 'foo'), 'a').close()
     cmd_output('git', '-C', git_path, 'add', '.')
     cmd_output('git', '-C', git_path, 'commit', '-m', 'foo')
-    # We'll use this sha
-    head_sha = git.head_sha(git_path)
+    # We'll use this rev
+    head_rev = git.head_rev(git_path)
     # And check that this file doesn't exist
     open(os.path.join(git_path, 'bar'), 'a').close()
     cmd_output('git', '-C', git_path, 'add', '.')
@@ -28,7 +28,7 @@ def test_make_archive(tempdir_factory):
 
     # Do the thing
     archive_path = make_archives.make_archive(
-        'foo', git_path, head_sha, output_dir,
+        'foo', git_path, head_rev, output_dir,
     )
 
     assert archive_path == os.path.join(output_dir, 'foo.tar.gz')

--- a/tests/repository_test.py
+++ b/tests/repository_test.py
@@ -660,14 +660,14 @@ def test_tags_on_repositories(in_tmpdir, tempdir_factory, store):
     )
 
     repo_1 = Repository.create(
-        make_config_from_repo(git_dir_1, sha=tag), store,
+        make_config_from_repo(git_dir_1, rev=tag), store,
     )
     ret = repo_1.run_hook(repo_1.hooks[0][1], ['-L'])
     assert ret[0] == 0
     assert ret[1].strip() == _norm_pwd(in_tmpdir)
 
     repo_2 = Repository.create(
-        make_config_from_repo(git_dir_2, sha=tag), store,
+        make_config_from_repo(git_dir_2, rev=tag), store,
     )
     ret = repo_2.run_hook(repo_2.hooks[0][1], ['bar'])
     assert ret[0] == 0


### PR DESCRIPTION
Resolves #106 

The ticket mentions "ref", but I think "rev" is perhaps a better name?  Would love to get input here

This will be a slow migration, and during that time both `sha` and `rev` will be supported (but not both!)

I was able to leverage a [custom `cfgv` validator](https://github.com/asottile/cfgv#writing-your-own-validator) to accomplish this cleanly.