### PR TITLE
Update xargs.partition with platform information

### DIFF
--- a/pre_commit/xargs.py
+++ b/pre_commit/xargs.py
@@ -17,9 +17,9 @@ def _command_length(*cmd):
     full_cmd = ' '.join(cmd)
 
     # win32 uses the amount of characters, more details at:
-    # https://blogs.msdn.microsoft.com/oldnewthing/20031210-00/?p=41553/
+    # https://github.com/pre-commit/pre-commit/pull/839
     if sys.platform == 'win32':
-        return len(full_cmd)
+        return len(full_cmd.encode('utf-16le')) // 2
 
     return len(full_cmd.encode(sys.getfilesystemencoding()))
 

--- a/pre_commit/xargs.py
+++ b/pre_commit/xargs.py
@@ -3,6 +3,8 @@ from __future__ import unicode_literals
 
 import sys
 
+import six
+
 from pre_commit import parse_shebang
 from pre_commit.util import cmd_output
 
@@ -19,9 +21,13 @@ def _command_length(*cmd):
     # win32 uses the amount of characters, more details at:
     # https://github.com/pre-commit/pre-commit/pull/839
     if sys.platform == 'win32':
-        return len(full_cmd.encode('utf-16le')) // 2
-
-    return len(full_cmd.encode(sys.getfilesystemencoding()))
+        # the python2.x apis require bytes, we encode as UTF-8
+        if six.PY2:
+            return len(full_cmd.encode('utf-8'))
+        else:
+            return len(full_cmd.encode('utf-16le')) // 2
+    else:
+        return len(full_cmd.encode(sys.getfilesystemencoding()))
 
 
 class ArgumentTooLongError(RuntimeError):

--- a/pre_commit/xargs.py
+++ b/pre_commit/xargs.py
@@ -22,7 +22,7 @@ def _get_command_length(command, arg):
     if sys.platform == 'win32':
         return len(full_cmd)
 
-    return len(full_cmd.encode(sys.getdefaultencoding()))
+    return len(full_cmd.encode(sys.getfilesystemencoding()))
 
 
 class ArgumentTooLongError(RuntimeError):

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,4 +5,3 @@ flake8
 mock
 pytest
 pytest-env
-pytest-mock

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,3 +5,4 @@ flake8
 mock
 pytest
 pytest-env
+pytest-mock

--- a/tests/xargs_test.py
+++ b/tests/xargs_test.py
@@ -2,24 +2,25 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
+import mock
 import pytest
 
 from pre_commit import xargs
 
 
 @pytest.fixture
-def sys_win32_mock(mocker):
-    return mocker.Mock(
+def sys_win32_mock():
+    return mock.Mock(
         platform='win32',
-        getfilesystemencoding=mocker.Mock(return_value='utf-8'),
+        getfilesystemencoding=mock.Mock(return_value='utf-8'),
     )
 
 
 @pytest.fixture
-def sys_linux_mock(mocker):
-    return mocker.Mock(
+def sys_linux_mock():
+    return mock.Mock(
         platform='linux',
-        getfilesystemencoding=mocker.Mock(return_value='utf-8'),
+        getfilesystemencoding=mock.Mock(return_value='utf-8'),
     )
 
 
@@ -52,28 +53,28 @@ def test_partition_limits():
     )
 
 
-def test_partition_limit_win32(mocker, sys_win32_mock):
+def test_partition_limit_win32(sys_win32_mock):
     cmd = ('ninechars',)
     varargs = ('😑' * 10,)
-    with mocker.mock_module.patch('pre_commit.xargs.sys', sys_win32_mock):
+    with mock.patch('pre_commit.xargs.sys', sys_win32_mock):
         ret = xargs.partition(cmd, varargs, _max_length=20)
 
     assert ret == (cmd + varargs,)
 
 
-def test_partition_limit_linux(mocker, sys_linux_mock):
+def test_partition_limit_linux(sys_linux_mock):
     cmd = ('ninechars',)
     varargs = ('😑' * 5,)
-    with mocker.mock_module.patch('pre_commit.xargs.sys', sys_linux_mock):
+    with mock.patch('pre_commit.xargs.sys', sys_linux_mock):
         ret = xargs.partition(cmd, varargs, _max_length=30)
 
     assert ret == (cmd + varargs,)
 
 
-def test_argument_too_long_with_large_unicode(mocker, sys_linux_mock):
+def test_argument_too_long_with_large_unicode(sys_linux_mock):
     cmd = ('ninechars',)
     varargs = ('😑' * 10,)  # 4 bytes * 10
-    with mocker.mock_module.patch('pre_commit.xargs.sys', sys_linux_mock):
+    with mock.patch('pre_commit.xargs.sys', sys_linux_mock):
         with pytest.raises(xargs.ArgumentTooLongError):
             xargs.partition(cmd, varargs, _max_length=20)
 

--- a/tests/xargs_test.py
+++ b/tests/xargs_test.py
@@ -1,7 +1,6 @@
+# -*- coding: utf-8 -*-
 from __future__ import absolute_import
 from __future__ import unicode_literals
-
-from unittest import mock
 
 import pytest
 
@@ -9,18 +8,18 @@ from pre_commit import xargs
 
 
 @pytest.fixture
-def sys_win32_mock():
-    return mock.Mock(
+def sys_win32_mock(mocker):
+    return mocker.Mock(
         platform='win32',
-        getdefaultencoding=mock.Mock(return_value='utf-8'),
+        getdefaultencoding=mocker.Mock(return_value='utf-8'),
     )
 
 
 @pytest.fixture
-def sys_linux_mock():
-    return mock.Mock(
+def sys_linux_mock(mocker):
+    return mocker.Mock(
         platform='linux',
-        getdefaultencoding=mock.Mock(return_value='utf-8'),
+        getdefaultencoding=mocker.Mock(return_value='utf-8'),
     )
 
 
@@ -53,28 +52,28 @@ def test_partition_limits():
     )
 
 
-def test_partition_limit_win32(sys_win32_mock):
+def test_partition_limit_win32(mocker, sys_win32_mock):
     cmd = ('ninechars',)
     varargs = ('😑' * 10,)
-    with mock.patch('pre_commit.xargs.sys', sys_win32_mock):
+    with mocker.mock_module.patch('pre_commit.xargs.sys', sys_win32_mock):
         ret = xargs.partition(cmd, varargs, _max_length=20)
 
     assert ret == (cmd + varargs,)
 
 
-def test_partition_limit_linux(sys_linux_mock):
+def test_partition_limit_linux(mocker, sys_linux_mock):
     cmd = ('ninechars',)
     varargs = ('😑' * 5,)
-    with mock.patch('pre_commit.xargs.sys', sys_linux_mock):
+    with mocker.mock_module.patch('pre_commit.xargs.sys', sys_linux_mock):
         ret = xargs.partition(cmd, varargs, _max_length=30)
 
     assert ret == (cmd + varargs,)
 
 
-def test_argument_too_long_with_large_unicode(sys_linux_mock):
+def test_argument_too_long_with_large_unicode(mocker, sys_linux_mock):
     cmd = ('ninechars',)
     varargs = ('😑' * 10,)  # 4 bytes * 10
-    with mock.patch('pre_commit.xargs.sys', sys_linux_mock):
+    with mocker.mock_module.patch('pre_commit.xargs.sys', sys_linux_mock):
         with pytest.raises(xargs.ArgumentTooLongError):
             xargs.partition(cmd, varargs, _max_length=20)
 

--- a/tests/xargs_test.py
+++ b/tests/xargs_test.py
@@ -11,7 +11,7 @@ from pre_commit import xargs
 def sys_win32_mock(mocker):
     return mocker.Mock(
         platform='win32',
-        getdefaultencoding=mocker.Mock(return_value='utf-8'),
+        getfilesystemencoding=mocker.Mock(return_value='utf-8'),
     )
 
 
@@ -19,7 +19,7 @@ def sys_win32_mock(mocker):
 def sys_linux_mock(mocker):
     return mocker.Mock(
         platform='linux',
-        getdefaultencoding=mocker.Mock(return_value='utf-8'),
+        getfilesystemencoding=mocker.Mock(return_value='utf-8'),
     )
 
 

--- a/tests/xargs_test.py
+++ b/tests/xargs_test.py
@@ -55,7 +55,8 @@ def test_partition_limits():
 
 def test_partition_limit_win32(sys_win32_mock):
     cmd = ('ninechars',)
-    varargs = ('😑' * 10,)
+    # counted as half because of utf-16 encode
+    varargs = ('😑' * 5,)
     with mock.patch('pre_commit.xargs.sys', sys_win32_mock):
         ret = xargs.partition(cmd, varargs, _max_length=20)
 

--- a/tests/xargs_test.py
+++ b/tests/xargs_test.py
@@ -55,7 +55,7 @@ def test_partition_limits():
 
 def test_partition_limit_win32(sys_win32_mock):
     cmd = ('ninechars',)
-    varargs = (u'😑' * 10,)
+    varargs = ('😑' * 10,)
     with mock.patch('pre_commit.xargs.sys', sys_win32_mock):
         ret = xargs.partition(cmd, varargs, _max_length=20)
 
@@ -64,7 +64,7 @@ def test_partition_limit_win32(sys_win32_mock):
 
 def test_partition_limit_linux(sys_linux_mock):
     cmd = ('ninechars',)
-    varargs = (u'😑' * 5,)
+    varargs = ('😑' * 5,)
     with mock.patch('pre_commit.xargs.sys', sys_linux_mock):
         ret = xargs.partition(cmd, varargs, _max_length=30)
 
@@ -73,7 +73,7 @@ def test_partition_limit_linux(sys_linux_mock):
 
 def test_argument_too_long_with_large_unicode(sys_linux_mock):
     cmd = ('ninechars',)
-    varargs = (u'😑' * 10,)  # 4 bytes * 10
+    varargs = ('😑' * 10,)  # 4 bytes * 10
     with mock.patch('pre_commit.xargs.sys', sys_linux_mock):
         with pytest.raises(xargs.ArgumentTooLongError):
             xargs.partition(cmd, varargs, _max_length=20)

--- a/tests/xargs_test.py
+++ b/tests/xargs_test.py
@@ -55,7 +55,7 @@ def test_partition_limits():
 
 def test_partition_limit_win32(sys_win32_mock):
     cmd = ('ninechars',)
-    varargs = ('😑' * 10,)
+    varargs = (u'😑' * 10,)
     with mock.patch('pre_commit.xargs.sys', sys_win32_mock):
         ret = xargs.partition(cmd, varargs, _max_length=20)
 
@@ -64,7 +64,7 @@ def test_partition_limit_win32(sys_win32_mock):
 
 def test_partition_limit_linux(sys_linux_mock):
     cmd = ('ninechars',)
-    varargs = ('😑' * 5,)
+    varargs = (u'😑' * 5,)
     with mock.patch('pre_commit.xargs.sys', sys_linux_mock):
         ret = xargs.partition(cmd, varargs, _max_length=30)
 
@@ -73,7 +73,7 @@ def test_partition_limit_linux(sys_linux_mock):
 
 def test_argument_too_long_with_large_unicode(sys_linux_mock):
     cmd = ('ninechars',)
-    varargs = ('😑' * 10,)  # 4 bytes * 10
+    varargs = (u'😑' * 10,)  # 4 bytes * 10
     with mock.patch('pre_commit.xargs.sys', sys_linux_mock):
         with pytest.raises(xargs.ArgumentTooLongError):
             xargs.partition(cmd, varargs, _max_length=20)


### PR DESCRIPTION
Changes how `xargs.partition` computes the command length (including arguments) depending on the plataform.
More specifically, 'win32' uses the amount of characters while posix system uses the byte count.

I'm splitting what was discussed in https://github.com/pre-commit/pre-commit/issues/691 in two parts (the next one implements upper limit length).

Since I have no resource to test this under windows, it might be good to ask for help from other developers/users to help validate the change.