### PR TITLE
Revert "Merge pull request #788 from pre-commit/cache_cargo_windows"

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,4 +27,3 @@ test_script: tox
 cache:
   - '%LOCALAPPDATA%\pip\cache'
   - '%USERPROFILE%\.cache\pre-commit'
-  - '%USERPROFILE%\.cargo'


### PR DESCRIPTION
This reverts commit e731aa835ce445cb5ba0cfec8c0637ac6933577c, reversing
changes made to a4b5a9f7fb2cb26d8d0c23620b701130f651d8bf.

Turns out it's huge and actually makes the builds slower -- go figure