### PR TITLE
Implement concurrent execution of individual hooks

### DIFF
--- a/pre_commit/clientlib.py
+++ b/pre_commit/clientlib.py
@@ -56,6 +56,7 @@ MANIFEST_HOOK_DICT = cfgv.Map(
     cfgv.Optional('language_version', cfgv.check_string, 'default'),
     cfgv.Optional('log_file', cfgv.check_string, ''),
     cfgv.Optional('minimum_pre_commit_version', cfgv.check_string, '0'),
+    cfgv.Optional('require_serial', cfgv.check_bool, False),
     cfgv.Optional('stages', cfgv.check_array(cfgv.check_one_of(C.STAGES)), []),
     cfgv.Optional('verbose', cfgv.check_bool, False),
 )

--- a/pre_commit/languages/docker.py
+++ b/pre_commit/languages/docker.py
@@ -97,4 +97,8 @@ def run_hook(prefix, hook, file_args):  # pragma: windows no cover
 
     entry_tag = ('--entrypoint', entry_exe, docker_tag(prefix))
     cmd = docker_cmd() + entry_tag + cmd_rest
-    return xargs(cmd, file_args)
+    return xargs(
+        cmd,
+        file_args,
+        target_concurrency=helpers.target_concurrency(hook),
+    )

--- a/pre_commit/languages/docker.py
+++ b/pre_commit/languages/docker.py
@@ -9,7 +9,6 @@ from pre_commit.languages import helpers
 from pre_commit.util import CalledProcessError
 from pre_commit.util import clean_path_on_failure
 from pre_commit.util import cmd_output
-from pre_commit.xargs import xargs
 
 
 ENVIRONMENT_DIR = 'docker'
@@ -97,8 +96,4 @@ def run_hook(prefix, hook, file_args):  # pragma: windows no cover
 
     entry_tag = ('--entrypoint', entry_exe, docker_tag(prefix))
     cmd = docker_cmd() + entry_tag + cmd_rest
-    return xargs(
-        cmd,
-        file_args,
-        target_concurrency=helpers.target_concurrency(hook),
-    )
+    return helpers.run_xargs(hook, cmd, file_args)

--- a/pre_commit/languages/docker_image.py
+++ b/pre_commit/languages/docker_image.py
@@ -16,4 +16,8 @@ install_environment = helpers.no_install
 def run_hook(prefix, hook, file_args):  # pragma: windows no cover
     assert_docker_available()
     cmd = docker_cmd() + helpers.to_cmd(hook)
-    return xargs(cmd, file_args)
+    return xargs(
+        cmd,
+        file_args,
+        target_concurrency=helpers.target_concurrency(hook),
+    )

--- a/pre_commit/languages/docker_image.py
+++ b/pre_commit/languages/docker_image.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals
 from pre_commit.languages import helpers
 from pre_commit.languages.docker import assert_docker_available
 from pre_commit.languages.docker import docker_cmd
-from pre_commit.xargs import xargs
 
 
 ENVIRONMENT_DIR = None
@@ -16,8 +15,4 @@ install_environment = helpers.no_install
 def run_hook(prefix, hook, file_args):  # pragma: windows no cover
     assert_docker_available()
     cmd = docker_cmd() + helpers.to_cmd(hook)
-    return xargs(
-        cmd,
-        file_args,
-        target_concurrency=helpers.target_concurrency(hook),
-    )
+    return helpers.run_xargs(hook, cmd, file_args)

--- a/pre_commit/languages/golang.py
+++ b/pre_commit/languages/golang.py
@@ -11,7 +11,6 @@ from pre_commit.languages import helpers
 from pre_commit.util import clean_path_on_failure
 from pre_commit.util import cmd_output
 from pre_commit.util import rmtree
-from pre_commit.xargs import xargs
 
 
 ENVIRONMENT_DIR = 'golangenv'
@@ -81,8 +80,4 @@ def install_environment(prefix, version, additional_dependencies):
 
 def run_hook(prefix, hook, file_args):
     with in_env(prefix):
-        return xargs(
-            helpers.to_cmd(hook),
-            file_args,
-            target_concurrency=helpers.target_concurrency(hook),
-        )
+        return helpers.run_xargs(hook, helpers.to_cmd(hook), file_args)

--- a/pre_commit/languages/golang.py
+++ b/pre_commit/languages/golang.py
@@ -81,4 +81,8 @@ def install_environment(prefix, version, additional_dependencies):
 
 def run_hook(prefix, hook, file_args):
     with in_env(prefix):
-        return xargs(helpers.to_cmd(hook), file_args)
+        return xargs(
+            helpers.to_cmd(hook),
+            file_args,
+            target_concurrency=helpers.target_concurrency(hook),
+        )

--- a/pre_commit/languages/helpers.py
+++ b/pre_commit/languages/helpers.py
@@ -50,7 +50,7 @@ def no_install(prefix, version, additional_dependencies):
 
 
 def target_concurrency(hook):
-    if hook['require_serial']:
+    if hook['require_serial'] or 'PRE_COMMIT_NO_CONCURRENCY' in os.environ:
         return 1
     else:
         # Travis appears to have a bunch of CPUs, but we can't use them all.

--- a/pre_commit/languages/helpers.py
+++ b/pre_commit/languages/helpers.py
@@ -1,5 +1,6 @@
 from __future__ import unicode_literals
 
+import multiprocessing
 import shlex
 
 from pre_commit.util import cmd_output
@@ -45,3 +46,11 @@ def basic_healthy(prefix, language_version):
 
 def no_install(prefix, version, additional_dependencies):
     raise AssertionError('This type is not installable')
+
+
+def target_concurrency(hook):
+    if hook['require_serial']:
+        return 1
+    else:
+        # TODO: something smart!
+        return multiprocessing.cpu_count()

--- a/pre_commit/languages/helpers.py
+++ b/pre_commit/languages/helpers.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 
 import multiprocessing
+import os
 import shlex
 
 from pre_commit.util import cmd_output
@@ -52,5 +53,11 @@ def target_concurrency(hook):
     if hook['require_serial']:
         return 1
     else:
-        # TODO: something smart!
-        return multiprocessing.cpu_count()
+        # Travis appears to have a bunch of CPUs, but we can't use them all.
+        if 'TRAVIS' in os.environ:
+            return 2
+        else:
+            try:
+                return multiprocessing.cpu_count()
+            except NotImplementedError:
+                return 1

--- a/pre_commit/languages/helpers.py
+++ b/pre_commit/languages/helpers.py
@@ -5,6 +5,7 @@ import os
 import shlex
 
 from pre_commit.util import cmd_output
+from pre_commit.xargs import xargs
 
 
 def run_setup_cmd(prefix, cmd):
@@ -61,3 +62,7 @@ def target_concurrency(hook):
                 return multiprocessing.cpu_count()
             except NotImplementedError:
                 return 1
+
+
+def run_xargs(hook, cmd, file_args):
+    return xargs(cmd, file_args, target_concurrency=target_concurrency(hook))

--- a/pre_commit/languages/node.py
+++ b/pre_commit/languages/node.py
@@ -10,7 +10,6 @@ from pre_commit.languages import helpers
 from pre_commit.languages.python import bin_dir
 from pre_commit.util import clean_path_on_failure
 from pre_commit.util import cmd_output
-from pre_commit.xargs import xargs
 
 
 ENVIRONMENT_DIR = 'node_env'
@@ -71,8 +70,4 @@ def install_environment(prefix, version, additional_dependencies):
 
 def run_hook(prefix, hook, file_args):
     with in_env(prefix, hook['language_version']):
-        return xargs(
-            helpers.to_cmd(hook),
-            file_args,
-            target_concurrency=helpers.target_concurrency(hook),
-        )
+        return helpers.run_xargs(hook, helpers.to_cmd(hook), file_args)

--- a/pre_commit/languages/node.py
+++ b/pre_commit/languages/node.py
@@ -71,4 +71,8 @@ def install_environment(prefix, version, additional_dependencies):
 
 def run_hook(prefix, hook, file_args):
     with in_env(prefix, hook['language_version']):
-        return xargs(helpers.to_cmd(hook), file_args)
+        return xargs(
+            helpers.to_cmd(hook),
+            file_args,
+            target_concurrency=helpers.target_concurrency(hook),
+        )

--- a/pre_commit/languages/python.py
+++ b/pre_commit/languages/python.py
@@ -127,7 +127,11 @@ def py_interface(_dir, _make_venv):
 
     def run_hook(prefix, hook, file_args):
         with in_env(prefix, hook['language_version']):
-            return xargs(helpers.to_cmd(hook), file_args)
+            return xargs(
+                helpers.to_cmd(hook),
+                file_args,
+                target_concurrency=helpers.target_concurrency(hook),
+            )
 
     def install_environment(prefix, version, additional_dependencies):
         additional_dependencies = tuple(additional_dependencies)

--- a/pre_commit/languages/python.py
+++ b/pre_commit/languages/python.py
@@ -12,7 +12,6 @@ from pre_commit.parse_shebang import find_executable
 from pre_commit.util import CalledProcessError
 from pre_commit.util import clean_path_on_failure
 from pre_commit.util import cmd_output
-from pre_commit.xargs import xargs
 
 
 ENVIRONMENT_DIR = 'py_env'
@@ -127,11 +126,7 @@ def py_interface(_dir, _make_venv):
 
     def run_hook(prefix, hook, file_args):
         with in_env(prefix, hook['language_version']):
-            return xargs(
-                helpers.to_cmd(hook),
-                file_args,
-                target_concurrency=helpers.target_concurrency(hook),
-            )
+            return helpers.run_xargs(hook, helpers.to_cmd(hook), file_args)
 
     def install_environment(prefix, version, additional_dependencies):
         additional_dependencies = tuple(additional_dependencies)

--- a/pre_commit/languages/ruby.py
+++ b/pre_commit/languages/ruby.py
@@ -12,7 +12,6 @@ from pre_commit.languages import helpers
 from pre_commit.util import CalledProcessError
 from pre_commit.util import clean_path_on_failure
 from pre_commit.util import resource_bytesio
-from pre_commit.xargs import xargs
 
 
 ENVIRONMENT_DIR = 'rbenv'
@@ -126,8 +125,4 @@ def install_environment(
 
 def run_hook(prefix, hook, file_args):  # pragma: windows no cover
     with in_env(prefix, hook['language_version']):
-        return xargs(
-            helpers.to_cmd(hook),
-            file_args,
-            target_concurrency=helpers.target_concurrency(hook),
-        )
+        return helpers.run_xargs(hook, helpers.to_cmd(hook), file_args)

--- a/pre_commit/languages/ruby.py
+++ b/pre_commit/languages/ruby.py
@@ -126,4 +126,8 @@ def install_environment(
 
 def run_hook(prefix, hook, file_args):  # pragma: windows no cover
     with in_env(prefix, hook['language_version']):
-        return xargs(helpers.to_cmd(hook), file_args)
+        return xargs(
+            helpers.to_cmd(hook),
+            file_args,
+            target_concurrency=helpers.target_concurrency(hook),
+        )

--- a/pre_commit/languages/rust.py
+++ b/pre_commit/languages/rust.py
@@ -10,7 +10,6 @@ from pre_commit.envcontext import Var
 from pre_commit.languages import helpers
 from pre_commit.util import clean_path_on_failure
 from pre_commit.util import cmd_output
-from pre_commit.xargs import xargs
 
 
 ENVIRONMENT_DIR = 'rustenv'
@@ -91,8 +90,4 @@ def install_environment(prefix, version, additional_dependencies):
 
 def run_hook(prefix, hook, file_args):
     with in_env(prefix):
-        return xargs(
-            helpers.to_cmd(hook),
-            file_args,
-            target_concurrency=helpers.target_concurrency(hook),
-        )
+        return helpers.run_xargs(hook, helpers.to_cmd(hook), file_args)

--- a/pre_commit/languages/rust.py
+++ b/pre_commit/languages/rust.py
@@ -91,4 +91,8 @@ def install_environment(prefix, version, additional_dependencies):
 
 def run_hook(prefix, hook, file_args):
     with in_env(prefix):
-        return xargs(helpers.to_cmd(hook), file_args)
+        return xargs(
+            helpers.to_cmd(hook),
+            file_args,
+            target_concurrency=helpers.target_concurrency(hook),
+        )

--- a/pre_commit/languages/script.py
+++ b/pre_commit/languages/script.py
@@ -13,4 +13,8 @@ install_environment = helpers.no_install
 def run_hook(prefix, hook, file_args):
     cmd = helpers.to_cmd(hook)
     cmd = (prefix.path(cmd[0]),) + cmd[1:]
-    return xargs(cmd, file_args)
+    return xargs(
+        cmd,
+        file_args,
+        target_concurrency=helpers.target_concurrency(hook),
+    )

--- a/pre_commit/languages/script.py
+++ b/pre_commit/languages/script.py
@@ -1,7 +1,6 @@
 from __future__ import unicode_literals
 
 from pre_commit.languages import helpers
-from pre_commit.xargs import xargs
 
 
 ENVIRONMENT_DIR = None
@@ -13,8 +12,4 @@ install_environment = helpers.no_install
 def run_hook(prefix, hook, file_args):
     cmd = helpers.to_cmd(hook)
     cmd = (prefix.path(cmd[0]),) + cmd[1:]
-    return xargs(
-        cmd,
-        file_args,
-        target_concurrency=helpers.target_concurrency(hook),
-    )
+    return helpers.run_xargs(hook, cmd, file_args)

--- a/pre_commit/languages/swift.py
+++ b/pre_commit/languages/swift.py
@@ -53,4 +53,8 @@ def install_environment(
 
 def run_hook(prefix, hook, file_args):  # pragma: windows no cover
     with in_env(prefix):
-        return xargs(helpers.to_cmd(hook), file_args)
+        return xargs(
+            helpers.to_cmd(hook),
+            file_args,
+            target_concurrency=helpers.target_concurrency(hook),
+        )

--- a/pre_commit/languages/swift.py
+++ b/pre_commit/languages/swift.py
@@ -8,7 +8,6 @@ from pre_commit.envcontext import Var
 from pre_commit.languages import helpers
 from pre_commit.util import clean_path_on_failure
 from pre_commit.util import cmd_output
-from pre_commit.xargs import xargs
 
 ENVIRONMENT_DIR = 'swift_env'
 get_default_version = helpers.basic_get_default_version
@@ -53,8 +52,4 @@ def install_environment(
 
 def run_hook(prefix, hook, file_args):  # pragma: windows no cover
     with in_env(prefix):
-        return xargs(
-            helpers.to_cmd(hook),
-            file_args,
-            target_concurrency=helpers.target_concurrency(hook),
-        )
+        return helpers.run_xargs(hook, helpers.to_cmd(hook), file_args)

--- a/pre_commit/languages/system.py
+++ b/pre_commit/languages/system.py
@@ -11,4 +11,8 @@ install_environment = helpers.no_install
 
 
 def run_hook(prefix, hook, file_args):
-    return xargs(helpers.to_cmd(hook), file_args)
+    return xargs(
+        helpers.to_cmd(hook),
+        file_args,
+        target_concurrency=helpers.target_concurrency(hook),
+    )

--- a/pre_commit/languages/system.py
+++ b/pre_commit/languages/system.py
@@ -1,7 +1,6 @@
 from __future__ import unicode_literals
 
 from pre_commit.languages import helpers
-from pre_commit.xargs import xargs
 
 
 ENVIRONMENT_DIR = None
@@ -11,8 +10,4 @@ install_environment = helpers.no_install
 
 
 def run_hook(prefix, hook, file_args):
-    return xargs(
-        helpers.to_cmd(hook),
-        file_args,
-        target_concurrency=helpers.target_concurrency(hook),
-    )
+    return helpers.run_xargs(hook, helpers.to_cmd(hook), file_args)

--- a/pre_commit/xargs.py
+++ b/pre_commit/xargs.py
@@ -108,9 +108,8 @@ def xargs(cmd, varargs, **kwargs):
     def run_cmd_partition(run_cmd):
         return cmd_output(*run_cmd, encoding=None, retcode=None)
 
-    with _thread_mapper(
-            min(len(partitions), target_concurrency),
-    ) as thread_map:
+    threads = min(len(partitions), target_concurrency)
+    with _thread_mapper(threads) as thread_map:
         results = thread_map(run_cmd_partition, partitions)
 
         for proc_retcode, proc_out, proc_err in results:

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,10 @@ setup(
         'toml',
         'virtualenv',
     ],
-    extras_require={':python_version<"3.7"': ['importlib-resources']},
+    extras_require={
+        ':python_version<"3.2"': ['futures'],
+        ':python_version<"3.7"': ['importlib-resources'],
+    },
     entry_points={
         'console_scripts': [
             'pre-commit = pre_commit.main:main',

--- a/tests/languages/helpers_test.py
+++ b/tests/languages/helpers_test.py
@@ -40,7 +40,15 @@ def test_target_concurrency_normal():
 
 
 def test_target_concurrency_cpu_count_require_serial_true():
-    assert helpers.target_concurrency({'require_serial': True}) == 1
+    with mock.patch.dict(os.environ, {}, clear=True):
+        assert helpers.target_concurrency({'require_serial': True}) == 1
+
+
+def test_target_concurrency_testing_env_var():
+    with mock.patch.dict(
+            os.environ, {'PRE_COMMIT_NO_CONCURRENCY': '1'}, clear=True,
+    ):
+        assert helpers.target_concurrency({'require_serial': False}) == 1
 
 
 def test_target_concurrency_on_travis():
@@ -52,4 +60,5 @@ def test_target_concurrency_cpu_count_not_implemented():
     with mock.patch.object(
             multiprocessing, 'cpu_count', side_effect=NotImplementedError,
     ):
-        assert helpers.target_concurrency({'require_serial': False}) == 1
+        with mock.patch.dict(os.environ, {}, clear=True):
+            assert helpers.target_concurrency({'require_serial': False}) == 1

--- a/tests/languages/helpers_test.py
+++ b/tests/languages/helpers_test.py
@@ -1,8 +1,11 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
+import multiprocessing
+import os
 import sys
 
+import mock
 import pytest
 
 from pre_commit.languages import helpers
@@ -28,3 +31,25 @@ def test_failed_setup_command_does_not_unicode_error():
     # an assertion that this does not raise `UnicodeError`
     with pytest.raises(CalledProcessError):
         helpers.run_setup_cmd(Prefix('.'), (sys.executable, '-c', script))
+
+
+def test_target_concurrency_normal():
+    with mock.patch.object(multiprocessing, 'cpu_count', return_value=123):
+        with mock.patch.dict(os.environ, {}, clear=True):
+            assert helpers.target_concurrency({'require_serial': False}) == 123
+
+
+def test_target_concurrency_cpu_count_require_serial_true():
+    assert helpers.target_concurrency({'require_serial': True}) == 1
+
+
+def test_target_concurrency_on_travis():
+    with mock.patch.dict(os.environ, {'TRAVIS': '1'}, clear=True):
+        assert helpers.target_concurrency({'require_serial': False}) == 2
+
+
+def test_target_concurrency_cpu_count_not_implemented():
+    with mock.patch.object(
+            multiprocessing, 'cpu_count', side_effect=NotImplementedError,
+    ):
+        assert helpers.target_concurrency({'require_serial': False}) == 1

--- a/tests/repository_test.py
+++ b/tests/repository_test.py
@@ -837,6 +837,7 @@ def test_manifest_hooks(tempdir_factory, store):
         'minimum_pre_commit_version': '0',
         'name': 'Bash hook',
         'pass_filenames': True,
+        'require_serial': False,
         'stages': [],
         'types': ['file'],
         'exclude_types': [],

--- a/tests/xargs_test.py
+++ b/tests/xargs_test.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 import sys
+import time
 
 import mock
 import pytest
@@ -132,3 +133,20 @@ def test_xargs_retcode_normal():
 
     ret, _, _ = xargs.xargs(exit_cmd, ('0', '1'), _max_length=max_length)
     assert ret == 1
+
+
+def test_xargs_concurrency():
+    bash_cmd = ('bash', '-c')
+    print_pid = ('sleep 0.5 && echo $$',)
+
+    start = time.time()
+    ret, stdout, _ = xargs.xargs(
+        bash_cmd, print_pid * 5,
+        target_concurrency=5,
+        _max_length=len(' '.join(bash_cmd + print_pid)),
+    )
+    elapsed = time.time() - start
+    assert ret == 0
+    pids = stdout.splitlines()
+    assert len(pids) == 5
+    assert elapsed < 1

--- a/tests/xargs_test.py
+++ b/tests/xargs_test.py
@@ -177,4 +177,6 @@ def test_xargs_concurrency():
     assert ret == 0
     pids = stdout.splitlines()
     assert len(pids) == 5
-    assert elapsed < 1
+    # It would take 0.5*5=2.5 seconds ot run all of these in serial, so if it
+    # takes less, they must have run concurrently.
+    assert elapsed < 2.5

--- a/tests/xargs_test.py
+++ b/tests/xargs_test.py
@@ -5,6 +5,7 @@ from __future__ import unicode_literals
 import sys
 import time
 
+import concurrent.futures
 import mock
 import pytest
 import six
@@ -180,3 +181,15 @@ def test_xargs_concurrency():
     # It would take 0.5*5=2.5 seconds ot run all of these in serial, so if it
     # takes less, they must have run concurrently.
     assert elapsed < 2.5
+
+
+def test_thread_mapper_concurrency_uses_threadpoolexecutor_map():
+    with xargs._thread_mapper(10) as thread_map:
+        assert isinstance(
+            thread_map.__self__, concurrent.futures.ThreadPoolExecutor,
+        ) is True
+
+
+def test_thread_mapper_concurrency_uses_regular_map():
+    with xargs._thread_mapper(1) as thread_map:
+        assert thread_map is map

--- a/tox.ini
+++ b/tox.ini
@@ -27,3 +27,4 @@ env =
     GIT_AUTHOR_EMAIL=test@example.com
     GIT_COMMITTER_EMAIL=test@example.com
     VIRTUALENV_NO_DOWNLOAD=1
+    PRE_COMMIT_NO_CONCURRENCY=1


### PR DESCRIPTION
Fixes #510

This implements something like the interface described in the ticket. Individual hooks have partitions run in parallel. The current logic is just a sketch (it uses the number of CPUs as the target concurrency, and does not adjust partitioning logic, so partitions are usually very large and the benefit is minimal).

Mainly looking for feedback on the current interface changes. I think it makes sense for `xargs()` to remain a "hook-ignorant" function (i.e. it's basically a generic Python implementation of xargs, and does not know anything about pre-commit or hook configs), so the logic for determining the target concurrency based on a hook's config lives in language helpers instead. This leads to a bit more boilerplate, but I could imagine different languages wanting to optimize this differently anyhow. (For example, I added TODOs about whether it really makes sense to parallelize the `grep` languages.)

Any thoughts?

### TODO

* [x] Smarter partitioning to take advantage of concurrency
* [x] Better algorithm for calculating target concurrency?
* [x] Tests for require_serial / the above