### PR TITLE
Use --clean-src for nodeenv

### DIFF
--- a/pre_commit/languages/node.py
+++ b/pre_commit/languages/node.py
@@ -55,7 +55,9 @@ def install_environment(prefix, version, additional_dependencies):
     if sys.platform == 'win32':  # pragma: no cover
         envdir = '\\\\?\\' + os.path.normpath(envdir)
     with clean_path_on_failure(envdir):
-        cmd = [sys.executable, '-m', 'nodeenv', '--prebuilt', envdir]
+        cmd = [
+            sys.executable, '-mnodeenv', '--prebuilt', '--clean-src', envdir,
+        ]
         if version != 'default':
             cmd.extend(['-n', version])
         cmd_output(*cmd)


### PR DESCRIPTION
Makes a pretty big difference on size:

```console
$ nodeenv nenv3 --prebuilt --clean-src
 * Install prebuilt node (9.7.0) ..... done.
$ du -hs nenv3/
70M	nenv3/
$ nodeenv nenv4 --prebuilt
 * Install prebuilt node (9.7.0) ..... done.
$ du -hs nenv4
140M	nenv4
```