### PR TITLE
Restore git 1.8 support

### DIFF
--- a/latest-git.sh
+++ b/latest-git.sh
@@ -3,6 +3,5 @@
 set -ex
 git clone git://github.com/git/git --depth 1 /tmp/git
 pushd /tmp/git
-make prefix=/tmp/git -j 8 all
-make prefix=/tmp/git install
+make prefix=/tmp/git -j8 install
 popd

--- a/pre_commit/commands/autoupdate.py
+++ b/pre_commit/commands/autoupdate.py
@@ -34,17 +34,17 @@ def _update_repo(repo_config, runner, tags_only):
     """
     repo_path = runner.store.clone(repo_config['repo'], repo_config['rev'])
 
-    cmd_output('git', '-C', repo_path, 'fetch')
-    tag_cmd = ('git', '-C', repo_path, 'describe', 'origin/master', '--tags')
+    cmd_output('git', 'fetch', cwd=repo_path)
+    tag_cmd = ('git', 'describe', 'origin/master', '--tags')
     if tags_only:
         tag_cmd += ('--abbrev=0',)
     else:
         tag_cmd += ('--exact',)
     try:
-        rev = cmd_output(*tag_cmd)[1].strip()
+        rev = cmd_output(*tag_cmd, cwd=repo_path)[1].strip()
     except CalledProcessError:
-        tag_cmd = ('git', '-C', repo_path, 'rev-parse', 'origin/master')
-        rev = cmd_output(*tag_cmd)[1].strip()
+        tag_cmd = ('git', 'rev-parse', 'origin/master')
+        rev = cmd_output(*tag_cmd, cwd=repo_path)[1].strip()
 
     # Don't bother trying to update if our rev is the same
     if rev == repo_config['rev']:

--- a/pre_commit/make_archives.py
+++ b/pre_commit/make_archives.py
@@ -41,7 +41,7 @@ def make_archive(name, repo, ref, destdir):
     with tmpdir() as tempdir:
         # Clone the repository to the temporary directory
         cmd_output('git', 'clone', repo, tempdir)
-        cmd_output('git', '-C', tempdir, 'checkout', ref)
+        cmd_output('git', 'checkout', ref, cwd=tempdir)
 
         # We don't want the '.git' directory
         # It adds a bunch of size to the archive and we don't use it at

--- a/pre_commit/store.py
+++ b/pre_commit/store.py
@@ -144,7 +144,7 @@ class Store(object):
             env = no_git_env()
 
             def _git_cmd(*args):
-                return cmd_output('git', '-C', directory, *args, env=env)
+                return cmd_output('git', *args, cwd=directory, env=env)
 
             _git_cmd('clone', '--no-checkout', repo, '.')
             _git_cmd('reset', ref, '--hard')
@@ -163,7 +163,7 @@ class Store(object):
 
             # initialize the git repository so it looks more like cloned repos
             def _git_cmd(*args):
-                cmd_output('git', '-C', directory, *args, env=env)
+                cmd_output('git', *args, cwd=directory, env=env)
 
             _git_cmd('init', '.')
             _git_cmd('config', 'remote.origin.url', '<<unknown>>')

--- a/testing/fixtures.py
+++ b/testing/fixtures.py
@@ -29,8 +29,8 @@ def git_dir(tempdir_factory):
 def make_repo(tempdir_factory, repo_source):
     path = git_dir(tempdir_factory)
     copy_tree_to_path(get_resource_path(repo_source), path)
-    cmd_output('git', '-C', path, 'add', '.')
-    cmd_output('git', '-C', path, 'commit', '-m', 'Add hooks')
+    cmd_output('git', 'add', '.', cwd=path)
+    cmd_output('git', 'commit', '-m', 'Add hooks', cwd=path)
     return path
 
 
@@ -114,15 +114,14 @@ def write_config(directory, config, config_file=C.CONFIG_FILE):
 
 def add_config_to_repo(git_path, config, config_file=C.CONFIG_FILE):
     write_config(git_path, config, config_file=config_file)
-    cmd_output('git', '-C', git_path, 'add', config_file)
-    cmd_output('git', '-C', git_path, 'commit', '-m', 'Add hooks config')
+    cmd_output('git', 'add', config_file, cwd=git_path)
+    cmd_output('git', 'commit', '-m', 'Add hooks config', cwd=git_path)
     return git_path
 
 
 def remove_config_from_repo(git_path, config_file=C.CONFIG_FILE):
-    os.unlink(os.path.join(git_path, config_file))
-    cmd_output('git', '-C', git_path, 'add', config_file)
-    cmd_output('git', '-C', git_path, 'commit', '-m', 'Remove hooks config')
+    cmd_output('git', 'rm', config_file, cwd=git_path)
+    cmd_output('git', 'commit', '-m', 'Remove hooks config', cwd=git_path)
     return git_path
 
 

--- a/tests/commands/autoupdate_test.py
+++ b/tests/commands/autoupdate_test.py
@@ -62,12 +62,12 @@ def test_autoupdate_old_revision_broken(
     path = make_repo(tempdir_factory, 'python_hooks_repo')
     config = make_config_from_repo(path, check=False)
 
-    cmd_output('git', '-C', path, 'mv', C.MANIFEST_FILE, 'nope.yaml')
-    cmd_output('git', '-C', path, 'commit', '-m', 'simulate old repo')
+    cmd_output('git', 'mv', C.MANIFEST_FILE, 'nope.yaml', cwd=path)
+    cmd_output('git', 'commit', '-m', 'simulate old repo', cwd=path)
     # Assume this is the revision the user's old repository was at
     rev = git.head_rev(path)
-    cmd_output('git', '-C', path, 'mv', 'nope.yaml', C.MANIFEST_FILE)
-    cmd_output('git', '-C', path, 'commit', '-m', 'move hooks file')
+    cmd_output('git', 'mv', 'nope.yaml', C.MANIFEST_FILE, cwd=path)
+    cmd_output('git', 'commit', '-m', 'move hooks file', cwd=path)
     update_rev = git.head_rev(path)
 
     config['rev'] = rev
@@ -86,7 +86,7 @@ def out_of_date_repo(tempdir_factory):
     original_rev = git.head_rev(path)
 
     # Make a commit
-    cmd_output('git', '-C', path, 'commit', '--allow-empty', '-m', 'foo')
+    cmd_output('git', 'commit', '--allow-empty', '-m', 'foo', cwd=path)
     head_rev = git.head_rev(path)
 
     yield auto_namedtuple(
@@ -221,7 +221,7 @@ def test_loses_formatting_when_not_detectable(
 
 @pytest.fixture
 def tagged_repo(out_of_date_repo):
-    cmd_output('git', '-C', out_of_date_repo.path, 'tag', 'v1.2.3')
+    cmd_output('git', 'tag', 'v1.2.3', cwd=out_of_date_repo.path)
     yield out_of_date_repo
 
 
@@ -240,8 +240,7 @@ def test_autoupdate_tagged_repo(
 
 @pytest.fixture
 def tagged_repo_with_more_commits(tagged_repo):
-    cmd = ('git', '-C', tagged_repo.path, 'commit', '--allow-empty', '-mfoo')
-    cmd_output(*cmd)
+    cmd_output('git', 'commit', '--allow-empty', '-mfoo', cwd=tagged_repo.path)
     yield tagged_repo
 
 
@@ -268,8 +267,8 @@ def hook_disappearing_repo(tempdir_factory):
         get_resource_path('manifest_without_foo.yaml'),
         os.path.join(path, C.MANIFEST_FILE),
     )
-    cmd_output('git', '-C', path, 'add', '.')
-    cmd_output('git', '-C', path, 'commit', '-m', 'Remove foo')
+    cmd_output('git', 'add', '.', cwd=path)
+    cmd_output('git', 'commit', '-m', 'Remove foo', cwd=path)
 
     yield auto_namedtuple(path=path, original_rev=original_rev)
 

--- a/tests/commands/install_uninstall_test.py
+++ b/tests/commands/install_uninstall_test.py
@@ -161,8 +161,8 @@ def test_install_pre_commit_and_run_custom_path(tempdir_factory):
 def test_install_in_submodule_and_run(tempdir_factory):
     src_path = make_consuming_repo(tempdir_factory, 'script_hooks_repo')
     parent_path = git_dir(tempdir_factory)
-    cmd_output('git', '-C', parent_path, 'submodule', 'add', src_path, 'sub')
-    cmd_output('git', '-C', parent_path, 'commit', '-m', 'foo')
+    cmd_output('git', 'submodule', 'add', src_path, 'sub', cwd=parent_path)
+    cmd_output('git', 'commit', '-m', 'foo', cwd=parent_path)
 
     sub_pth = os.path.join(parent_path, 'sub')
     with cwd(sub_pth):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -69,8 +69,8 @@ def _make_conflict():
 def in_merge_conflict(tempdir_factory):
     path = make_consuming_repo(tempdir_factory, 'script_hooks_repo')
     open(os.path.join(path, 'dummy'), 'a').close()
-    cmd_output('git', '-C', path, 'add', 'dummy')
-    cmd_output('git', '-C', path, 'commit', '-m', 'Add config.')
+    cmd_output('git', 'add', 'dummy', cwd=path)
+    cmd_output('git', 'commit', '-m', 'Add config.', cwd=path)
 
     conflict_path = tempdir_factory.get()
     cmd_output('git', 'clone', path, conflict_path)
@@ -83,8 +83,8 @@ def in_merge_conflict(tempdir_factory):
 def in_conflicting_submodule(tempdir_factory):
     git_dir_1 = git_dir(tempdir_factory)
     git_dir_2 = git_dir(tempdir_factory)
-    cmd_output('git', '-C', git_dir_2, 'commit', '--allow-empty', '-minit!')
-    cmd_output('git', '-C', git_dir_1, 'submodule', 'add', git_dir_2, 'sub')
+    cmd_output('git', 'commit', '--allow-empty', '-minit!', cwd=git_dir_2)
+    cmd_output('git', 'submodule', 'add', git_dir_2, 'sub', cwd=git_dir_1)
     with cwd(os.path.join(git_dir_1, 'sub')):
         _make_conflict()
         yield

--- a/tests/make_archives_test.py
+++ b/tests/make_archives_test.py
@@ -17,14 +17,14 @@ def test_make_archive(tempdir_factory):
     git_path = git_dir(tempdir_factory)
     # Add a files to the git directory
     open(os.path.join(git_path, 'foo'), 'a').close()
-    cmd_output('git', '-C', git_path, 'add', '.')
-    cmd_output('git', '-C', git_path, 'commit', '-m', 'foo')
+    cmd_output('git', 'add', '.', cwd=git_path)
+    cmd_output('git', 'commit', '-m', 'foo', cwd=git_path)
     # We'll use this rev
     head_rev = git.head_rev(git_path)
     # And check that this file doesn't exist
     open(os.path.join(git_path, 'bar'), 'a').close()
-    cmd_output('git', '-C', git_path, 'add', '.')
-    cmd_output('git', '-C', git_path, 'commit', '-m', 'bar')
+    cmd_output('git', 'add', '.', cwd=git_path)
+    cmd_output('git', 'commit', '-m', 'bar', cwd=git_path)
 
     # Do the thing
     archive_path = make_archives.make_archive(

--- a/tests/staged_files_only_test.py
+++ b/tests/staged_files_only_test.py
@@ -199,7 +199,7 @@ def submodule_with_commits(tempdir_factory):
 
 
 def checkout_submodule(rev):
-    cmd_output('git', '-C', 'sub', 'checkout', rev)
+    cmd_output('git', 'checkout', rev, cwd='sub')
 
 
 @pytest.fixture


### PR DESCRIPTION
Resolves #723

I manually verified the testsuite against git 1.8 (built from source) -- I don't think it's worth adding to the CI suite but that could be implemented as a followup.

When running the testsuite against 1.8 I also fixed ~3 tests in `tests/commands/install_uninstall_test.py` which are unrelated to the changes here (though in adjacent lines)