### PR TITLE
tox 3.1 passes PROCESSOR_ARCHITECTURE by default

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist = py27,py36,py37,pypy
 
 [testenv]
 deps = -rrequirements-dev.txt
-passenv = GOROOT HOME HOMEPATH PROCESSOR_ARCHITECTURE PROGRAMDATA TERM
+passenv = GOROOT HOME HOMEPATH PROGRAMDATA TERM
 commands =
     coverage erase
     coverage run -m pytest {posargs:tests}


### PR DESCRIPTION
https://github.com/tox-dev/tox/pull/742 🎉 