### PR TITLE
Install multi-hook repositories only once

### DIFF
--- a/pre_commit/prefix.py
+++ b/pre_commit/prefix.py
@@ -1,11 +1,11 @@
 from __future__ import unicode_literals
 
+import collections
 import os.path
 
 
-class Prefix(object):
-    def __init__(self, prefix_dir):
-        self.prefix_dir = prefix_dir
+class Prefix(collections.namedtuple('Prefix', ('prefix_dir',))):
+    __slots__ = ()
 
     def path(self, *parts):
         return os.path.normpath(os.path.join(self.prefix_dir, *parts))

--- a/pre_commit/repository.py
+++ b/pre_commit/repository.py
@@ -179,12 +179,12 @@ class Repository(object):
         return Prefix(self.store.clone(repo, rev, deps))
 
     def _venvs(self):
-        ret = []
+        ret = set()
         for _, hook in self.hooks:
             language = hook['language']
             version = hook['language_version']
-            deps = hook['additional_dependencies']
-            ret.append((
+            deps = tuple(hook['additional_dependencies'])
+            ret.add((
                 self._prefix_from_deps(language, deps),
                 language, version, deps,
             ))

--- a/tests/repository_test.py
+++ b/tests/repository_test.py
@@ -466,7 +466,7 @@ def test_venvs(tempdir_factory, store):
     config = make_config_from_repo(path)
     repo = Repository.create(config, store)
     venv, = repo._venvs()
-    assert venv == (mock.ANY, 'python', python.get_default_version(), [])
+    assert venv == (mock.ANY, 'python', python.get_default_version(), ())
 
 
 def test_additional_dependencies(tempdir_factory, store):
@@ -474,8 +474,8 @@ def test_additional_dependencies(tempdir_factory, store):
     config = make_config_from_repo(path)
     config['hooks'][0]['additional_dependencies'] = ['pep8']
     repo = Repository.create(config, store)
-    venv, = repo._venvs()
-    assert venv == (mock.ANY, 'python', python.get_default_version(), ['pep8'])
+    env, = repo._venvs()
+    assert env == (mock.ANY, 'python', python.get_default_version(), ('pep8',))
 
 
 def test_additional_dependencies_roll_forward(tempdir_factory, store):


### PR DESCRIPTION
Thanks @chriskuehl for the report!

This was a regression introduced in b827694520be0f39bfc0599f3680b6c08b4516cf (first released in 1.7.0)

This speeds up installation of pre-commit/pre-commit-hooks from 90s to 5s