### PR TITLE
Run only the specified hook even when stages exist in config.

### DIFF
--- a/pre_commit/commands/run.py
+++ b/pre_commit/commands/run.py
@@ -254,11 +254,13 @@ def run(runner, store, args, environ=os.environ):
         repo_hooks = []
         for repo in repositories(runner.config, store):
             for _, hook in repo.hooks:
-                if (
-                    (not args.hook or hook['id'] == args.hook) and
-                    not hook['stages'] or args.hook_stage in hook['stages']
-                ):
-                    repo_hooks.append((repo, hook))
+                if args.hook:
+                    if args.hook == hook['id']:
+                        repo_hooks.append((repo, hook))
+                        break
+                else:
+                    if not hook['stages'] or args.hook_stage in hook['stages']:
+                        repo_hooks.append((repo, hook))
 
         if args.hook and not repo_hooks:
             output.write_line('No hook with id `{}`'.format(args.hook))

--- a/pre_commit/commands/run.py
+++ b/pre_commit/commands/run.py
@@ -254,13 +254,11 @@ def run(runner, store, args, environ=os.environ):
         repo_hooks = []
         for repo in repositories(runner.config, store):
             for _, hook in repo.hooks:
-                if args.hook:
-                    if args.hook == hook['id']:
-                        repo_hooks.append((repo, hook))
-                        break
-                else:
-                    if not hook['stages'] or args.hook_stage in hook['stages']:
-                        repo_hooks.append((repo, hook))
+                if (
+                    (not args.hook or hook['id'] == args.hook) and
+                    (not hook['stages'] or args.hook_stage in hook['stages'])
+                ):
+                    repo_hooks.append((repo, hook))
 
         if args.hook and not repo_hooks:
             output.write_line('No hook with id `{}`'.format(args.hook))

--- a/tests/commands/run_test.py
+++ b/tests/commands/run_test.py
@@ -762,3 +762,34 @@ def test_include_exclude_does_search_instead_of_match(some_filenames):
 def test_include_exclude_exclude_removes_files(some_filenames):
     ret = _filter_by_include_exclude(some_filenames, '', r'\.py$')
     assert ret == ['.pre-commit-hooks.yaml']
+
+
+def test_args_hook_only(cap_out, store, repo_with_passing_hook):
+    config = OrderedDict((
+        ('repo', 'local'),
+        (
+            'hooks', (
+                OrderedDict((
+                    ('id', 'flake8'),
+                    ('name', 'flake8'),
+                    ('entry', "'{}' -m flake8".format(sys.executable)),
+                    ('language', 'system'),
+                    ('stages', ['commit']),
+                )), OrderedDict((
+                    ('id', 'do_not_commit'),
+                    ('name', 'Block if "DO NOT COMMIT" is found'),
+                    ('entry', 'DO NOT COMMIT'),
+                    ('language', 'pygrep'),
+                )),
+            ),
+        ),
+    ))
+    add_config_to_repo(repo_with_passing_hook, config)
+    stage_a_file()
+    ret, printed = _do_run(
+        cap_out,
+        store,
+        repo_with_passing_hook,
+        run_opts(hook='do_not_commit'),
+    )
+    assert 'flake8' not in printed

--- a/tests/commands/run_test.py
+++ b/tests/commands/run_test.py
@@ -792,4 +792,4 @@ def test_args_hook_only(cap_out, store, repo_with_passing_hook):
         repo_with_passing_hook,
         run_opts(hook='do_not_commit'),
     )
-    assert 'flake8' not in printed
+    assert b'flake8' not in printed


### PR DESCRIPTION
This branches fixes the run logic so that when
`pre-commit run some_hook -a` runs when the config contains
`stages: ['commit']` for some other hook, only the hook specified as an
argument will run.

Fixes #772