### PR TITLE
Don't print bogus characters on windows terminals that don't support colors

### DIFF
--- a/pre_commit/color.py
+++ b/pre_commit/color.py
@@ -3,11 +3,13 @@ from __future__ import unicode_literals
 import os
 import sys
 
+terminal_supports_colors = True
 if os.name == 'nt':  # pragma: no cover (windows)
     from pre_commit.color_windows import enable_virtual_terminal_processing
     try:
         enable_virtual_terminal_processing()
     except WindowsError:
+        terminal_supports_colors = False
         pass
 
 RED = '\033[41m'
@@ -29,7 +31,7 @@ def format_color(text, color, use_color_setting):
         color - The color start string
         use_color_setting - Whether or not to color
     """
-    if not use_color_setting:
+    if not use_color_setting or not terminal_supports_colors:
         return text
     else:
         return '{}{}{}'.format(color, text, NORMAL)

--- a/pre_commit/color.py
+++ b/pre_commit/color.py
@@ -10,7 +10,6 @@ if os.name == 'nt':  # pragma: no cover (windows)
         enable_virtual_terminal_processing()
     except WindowsError:
         terminal_supports_colors = False
-        pass
 
 RED = '\033[41m'
 GREEN = '\033[42m'

--- a/pre_commit/color.py
+++ b/pre_commit/color.py
@@ -3,13 +3,13 @@ from __future__ import unicode_literals
 import os
 import sys
 
-terminal_supports_colors = True
+terminal_supports_color = True
 if os.name == 'nt':  # pragma: no cover (windows)
     from pre_commit.color_windows import enable_virtual_terminal_processing
     try:
         enable_virtual_terminal_processing()
     except WindowsError:
-        terminal_supports_colors = False
+        terminal_supports_color = False
 
 RED = '\033[41m'
 GREEN = '\033[42m'
@@ -30,7 +30,7 @@ def format_color(text, color, use_color_setting):
         color - The color start string
         use_color_setting - Whether or not to color
     """
-    if not use_color_setting or not terminal_supports_colors:
+    if not use_color_setting:
         return text
     else:
         return '{}{}{}'.format(color, text, NORMAL)
@@ -48,4 +48,7 @@ def use_color(setting):
     if setting not in COLOR_CHOICES:
         raise InvalidColorSetting(setting)
 
-    return setting == 'always' or (setting == 'auto' and sys.stdout.isatty())
+    return (
+        setting == 'always' or
+        (setting == 'auto' and sys.stdout.isatty() and terminal_supports_color)
+    )

--- a/tests/color_test.py
+++ b/tests/color_test.py
@@ -35,9 +35,16 @@ def test_use_color_no_tty():
         assert use_color('auto') is False
 
 
-def test_use_color_tty():
+def test_use_color_tty_with_color_support():
     with mock.patch.object(sys.stdout, 'isatty', return_value=True):
-        assert use_color('auto') is True
+        with mock.patch('pre_commit.color.terminal_supports_color', True):
+            assert use_color('auto') is True
+
+
+def test_use_color_tty_without_color_support():
+    with mock.patch.object(sys.stdout, 'isatty', return_value=True):
+        with mock.patch('pre_commit.color.terminal_supports_color', False):
+            assert use_color('auto') is False
 
 
 def test_use_color_raises_if_given_shenanigans():


### PR DESCRIPTION
When running the command prompt on windows 8, color characters aren't supported.
This causes the pre-commit output to be really hard to read, as the color characters still get printed out.

Example of the current output:
```
(test_env) C:\Users\User\Desktop\pytest>pre-commit
←[43;30m[WARNING]←[0m Unstaged files detected.
[INFO]←[0m Stashing unstaged files to C:\Users\User/.cache\pre-commit\patch15356
78758.
black................................................(no files to check)←[46;30m
Skipped←[0m
blacken-docs.........................................(no files to check)←[46;30m
Skipped←[0m
Trim Trailing Whitespace.............................(no files to check)←[46;30m
Skipped←[0m
Fix End of Files.....................................(no files to check)←[46;30m
Skipped←[0m
Check Yaml...........................................(no files to check)←[46;30m
Skipped←[0m
Debug Statements (Python)............................(no files to check)←[46;30m
Skipped←[0m
Flake8...............................................(no files to check)←[46;30m
Skipped←[0m
pyupgrade............................................(no files to check)←[46;30m
Skipped←[0m
rst..................................................(no files to check)←[46;30m
Skipped←[0m
[INFO]←[0m Restored changes from C:\Users\User/.cache\pre-commit\patch1535678758
.

(test_env) C:\Users\User\Desktop\pytest>
```

Note that the lines wrap, and the Skipped appears on a different line.
In addition, the color characters are getting printed to the screen.

With this change:
```
(test_env) C:\Users\User\Desktop\pytest>pre-commit
[WARNING] Unstaged files detected.
[INFO] Stashing unstaged files to C:\Users\User/.cache\pre-commit\patch153567897
6.
black................................................(no files to check)Skipped
blacken-docs.........................................(no files to check)Skipped
Trim Trailing Whitespace.............................(no files to check)Skipped
Fix End of Files.....................................(no files to check)Skipped
Check Yaml...........................................(no files to check)Skipped
Debug Statements (Python)............................(no files to check)Skipped
Flake8...............................................(no files to check)Skipped
pyupgrade............................................(no files to check)Skipped
rst..................................................(no files to check)Skipped
[INFO] Restored changes from C:\Users\User/.cache\pre-commit\patch1535678976.

(test_env) C:\Users\User\Desktop\pytest>
```

While the colors still won't work, at least everything will be lined up as expected :)