### PR TITLE
Switch back to `diff` instead of `diff-index`

### DIFF
--- a/pre_commit/staged_files_only.py
+++ b/pre_commit/staged_files_only.py
@@ -29,10 +29,9 @@ def staged_files_only(patch_dir):
     context.
     """
     # Determine if there are unstaged files
-    tree = cmd_output('git', 'write-tree')[1].strip()
     retcode, diff_stdout_binary, _ = cmd_output(
-        'git', 'diff-index', '--ignore-submodules', '--binary',
-        '--exit-code', '--no-color', '--no-ext-diff', tree, '--',
+        'git', 'diff', '--ignore-submodules', '--binary',
+        '--exit-code', '--no-color', '--no-ext-diff', '--',
         retcode=None,
         encoding=None,
     )

--- a/tests/staged_files_only_test.py
+++ b/tests/staged_files_only_test.py
@@ -350,3 +350,14 @@ def test_autocrlf_commited_crlf(in_git_dir, patch_dir):
 
     with staged_files_only(patch_dir):
         assert_no_diff()
+
+
+def test_intent_to_add(in_git_dir, patch_dir):
+    """Regression test for #881"""
+    _write(b'hello\nworld\n')
+    cmd_output('git', 'add', '--intent-to-add', 'foo')
+
+    with staged_files_only(patch_dir):
+        # there's another bug with `diff-index` with `--intent-to-add`
+        # TODO: use `assert_no_diff()`
+        cmd_output('git', 'diff', '--exit-code', '--')


### PR DESCRIPTION
`diff-index` appears to act strangely with `git add --intent-to-add`

Resolves #881 

Essentially a revert of #571