### PR TITLE
Fixes file `types` from .pre-commit-config.yaml issue

### DIFF
--- a/pre_commit/commands/run.py
+++ b/pre_commit/commands/run.py
@@ -48,11 +48,14 @@ def _filter_by_include_exclude(filenames, include, exclude):
     }
 
 
-def _filter_by_types(filenames, types, exclude_types):
+def _filter_by_types(filenames,
+                     types,
+                     exclude_types,
+                     get_tags=tags_from_path):
     types, exclude_types = frozenset(types), frozenset(exclude_types)
     ret = []
     for filename in filenames:
-        tags = tags_from_path(filename)
+        tags = get_tags(filename)
         if tags >= types and not tags & exclude_types:
             ret.append(filename)
     return tuple(ret)

--- a/pre_commit/commands/run.py
+++ b/pre_commit/commands/run.py
@@ -53,10 +53,12 @@ def _filter_by_types(filenames,
                      exclude_types,
                      get_tags=tags_from_path):
     types, exclude_types = frozenset(types), frozenset(exclude_types)
+    valid_types = types - exclude_types
+
     ret = []
     for filename in filenames:
-        tags = get_tags(filename)
-        if tags >= types and not tags & exclude_types:
+        tags = frozenset(get_tags(filename))
+        if len(valid_types.intersection(tags)) > 0:
             ret.append(filename)
     return tuple(ret)
 

--- a/tests/commands/run_test.py
+++ b/tests/commands/run_test.py
@@ -834,15 +834,16 @@ def test_include_exclude_exclude_removes_files(some_filenames):
     ret = _filter_by_include_exclude(some_filenames, '', r'\.py$')
     assert ret == {'.pre-commit-hooks.yaml'}
 
+
 def get_tags_stub(interpreter):
     return lambda x: tags_from_interpreter(interpreter)
 
-@pytest.mark.current
+
 def test_filter_by_types_for_bash_by_interpreter():
     ret = _filter_by_types(['bash_script'], ['shell', 'sh', 'bash'], [], get_tags=get_tags_stub('bash'))
     assert ret == ('bash_script',)
 
-@pytest.mark.current
+
 def test_filter_by_types_for_python_by_interpreter():
     ret = _filter_by_types(['script.py'], ['python'], [], get_tags=get_tags_stub('python'))
     assert ret == ('script.py',)

--- a/tests/commands/run_test.py
+++ b/tests/commands/run_test.py
@@ -9,12 +9,14 @@ from collections import OrderedDict
 
 import pytest
 
+from identify.identify import tags_from_interpreter
 import pre_commit.constants as C
 from pre_commit.commands.install_uninstall import install
 from pre_commit.commands.run import _compute_cols
 from pre_commit.commands.run import _filter_by_include_exclude
 from pre_commit.commands.run import _get_skips
 from pre_commit.commands.run import _has_unmerged_paths
+from pre_commit.commands.run import _filter_by_types
 from pre_commit.commands.run import run
 from pre_commit.runner import Runner
 from pre_commit.util import cmd_output
@@ -831,3 +833,16 @@ def test_include_exclude_does_search_instead_of_match(some_filenames):
 def test_include_exclude_exclude_removes_files(some_filenames):
     ret = _filter_by_include_exclude(some_filenames, '', r'\.py$')
     assert ret == {'.pre-commit-hooks.yaml'}
+
+def get_tags_stub(interpreter):
+    return lambda x: tags_from_interpreter(interpreter)
+
+@pytest.mark.current
+def test_filter_by_types_for_bash_by_interpreter():
+    ret = _filter_by_types(['bash_script'], ['shell', 'sh', 'bash'], [], get_tags=get_tags_stub('bash'))
+    assert ret == ('bash_script',)
+
+@pytest.mark.current
+def test_filter_by_types_for_python_by_interpreter():
+    ret = _filter_by_types(['script.py'], ['python'], [], get_tags=get_tags_stub('python'))
+    assert ret == ('script.py',)


### PR DESCRIPTION
This PR fixes a bug where files are not being recognized based on their `types` using configuration file setting `types`.

# Issue / Reproduction case
When using a pre-commit-config.yaml in a repository with many bash scripts (that lack a `.sh` suffix to filename):

```
- repo: local
 - id: shellcheck
    name: 'Shellcheck Linter'
    entry: shellcheck
    language: system
    types:
      - shell
      - sh
      - bash
```

And running:
```
pre-commit run --all-files
```

## Actual output:
```
Shellcheck Linter....................................(no files to check)Skipped
```

## Expected behavior
That pre-commit finds the files with a shebang of `#!/usr/bin/env bash` and lints them.

# Solution

I added two test cases, one for Python (which did behave properly) and one for a bash script like: 

Filename: `bash_script`
```
#!/usr/bin/env bash
echo "Hello"
```

Then I tracked down the issue to the comparison between a List and a FrozenSet here:
```
if tags >= types and not tags & exclude_types:
  ret.append(filename)
```

I rewrote that comparison to compare two FrozenSets using the `intersection` function. This produces predictable results on Python 2.7 and 3.5.

Once this is approved, I'll happily squash it down to a single commit. Right now it's 2 commits to show the spec failing before the patch.

Note: I stubbed in a `get_tags` function via dependency injection to simplify testing. If you prefer a different mechanism, feel free to adjust the PR to suit your testing preferences.
