### PR TITLE
Fix several ResourceWarning: unclosed file

### DIFF
--- a/pre_commit/commands/autoupdate.py
+++ b/pre_commit/commands/autoupdate.py
@@ -72,7 +72,8 @@ REV_LINE_FMT = '{}rev:{}{}{}'
 
 
 def _write_new_config_file(path, output):
-    original_contents = open(path).read()
+    with open(path) as f:
+        original_contents = f.read()
     output = remove_defaults(output, CONFIG_SCHEMA)
     new_contents = ordered_dump(output, **C.YAML_DUMP_KWARGS)
 

--- a/pre_commit/commands/install_uninstall.py
+++ b/pre_commit/commands/install_uninstall.py
@@ -38,7 +38,8 @@ def _hook_paths(git_root, hook_type):
 def is_our_script(filename):
     if not os.path.exists(filename):
         return False
-    contents = io.open(filename).read()
+    with io.open(filename) as f:
+        contents = f.read()
     return any(h in contents for h in (CURRENT_HASH,) + PRIOR_HASHES)
 
 

--- a/pre_commit/git.py
+++ b/pre_commit/git.py
@@ -70,7 +70,8 @@ def get_conflicted_files():
     logger.info('Checking merge-conflict files only.')
     # Need to get the conflicted files from the MERGE_MSG because they could
     # have resolved the conflict by choosing one side or the other
-    merge_msg = open(os.path.join(get_git_dir('.'), 'MERGE_MSG'), 'rb').read()
+    with open(os.path.join(get_git_dir('.'), 'MERGE_MSG'), 'rb') as f:
+        merge_msg = f.read()
     merge_conflict_filenames = parse_merge_msg_for_conflicts(merge_msg)
 
     # This will get the rest of the changes made after the merge.

--- a/pre_commit/repository.py
+++ b/pre_commit/repository.py
@@ -43,7 +43,8 @@ def _read_state(prefix, venv):
     if not os.path.exists(filename):
         return None
     else:
-        return json.loads(io.open(filename).read())
+        with io.open(filename) as f:
+            return json.loads(f.read())
 
 
 def _write_state(prefix, venv, state):

--- a/testing/fixtures.py
+++ b/testing/fixtures.py
@@ -40,7 +40,8 @@ def modify_manifest(path):
     .pre-commit-hooks.yaml.
     """
     manifest_path = os.path.join(path, C.MANIFEST_FILE)
-    manifest = ordered_load(io.open(manifest_path).read())
+    with io.open(manifest_path) as f:
+        manifest = ordered_load(f.read())
     yield manifest
     with io.open(manifest_path, 'w') as manifest_file:
         manifest_file.write(ordered_dump(manifest, **C.YAML_DUMP_KWARGS))
@@ -55,7 +56,8 @@ def modify_config(path='.', commit=True):
     .pre-commit-config.yaml
     """
     config_path = os.path.join(path, C.CONFIG_FILE)
-    config = ordered_load(io.open(config_path).read())
+    with io.open(config_path) as f:
+        config = ordered_load(f.read())
     yield config
     with io.open(config_path, 'w', encoding='UTF-8') as config_file:
         config_file.write(ordered_dump(config, **C.YAML_DUMP_KWARGS))
@@ -100,7 +102,8 @@ def make_config_from_repo(repo_path, rev=None, hooks=None, check=True):
 
 def read_config(directory, config_file=C.CONFIG_FILE):
     config_path = os.path.join(directory, config_file)
-    config = ordered_load(io.open(config_path).read())
+    with io.open(config_path) as f:
+        config = ordered_load(f.read())
     return config
 
 

--- a/tests/commands/autoupdate_test.py
+++ b/tests/commands/autoupdate_test.py
@@ -42,10 +42,12 @@ def test_autoupdate_up_to_date_repo(up_to_date_repo, in_tmpdir, store):
     config = make_config_from_repo(up_to_date_repo, check=False)
     write_config('.', config)
 
-    before = open(C.CONFIG_FILE).read()
+    with open(C.CONFIG_FILE) as f:
+        before = f.read()
     assert '^$' not in before
     ret = autoupdate(Runner('.', C.CONFIG_FILE), store, tags_only=False)
-    after = open(C.CONFIG_FILE).read()
+    with open(C.CONFIG_FILE) as f:
+        after = f.read()
     assert ret == 0
     assert before == after
 
@@ -68,9 +70,11 @@ def test_autoupdate_old_revision_broken(tempdir_factory, in_tmpdir, store):
 
     config['rev'] = rev
     write_config('.', config)
-    before = open(C.CONFIG_FILE).read()
+    with open(C.CONFIG_FILE) as f:
+        before = f.read()
     ret = autoupdate(Runner('.', C.CONFIG_FILE), store, tags_only=False)
-    after = open(C.CONFIG_FILE).read()
+    with open(C.CONFIG_FILE) as f:
+        after = f.read()
     assert ret == 0
     assert before != after
     assert update_rev in after
@@ -106,9 +110,11 @@ def test_autoupdate_out_of_date_repo(out_of_date_repo, in_tmpdir, store):
     )
     write_config('.', config)
 
-    before = open(C.CONFIG_FILE).read()
+    with open(C.CONFIG_FILE) as f:
+        before = f.read()
     ret = autoupdate(Runner('.', C.CONFIG_FILE), store, tags_only=False)
-    after = open(C.CONFIG_FILE).read()
+    with open(C.CONFIG_FILE) as f:
+        after = f.read()
     assert ret == 0
     assert before != after
     # Make sure we don't add defaults
@@ -128,10 +134,12 @@ def test_autoupdate_out_of_date_repo_with_correct_repo_name(
     write_config('.', config)
 
     runner = Runner('.', C.CONFIG_FILE)
-    before = open(C.CONFIG_FILE).read()
+    with open(C.CONFIG_FILE) as f:
+        before = f.read()
     repo_name = 'file://{}'.format(out_of_date_repo.path)
     ret = autoupdate(runner, store, tags_only=False, repos=(repo_name,))
-    after = open(C.CONFIG_FILE).read()
+    with open(C.CONFIG_FILE) as f:
+        after = f.read()
     assert ret == 0
     assert before != after
     assert out_of_date_repo.head_rev in after
@@ -148,10 +156,12 @@ def test_autoupdate_out_of_date_repo_with_wrong_repo_name(
     write_config('.', config)
 
     runner = Runner('.', C.CONFIG_FILE)
-    before = open(C.CONFIG_FILE).read()
+    with open(C.CONFIG_FILE) as f:
+        before = f.read()
     # It will not update it, because the name doesn't match
     ret = autoupdate(runner, store, tags_only=False, repos=('dne',))
-    after = open(C.CONFIG_FILE).read()
+    with open(C.CONFIG_FILE) as f:
+        after = f.read()
     assert ret == 0
     assert before == after
 
@@ -171,7 +181,8 @@ def test_does_not_reformat(in_tmpdir, out_of_date_repo, store):
         f.write(config)
 
     autoupdate(Runner('.', C.CONFIG_FILE), store, tags_only=False)
-    after = open(C.CONFIG_FILE).read()
+    with open(C.CONFIG_FILE) as f:
+        after = f.read()
     expected = fmt.format(out_of_date_repo.path, out_of_date_repo.head_rev)
     assert after == expected
 
@@ -200,7 +211,8 @@ def test_loses_formatting_when_not_detectable(
         f.write(config)
 
     autoupdate(Runner('.', C.CONFIG_FILE), store, tags_only=False)
-    after = open(C.CONFIG_FILE).read()
+    with open(C.CONFIG_FILE) as f:
+        after = f.read()
     expected = (
         'repos:\n'
         '-   repo: {}\n'
@@ -225,7 +237,8 @@ def test_autoupdate_tagged_repo(tagged_repo, in_tmpdir, store):
 
     ret = autoupdate(Runner('.', C.CONFIG_FILE), store, tags_only=False)
     assert ret == 0
-    assert 'v1.2.3' in open(C.CONFIG_FILE).read()
+    with open(C.CONFIG_FILE) as f:
+        assert 'v1.2.3' in f.read()
 
 
 @pytest.fixture
@@ -243,7 +256,8 @@ def test_autoupdate_tags_only(tagged_repo_with_more_commits, in_tmpdir, store):
 
     ret = autoupdate(Runner('.', C.CONFIG_FILE), store, tags_only=True)
     assert ret == 0
-    assert 'v1.2.3' in open(C.CONFIG_FILE).read()
+    with open(C.CONFIG_FILE) as f:
+        assert 'v1.2.3' in f.read()
 
 
 @pytest.fixture
@@ -282,9 +296,11 @@ def test_autoupdate_hook_disappearing_repo(
     )
     write_config('.', config)
 
-    before = open(C.CONFIG_FILE).read()
+    with open(C.CONFIG_FILE) as f:
+        before = f.read()
     ret = autoupdate(Runner('.', C.CONFIG_FILE), store, tags_only=False)
-    after = open(C.CONFIG_FILE).read()
+    with open(C.CONFIG_FILE) as f:
+        after = f.read()
     assert ret == 1
     assert before == after
 

--- a/tests/commands/install_uninstall_test.py
+++ b/tests/commands/install_uninstall_test.py
@@ -415,7 +415,8 @@ def test_replace_old_commit_script(tempdir_factory, store):
         runner = Runner(path, C.CONFIG_FILE)
 
         # Install a script that looks like our old script
-        pre_commit_contents = io.open(resource_filename('hook-tmpl')).read()
+        with io.open(resource_filename('hook-tmpl')) as f:
+            pre_commit_contents = f.read()
         new_contents = pre_commit_contents.replace(
             CURRENT_HASH, PRIOR_HASHES[-1],
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,6 +21,26 @@ from testing.fixtures import write_config
 from testing.util import cwd
 
 
+@pytest.fixture(autouse=True)
+def no_warnings(recwarn):
+    yield
+    warnings = []
+    for warning in recwarn:  # pragma: no cover
+        message = str(warning.message)
+        # ImportWarning: Not importing directory '...' missing __init__(.py)
+        if not (
+            isinstance(warning.message, ImportWarning)
+            and message.startswith('Not importing directory ')
+            and ' missing __init__' in message
+        ):
+            warnings.append('{}:{} {}'.format(
+                warning.filename,
+                warning.lineno,
+                message,
+            ))
+    assert not warnings
+
+
 @pytest.fixture
 def tempdir_factory(tmpdir):
     class TmpdirFactory(object):

--- a/tests/error_handler_test.py
+++ b/tests/error_handler_test.py
@@ -87,11 +87,11 @@ def test_log_and_exit(cap_out, mock_store_dir):
     )
 
     assert os.path.exists(log_file)
-    contents = io.open(log_file).read()
-    assert contents == (
-        'msg: FatalError: hai\n'
-        "I'm a stacktrace\n"
-    )
+    with io.open(log_file) as f:
+        assert f.read() == (
+            'msg: FatalError: hai\n'
+            "I'm a stacktrace\n"
+        )
 
 
 def test_error_handler_non_ascii_exception(mock_store_dir):

--- a/tests/languages/all_test.py
+++ b/tests/languages/all_test.py
@@ -15,7 +15,7 @@ if six.PY2:  # pragma: no cover
         inspect.ArgSpec, varargs=None, keywords=None, defaults=None,
     )
     getargspec = inspect.getargspec
-else:
+else:  # pragma: no cover
     ArgSpec = functools.partial(
         inspect.FullArgSpec, varargs=None, varkw=None, defaults=None,
         kwonlyargs=[], kwonlydefaults=None, annotations={},

--- a/tests/languages/all_test.py
+++ b/tests/languages/all_test.py
@@ -1,20 +1,34 @@
 from __future__ import unicode_literals
 
+import functools
 import inspect
 
 import pytest
+import six
 
 from pre_commit.languages.all import all_languages
 from pre_commit.languages.all import languages
 
 
+if six.PY2:  # pragma: no cover
+    ArgSpec = functools.partial(
+        inspect.ArgSpec, varargs=None, keywords=None, defaults=None,
+    )
+    getargspec = inspect.getargspec
+else:
+    ArgSpec = functools.partial(
+        inspect.FullArgSpec, varargs=None, varkw=None, defaults=None,
+        kwonlyargs=[], kwonlydefaults=None, annotations={},
+    )
+    getargspec = inspect.getfullargspec
+
+
 @pytest.mark.parametrize('language', all_languages)
 def test_install_environment_argspec(language):
-    expected_argspec = inspect.ArgSpec(
+    expected_argspec = ArgSpec(
         args=['prefix', 'version', 'additional_dependencies'],
-        varargs=None, keywords=None, defaults=None,
     )
-    argspec = inspect.getargspec(languages[language].install_environment)
+    argspec = getargspec(languages[language].install_environment)
     assert argspec == expected_argspec
 
 
@@ -25,28 +39,20 @@ def test_ENVIRONMENT_DIR(language):
 
 @pytest.mark.parametrize('language', all_languages)
 def test_run_hook_argpsec(language):
-    expected_argspec = inspect.ArgSpec(
-        args=['prefix', 'hook', 'file_args'],
-        varargs=None, keywords=None, defaults=None,
-    )
-    argspec = inspect.getargspec(languages[language].run_hook)
+    expected_argspec = ArgSpec(args=['prefix', 'hook', 'file_args'])
+    argspec = getargspec(languages[language].run_hook)
     assert argspec == expected_argspec
 
 
 @pytest.mark.parametrize('language', all_languages)
 def test_get_default_version_argspec(language):
-    expected_argspec = inspect.ArgSpec(
-        args=[], varargs=None, keywords=None, defaults=None,
-    )
-    argspec = inspect.getargspec(languages[language].get_default_version)
+    expected_argspec = ArgSpec(args=[])
+    argspec = getargspec(languages[language].get_default_version)
     assert argspec == expected_argspec
 
 
 @pytest.mark.parametrize('language', all_languages)
 def test_healthy_argspec(language):
-    expected_argspec = inspect.ArgSpec(
-        args=['prefix', 'language_version'],
-        varargs=None, keywords=None, defaults=None,
-    )
-    argspec = inspect.getargspec(languages[language].healthy)
+    expected_argspec = ArgSpec(args=['prefix', 'language_version'])
+    argspec = getargspec(languages[language].healthy)
     assert argspec == expected_argspec

--- a/tests/make_archives_test.py
+++ b/tests/make_archives_test.py
@@ -4,8 +4,6 @@ from __future__ import unicode_literals
 import os.path
 import tarfile
 
-import pytest
-
 from pre_commit import git
 from pre_commit import make_archives
 from pre_commit.util import cmd_output
@@ -47,7 +45,6 @@ def test_make_archive(tempdir_factory):
     assert not os.path.exists(os.path.join(extract_dir, 'foo', 'bar'))
 
 
-@pytest.mark.integration
 def test_main(tmpdir):
     make_archives.main(('--dest', tmpdir.strpath))
 

--- a/tests/repository_test.py
+++ b/tests/repository_test.py
@@ -63,7 +63,6 @@ def _test_hook_repo(
     assert _norm_out(ret[1]) == expected
 
 
-@pytest.mark.integration
 def test_python_hook(tempdir_factory, store):
     _test_hook_repo(
         tempdir_factory, store, 'python_hooks_repo',
@@ -72,7 +71,6 @@ def test_python_hook(tempdir_factory, store):
     )
 
 
-@pytest.mark.integration
 def test_python_hook_default_version(tempdir_factory, store):
     # make sure that this continues to work for platforms where default
     # language detection does not work
@@ -82,7 +80,6 @@ def test_python_hook_default_version(tempdir_factory, store):
         test_python_hook(tempdir_factory, store)
 
 
-@pytest.mark.integration
 def test_python_hook_args_with_spaces(tempdir_factory, store):
     _test_hook_repo(
         tempdir_factory, store, 'python_hooks_repo',
@@ -99,7 +96,6 @@ def test_python_hook_args_with_spaces(tempdir_factory, store):
     )
 
 
-@pytest.mark.integration
 def test_python_hook_weird_setup_cfg(tempdir_factory, store):
     path = git_dir(tempdir_factory)
     with cwd(path):
@@ -122,7 +118,6 @@ def test_python_venv(tempdir_factory, store):  # pragma: no cover (no venv)
     )
 
 
-@pytest.mark.integration
 def test_switch_language_versions_doesnt_clobber(tempdir_factory, store):
     # We're using the python3 repo because it prints the python version
     path = make_repo(tempdir_factory, 'python3_hooks_repo')
@@ -145,7 +140,6 @@ def test_switch_language_versions_doesnt_clobber(tempdir_factory, store):
     run_on_version('python3', b'3\n[]\nHello World\n')
 
 
-@pytest.mark.integration
 def test_versioned_python_hook(tempdir_factory, store):
     _test_hook_repo(
         tempdir_factory, store, 'python3_hooks_repo',
@@ -156,7 +150,6 @@ def test_versioned_python_hook(tempdir_factory, store):
 
 
 @skipif_cant_run_docker
-@pytest.mark.integration
 def test_run_a_docker_hook(tempdir_factory, store):
     _test_hook_repo(
         tempdir_factory, store, 'docker_hooks_repo',
@@ -166,7 +159,6 @@ def test_run_a_docker_hook(tempdir_factory, store):
 
 
 @skipif_cant_run_docker
-@pytest.mark.integration
 def test_run_a_docker_hook_with_entry_args(tempdir_factory, store):
     _test_hook_repo(
         tempdir_factory, store, 'docker_hooks_repo',
@@ -176,7 +168,6 @@ def test_run_a_docker_hook_with_entry_args(tempdir_factory, store):
 
 
 @skipif_cant_run_docker
-@pytest.mark.integration
 def test_run_a_failing_docker_hook(tempdir_factory, store):
     _test_hook_repo(
         tempdir_factory, store, 'docker_hooks_repo',
@@ -187,7 +178,6 @@ def test_run_a_failing_docker_hook(tempdir_factory, store):
 
 
 @skipif_cant_run_docker
-@pytest.mark.integration
 @pytest.mark.parametrize('hook_id', ('echo-entrypoint', 'echo-cmd'))
 def test_run_a_docker_image_hook(tempdir_factory, store, hook_id):
     _test_hook_repo(
@@ -198,7 +188,6 @@ def test_run_a_docker_image_hook(tempdir_factory, store, hook_id):
 
 
 @xfailif_broken_deep_listdir
-@pytest.mark.integration
 def test_run_a_node_hook(tempdir_factory, store):
     _test_hook_repo(
         tempdir_factory, store, 'node_hooks_repo',
@@ -207,7 +196,6 @@ def test_run_a_node_hook(tempdir_factory, store):
 
 
 @xfailif_broken_deep_listdir
-@pytest.mark.integration
 def test_run_versioned_node_hook(tempdir_factory, store):
     _test_hook_repo(
         tempdir_factory, store, 'node_versioned_hooks_repo',
@@ -216,7 +204,6 @@ def test_run_versioned_node_hook(tempdir_factory, store):
 
 
 @xfailif_windows_no_ruby
-@pytest.mark.integration
 def test_run_a_ruby_hook(tempdir_factory, store):
     _test_hook_repo(
         tempdir_factory, store, 'ruby_hooks_repo',
@@ -225,7 +212,6 @@ def test_run_a_ruby_hook(tempdir_factory, store):
 
 
 @xfailif_windows_no_ruby
-@pytest.mark.integration
 def test_run_versioned_ruby_hook(tempdir_factory, store):
     _test_hook_repo(
         tempdir_factory, store, 'ruby_versioned_hooks_repo',
@@ -236,7 +222,6 @@ def test_run_versioned_ruby_hook(tempdir_factory, store):
 
 
 @xfailif_windows_no_ruby
-@pytest.mark.integration
 def test_run_ruby_hook_with_disable_shared_gems(
         tempdir_factory,
         store,
@@ -258,7 +243,6 @@ def test_run_ruby_hook_with_disable_shared_gems(
         )
 
 
-@pytest.mark.integration
 def test_system_hook_with_spaces(tempdir_factory, store):
     _test_hook_repo(
         tempdir_factory, store, 'system_hook_with_spaces_repo',
@@ -267,7 +251,6 @@ def test_system_hook_with_spaces(tempdir_factory, store):
 
 
 @skipif_cant_run_swift
-@pytest.mark.integration
 def test_swift_hook(tempdir_factory, store):
     _test_hook_repo(
         tempdir_factory, store, 'swift_hooks_repo',
@@ -275,7 +258,6 @@ def test_swift_hook(tempdir_factory, store):
     )
 
 
-@pytest.mark.integration
 def test_golang_hook(tempdir_factory, store):
     _test_hook_repo(
         tempdir_factory, store, 'golang_hooks_repo',
@@ -283,7 +265,6 @@ def test_golang_hook(tempdir_factory, store):
     )
 
 
-@pytest.mark.integration
 def test_rust_hook(tempdir_factory, store):
     _test_hook_repo(
         tempdir_factory, store, 'rust_hooks_repo',
@@ -291,7 +272,6 @@ def test_rust_hook(tempdir_factory, store):
     )
 
 
-@pytest.mark.integration
 @pytest.mark.parametrize('dep', ('cli:shellharden:3.1.0', 'cli:shellharden'))
 def test_additional_rust_cli_dependencies_installed(
         tempdir_factory, store, dep,
@@ -311,7 +291,6 @@ def test_additional_rust_cli_dependencies_installed(
     assert 'shellharden' in binaries
 
 
-@pytest.mark.integration
 def test_additional_rust_lib_dependencies_installed(
         tempdir_factory, store,
 ):
@@ -332,7 +311,6 @@ def test_additional_rust_lib_dependencies_installed(
     assert 'shellharden' not in binaries
 
 
-@pytest.mark.integration
 def test_missing_executable(tempdir_factory, store):
     _test_hook_repo(
         tempdir_factory, store, 'not_found_exe',
@@ -342,7 +320,6 @@ def test_missing_executable(tempdir_factory, store):
     )
 
 
-@pytest.mark.integration
 def test_run_a_script_hook(tempdir_factory, store):
     _test_hook_repo(
         tempdir_factory, store, 'script_hooks_repo',
@@ -350,7 +327,6 @@ def test_run_a_script_hook(tempdir_factory, store):
     )
 
 
-@pytest.mark.integration
 def test_run_hook_with_spaced_args(tempdir_factory, store):
     _test_hook_repo(
         tempdir_factory, store, 'arg_per_line_hooks_repo',
@@ -360,7 +336,6 @@ def test_run_hook_with_spaced_args(tempdir_factory, store):
     )
 
 
-@pytest.mark.integration
 def test_run_hook_with_curly_braced_arguments(tempdir_factory, store):
     _test_hook_repo(
         tempdir_factory, store, 'arg_per_line_hooks_repo',
@@ -469,7 +444,6 @@ def _norm_pwd(path):
     )[1].strip()
 
 
-@pytest.mark.integration
 def test_cwd_of_hook(tempdir_factory, store):
     # Note: this doubles as a test for `system` hooks
     path = git_dir(tempdir_factory)
@@ -480,7 +454,6 @@ def test_cwd_of_hook(tempdir_factory, store):
         )
 
 
-@pytest.mark.integration
 def test_lots_of_files(tempdir_factory, store):
     _test_hook_repo(
         tempdir_factory, store, 'script_hooks_repo',
@@ -488,7 +461,6 @@ def test_lots_of_files(tempdir_factory, store):
     )
 
 
-@pytest.mark.integration
 def test_venvs(tempdir_factory, store):
     path = make_repo(tempdir_factory, 'python_hooks_repo')
     config = make_config_from_repo(path)
@@ -497,7 +469,6 @@ def test_venvs(tempdir_factory, store):
     assert venv == (mock.ANY, 'python', python.get_default_version(), [])
 
 
-@pytest.mark.integration
 def test_additional_dependencies(tempdir_factory, store):
     path = make_repo(tempdir_factory, 'python_hooks_repo')
     config = make_config_from_repo(path)
@@ -507,7 +478,6 @@ def test_additional_dependencies(tempdir_factory, store):
     assert venv == (mock.ANY, 'python', python.get_default_version(), ['pep8'])
 
 
-@pytest.mark.integration
 def test_additional_dependencies_roll_forward(tempdir_factory, store):
     path = make_repo(tempdir_factory, 'python_hooks_repo')
 
@@ -533,7 +503,6 @@ def test_additional_dependencies_roll_forward(tempdir_factory, store):
 
 
 @xfailif_windows_no_ruby
-@pytest.mark.integration
 def test_additional_ruby_dependencies_installed(
         tempdir_factory, store,
 ):  # pragma: no cover (non-windows)
@@ -550,7 +519,6 @@ def test_additional_ruby_dependencies_installed(
 
 
 @xfailif_broken_deep_listdir
-@pytest.mark.integration
 def test_additional_node_dependencies_installed(
         tempdir_factory, store,
 ):  # pragma: no cover (non-windows)
@@ -566,7 +534,6 @@ def test_additional_node_dependencies_installed(
         assert 'lodash' in output
 
 
-@pytest.mark.integration
 def test_additional_golang_dependencies_installed(
         tempdir_factory, store,
 ):
@@ -695,7 +662,6 @@ def test_invalidated_virtualenv(tempdir_factory, store):
     assert retv == 0
 
 
-@pytest.mark.integration
 def test_really_long_file_paths(tempdir_factory, store):
     base_path = tempdir_factory.get()
     really_long_path = os.path.join(base_path, 'really_long' * 10)
@@ -709,7 +675,6 @@ def test_really_long_file_paths(tempdir_factory, store):
         repo.require_installed()
 
 
-@pytest.mark.integration
 def test_config_overrides_repo_specifics(tempdir_factory, store):
     path = make_repo(tempdir_factory, 'script_hooks_repo')
     config = make_config_from_repo(path)
@@ -729,7 +694,6 @@ def _create_repo_with_tags(tempdir_factory, src, tag):
     return path
 
 
-@pytest.mark.integration
 def test_tags_on_repositories(in_tmpdir, tempdir_factory, store):
     tag = 'v1.1'
     git_dir_1 = _create_repo_with_tags(tempdir_factory, 'prints_cwd_repo', tag)

--- a/tests/staged_files_only_test.py
+++ b/tests/staged_files_only_test.py
@@ -145,9 +145,9 @@ def img_staged(tempdir_factory):
 
 def _test_img_state(path, expected_file='img1.jpg', status='A'):
     assert os.path.exists(path.img_filename)
-    with io.open(path.img_filename, 'rb') as f1,\
-            io.open(get_resource_path(expected_file), 'rb') as f2:
-        assert f1.read() == f2.read()
+    with io.open(path.img_filename, 'rb') as f1
+        with io.open(get_resource_path(expected_file), 'rb') as f2:
+            assert f1.read() == f2.read()
     actual_status = get_short_git_status()['img.jpg']
     assert status == actual_status
 

--- a/tests/staged_files_only_test.py
+++ b/tests/staged_files_only_test.py
@@ -48,7 +48,8 @@ def _test_foo_state(
         encoding='UTF-8',
 ):
     assert os.path.exists(path.foo_filename)
-    assert io.open(path.foo_filename, encoding=encoding).read() == foo_contents
+    with io.open(path.foo_filename, encoding=encoding) as f:
+        assert f.read() == foo_contents
     actual_status = get_short_git_status()['foo']
     assert status == actual_status
 
@@ -144,10 +145,9 @@ def img_staged(tempdir_factory):
 
 def _test_img_state(path, expected_file='img1.jpg', status='A'):
     assert os.path.exists(path.img_filename)
-    assert (
-        io.open(path.img_filename, 'rb').read() ==
-        io.open(get_resource_path(expected_file), 'rb').read()
-    )
+    with io.open(path.img_filename, 'rb') as f1,\
+            io.open(get_resource_path(expected_file), 'rb') as f2:
+        assert f1.read() == f2.read()
     actual_status = get_short_git_status()['img.jpg']
     assert status == actual_status
 


### PR DESCRIPTION
Fixes a lot of ResourceWarning like:
```python
pre_commit/repository.py:46: ResourceWarning: unclosed file <_io.TextIOWrapper name='~/.cache/pre-commit/repozvpv73iz/py_env-python3.6/.install_state_v1' mode='r' encoding='UTF-8'>
  return json.loads(io.open(filename).read())
```
I also made changes to use the `with` context manager everywhere possible to prevent any other leaks.