### PR TITLE
Add multiline mode to pygrep

### DIFF
--- a/pre_commit/languages/pygrep.py
+++ b/pre_commit/languages/pygrep.py
@@ -29,7 +29,7 @@ def _process_filename_by_line(pattern, filename):
 def _process_filename_at_once(pattern, filename):
     retv = 0
     with open(filename, 'rb') as f:
-        match = pattern.search(f.read())
+        match = pattern.search(f.read().decode('utf-8').replace('\n',''))
         if match:
             retv = 1
             output.write('{}:'.format(filename))

--- a/pre_commit/languages/pygrep.py
+++ b/pre_commit/languages/pygrep.py
@@ -34,17 +34,13 @@ def _process_filename_at_once(pattern, filename):
         match = pattern.search(contents)
         if match:
             retv = 1
-            line_no = len(
-                re.compile('\n'.encode()).findall(contents, 0, match.start()),
-            )
-            output.write(
-                '{}:{}:'.format(filename, line_no + 1),
-            )
+            line_no = contents[:match.start()].count(b'\n')
+            output.write('{}:{}:'.format(filename, line_no + 1))
 
-            matched_lines = match.group().split('\n')
-            matched_lines[0] = contents.split('\n')[line_no]
+            matched_lines = match.group().split(b'\n')
+            matched_lines[0] = contents.split(b'\n')[line_no]
 
-            output.write_line('\n'.join(matched_lines))
+            output.write_line(b'\n'.join(matched_lines))
     return retv
 
 
@@ -70,7 +66,7 @@ def main(argv=None):
 
     flags = re.IGNORECASE if args.ignore_case else 0
     if args.multiline:
-        flags = flags | re.MULTILINE | re.DOTALL
+        flags |= re.MULTILINE | re.DOTALL
 
     pattern = re.compile(args.pattern.encode(), flags)
 

--- a/pre_commit/languages/pygrep.py
+++ b/pre_commit/languages/pygrep.py
@@ -33,7 +33,9 @@ def _process_filename_at_once(pattern, filename):
         match = pattern.search(f.read())
         if match:
             retv = 1
-            output.write('{}:{}-{}:'.format(filename, match.start(), match.end()))
+            output.write(
+                '{}:{}-{}:'.format(filename, match.start(), match.end()),
+            )
             output.write_line(match.group())
     return retv
 

--- a/pre_commit/languages/pygrep.py
+++ b/pre_commit/languages/pygrep.py
@@ -30,10 +30,10 @@ def _process_filename_by_line(pattern, filename):
 def _process_filename_at_once(pattern, filename):
     retv = 0
     with open(filename, 'rb') as f:
-        match = pattern.search(f.read().decode('utf-8').replace('\n', ''))
+        match = pattern.search(f.read())
         if match:
             retv = 1
-            output.write('{}:'.format(filename))
+            output.write('{}:{}-{}:'.format(filename, match.start(), match.end()))
             output.write_line(match.group())
     return retv
 
@@ -59,6 +59,9 @@ def main(argv=None):
     args = parser.parse_args(argv)
 
     flags = re.IGNORECASE if args.ignore_case else 0
+    if args.null_data:
+        flags = flags | re.MULTILINE | re.DOTALL
+
     pattern = re.compile(args.pattern.encode(), flags)
 
     retv = 0

--- a/pre_commit/languages/pygrep.py
+++ b/pre_commit/languages/pygrep.py
@@ -26,6 +26,15 @@ def _process_filename_by_line(pattern, filename):
                 output.write_line(line.rstrip(b'\r\n'))
     return retv
 
+def _process_filename_at_once(pattern, filename):
+    retv = 0
+    with open(filename, 'rb') as f:
+        match = pattern.search(f.read())
+        if match:
+            retv = 1
+            output.write('{}:'.format(filename))
+            output.write_line(match.group())
+    return retv
 
 def run_hook(prefix, hook, file_args):
     exe = (sys.executable, '-m', __name__)
@@ -42,6 +51,7 @@ def main(argv=None):
         ),
     )
     parser.add_argument('-i', '--ignore-case', action='store_true')
+    parser.add_argument('-z', '--null-data', action='store_true')
     parser.add_argument('pattern', help='python regex pattern.')
     parser.add_argument('filenames', nargs='*')
     args = parser.parse_args(argv)
@@ -51,7 +61,10 @@ def main(argv=None):
 
     retv = 0
     for filename in args.filenames:
-        retv |= _process_filename_by_line(pattern, filename)
+        if args.null_data:
+            retv |= _process_filename_at_once(pattern, filename)
+        else:
+            retv |= _process_filename_by_line(pattern, filename)
     return retv
 
 

--- a/pre_commit/languages/pygrep.py
+++ b/pre_commit/languages/pygrep.py
@@ -26,15 +26,17 @@ def _process_filename_by_line(pattern, filename):
                 output.write_line(line.rstrip(b'\r\n'))
     return retv
 
+
 def _process_filename_at_once(pattern, filename):
     retv = 0
     with open(filename, 'rb') as f:
-        match = pattern.search(f.read().decode('utf-8').replace('\n',''))
+        match = pattern.search(f.read().decode('utf-8').replace('\n', ''))
         if match:
             retv = 1
             output.write('{}:'.format(filename))
             output.write_line(match.group())
     return retv
+
 
 def run_hook(prefix, hook, file_args):
     exe = (sys.executable, '-m', __name__)

--- a/tests/languages/pygrep_test.py
+++ b/tests/languages/pygrep_test.py
@@ -39,6 +39,7 @@ def test_ignore_case(some_files, cap_out):
     assert ret == 1
     assert out == 'f2:1:[INFO] hi\n'
 
+
 def test_null_data(some_files, cap_out):
     ret = pygrep.main(('--null-data', r'foo.*bar', 'f1', 'f2', 'f3'))
     out = cap_out.get()

--- a/tests/languages/pygrep_test.py
+++ b/tests/languages/pygrep_test.py
@@ -38,3 +38,9 @@ def test_ignore_case(some_files, cap_out):
     out = cap_out.get()
     assert ret == 1
     assert out == 'f2:1:[INFO] hi\n'
+
+def test_null_data(some_files, cap_out):
+    ret = pygrep.main(('--null-data', r'foo.*bar', 'f1', 'f2', 'f3'))
+    out = cap_out.get()
+    assert ret == 1
+    assert out == 'f1:foobar\n'

--- a/tests/languages/pygrep_test.py
+++ b/tests/languages/pygrep_test.py
@@ -41,7 +41,21 @@ def test_ignore_case(some_files, cap_out):
 
 
 def test_null_data(some_files, cap_out):
-    ret = pygrep.main(('--null-data', r'foo.*bar', 'f1', 'f2', 'f3'))
+    ret = pygrep.main(('--null-data', r'foo\nbar', 'f1', 'f2', 'f3'))
     out = cap_out.get()
     assert ret == 1
-    assert out == 'f1:foobar\n'
+    assert out == 'f1:0-7:foo\nbar\n'
+
+
+def test_null_data_dotall_flag_is_enabled(some_files, cap_out):
+    ret = pygrep.main(('--null-data', r'o.*bar', 'f1', 'f2', 'f3'))
+    out = cap_out.get()
+    assert ret == 1
+    assert out == 'f1:1-7:oo\nbar\n'
+
+
+def test_null_data_multiline_flag_is_enabled(some_files, cap_out):
+    ret = pygrep.main(('--null-data', r'foo$.*bar', 'f1', 'f2', 'f3'))
+    out = cap_out.get()
+    assert ret == 1
+    assert out == 'f1:0-7:foo\nbar\n'

--- a/tests/languages/pygrep_test.py
+++ b/tests/languages/pygrep_test.py
@@ -40,22 +40,29 @@ def test_ignore_case(some_files, cap_out):
     assert out == 'f2:1:[INFO] hi\n'
 
 
-def test_null_data(some_files, cap_out):
-    ret = pygrep.main(('--null-data', r'foo\nbar', 'f1', 'f2', 'f3'))
+def test_multiline(some_files, cap_out):
+    ret = pygrep.main(('--multiline', r'foo\nbar', 'f1', 'f2', 'f3'))
     out = cap_out.get()
     assert ret == 1
-    assert out == 'f1:0-7:foo\nbar\n'
+    assert out == 'f1:1:foo\nbar\n'
 
 
-def test_null_data_dotall_flag_is_enabled(some_files, cap_out):
-    ret = pygrep.main(('--null-data', r'o.*bar', 'f1', 'f2', 'f3'))
+def test_multiline_line_number(some_files, cap_out):
+    ret = pygrep.main(('--multiline', r'ar', 'f1', 'f2', 'f3'))
     out = cap_out.get()
     assert ret == 1
-    assert out == 'f1:1-7:oo\nbar\n'
+    assert out == 'f1:2:bar\n'
 
 
-def test_null_data_multiline_flag_is_enabled(some_files, cap_out):
-    ret = pygrep.main(('--null-data', r'foo$.*bar', 'f1', 'f2', 'f3'))
+def test_multiline_dotall_flag_is_enabled(some_files, cap_out):
+    ret = pygrep.main(('--multiline', r'o.*bar', 'f1', 'f2', 'f3'))
     out = cap_out.get()
     assert ret == 1
-    assert out == 'f1:0-7:foo\nbar\n'
+    assert out == 'f1:1:foo\nbar\n'
+
+
+def test_multiline_multiline_flag_is_enabled(some_files, cap_out):
+    ret = pygrep.main(('--multiline', r'foo$.*bar', 'f1', 'f2', 'f3'))
+    out = cap_out.get()
+    assert ret == 1
+    assert out == 'f1:1:foo\nbar\n'


### PR DESCRIPTION
As a follow-up on https://github.com/pre-commit/pre-commit/issues/634, I'm using today pcre hooks with `-z` option, which is the multiline mode, I'd like to add support for this to be able to move to pygrep hooks. I used the same argument name as `grep` does