### PR TITLE
Fix regression: try-repo from relative path

### DIFF
--- a/pre_commit/store.py
+++ b/pre_commit/store.py
@@ -143,10 +143,12 @@ class Store(object):
         def clone_strategy(directory):
             env = no_git_env()
 
+            cmd = ('git', 'clone', '--no-checkout', repo, directory)
+            cmd_output(*cmd, env=env)
+
             def _git_cmd(*args):
                 return cmd_output('git', *args, cwd=directory, env=env)
 
-            _git_cmd('clone', '--no-checkout', repo, '.')
             _git_cmd('reset', ref, '--hard')
             _git_cmd('submodule', 'update', '--init', '--recursive')
 

--- a/tests/commands/try_repo_test.py
+++ b/tests/commands/try_repo_test.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
+import os.path
 import re
 
 from pre_commit.commands.try_repo import try_repo
@@ -69,3 +70,13 @@ def test_try_repo_with_specific_hook(cap_out, tempdir_factory):
         config,
     )
     assert rest == '[bash_hook] Bash hook................................(no files to check)Skipped\n'  # noqa
+
+
+def test_try_repo_relative_path(cap_out, tempdir_factory):
+    repo = make_repo(tempdir_factory, 'modified_file_returns_zero_repo')
+    with cwd(git_dir(tempdir_factory)):
+        open('test-file', 'a').close()
+        cmd_output('git', 'add', '.')
+        relative_repo = os.path.relpath(repo, '.')
+        # previously crashed on cloning a relative path
+        assert not try_repo(try_repo_opts(relative_repo, hook='bash_hook'))


### PR DESCRIPTION
This was broken in v1.7.0