### PR TITLE
Appease yaml.load linters

### DIFF
--- a/pre_commit/commands/migrate_config.py
+++ b/pre_commit/commands/migrate_config.py
@@ -32,7 +32,7 @@ def _migrate_map(contents):
         # will yield a valid configuration
         try:
             trial_contents = header + 'repos:\n' + rest
-            yaml.load(trial_contents)
+            ordered_load(trial_contents)
             contents = trial_contents
         except yaml.YAMLError:
             contents = header + 'repos:\n' + _indent(rest)


### PR DESCRIPTION
_technically_ yaml.load is unsafe, however the contents being loaded here are
previously loaded just above using a safe loader so this is not an abitrary
code vector.  Fixing it nonetheless :)

Thanks @tonybaloney!