### PR TITLE
Allow aliasing a hook and calling it by it's alias

### DIFF
--- a/pre_commit/clientlib.py
+++ b/pre_commit/clientlib.py
@@ -29,6 +29,20 @@ def _make_argparser(filenames_help):
     return parser
 
 
+class OptionalAlias(object):
+
+    def check(self, dct):
+        if 'alias' in dct:
+            cfgv.check_string(dct['alias'])
+
+    def apply_default(self, dct):
+        if 'alias' not in dct:
+            dct['alias'] = dct['id']
+
+    def remove_default(self, dct):
+        pass
+
+
 MANIFEST_HOOK_DICT = cfgv.Map(
     'Hook', 'id',
 
@@ -36,6 +50,7 @@ MANIFEST_HOOK_DICT = cfgv.Map(
     cfgv.Required('name', cfgv.check_string),
     cfgv.Required('entry', cfgv.check_string),
     cfgv.Required('language', cfgv.check_one_of(all_languages)),
+    cfgv.OptionalNoDefault('alias', cfgv.check_string),
 
     cfgv.Optional(
         'files', cfgv.check_and(cfgv.check_string, cfgv.check_regex), '',
@@ -125,6 +140,7 @@ CONFIG_HOOK_DICT = cfgv.Map(
     'Hook', 'id',
 
     cfgv.Required('id', cfgv.check_string),
+    OptionalAlias(),
 
     # All keys in manifest hook dict are valid in a config hook dict, but
     # are optional.
@@ -133,7 +149,7 @@ CONFIG_HOOK_DICT = cfgv.Map(
     *[
         cfgv.OptionalNoDefault(item.key, item.check_fn)
         for item in MANIFEST_HOOK_DICT.items
-        if item.key != 'id'
+        if item.key not in ('id', 'alias')
     ]
 )
 CONFIG_REPO_DICT = cfgv.Map(

--- a/pre_commit/clientlib.py
+++ b/pre_commit/clientlib.py
@@ -29,20 +29,6 @@ def _make_argparser(filenames_help):
     return parser
 
 
-class OptionalAlias(object):
-
-    def check(self, dct):
-        if 'alias' in dct:
-            cfgv.check_string(dct['alias'])
-
-    def apply_default(self, dct):
-        if 'alias' not in dct:
-            dct['alias'] = dct['id']
-
-    def remove_default(self, dct):
-        pass
-
-
 MANIFEST_HOOK_DICT = cfgv.Map(
     'Hook', 'id',
 
@@ -50,7 +36,7 @@ MANIFEST_HOOK_DICT = cfgv.Map(
     cfgv.Required('name', cfgv.check_string),
     cfgv.Required('entry', cfgv.check_string),
     cfgv.Required('language', cfgv.check_one_of(all_languages)),
-    cfgv.OptionalNoDefault('alias', cfgv.check_string),
+    cfgv.Optional('alias', cfgv.check_string, ''),
 
     cfgv.Optional(
         'files', cfgv.check_and(cfgv.check_string, cfgv.check_regex), '',
@@ -140,7 +126,6 @@ CONFIG_HOOK_DICT = cfgv.Map(
     'Hook', 'id',
 
     cfgv.Required('id', cfgv.check_string),
-    OptionalAlias(),
 
     # All keys in manifest hook dict are valid in a config hook dict, but
     # are optional.
@@ -149,7 +134,7 @@ CONFIG_HOOK_DICT = cfgv.Map(
     *[
         cfgv.OptionalNoDefault(item.key, item.check_fn)
         for item in MANIFEST_HOOK_DICT.items
-        if item.key not in ('id', 'alias')
+        if item.key != 'id'
     ]
 )
 CONFIG_REPO_DICT = cfgv.Map(

--- a/pre_commit/commands/run.py
+++ b/pre_commit/commands/run.py
@@ -257,13 +257,17 @@ def run(config_file, store, args, environ=os.environ):
         for repo in repositories(config, store):
             for _, hook in repo.hooks:
                 if (
-                    (not args.hook or hook['id'] == args.hook) and
+                    (not args.hook or hook['id'] == args.hook or (
+                        hook['alias'] and hook['alias'] == args.hook
+                    )) and
                     (not hook['stages'] or args.hook_stage in hook['stages'])
                 ):
                     repo_hooks.append((repo, hook))
 
         if args.hook and not repo_hooks:
-            output.write_line('No hook with id `{}`'.format(args.hook))
+            output.write_line(
+                'No hook with id or alias `{}`'.format(args.hook),
+            )
             return 1
 
         for repo in {repo for repo, _ in repo_hooks}:

--- a/pre_commit/commands/run.py
+++ b/pre_commit/commands/run.py
@@ -86,6 +86,15 @@ def _run_single_hook(filenames, hook, repo, args, skips, cols):
             cols=cols,
         ))
         return 0
+    elif hook['alias'] and hook['alias'] in skips:
+        output.write(get_hook_message(
+            _hook_msg_start(hook, args.verbose),
+            end_msg=SKIPPED,
+            end_color=color.YELLOW,
+            use_color=args.color,
+            cols=cols,
+        ))
+        return 0
     elif not filenames and not hook['always_run']:
         output.write(get_hook_message(
             _hook_msg_start(hook, args.verbose),

--- a/pre_commit/commands/run.py
+++ b/pre_commit/commands/run.py
@@ -77,16 +77,7 @@ def _run_single_hook(filenames, hook, repo, args, skips, cols):
             'replacement.'.format(hook['id'], repo.repo_config['repo']),
         )
 
-    if hook['id'] in skips:
-        output.write(get_hook_message(
-            _hook_msg_start(hook, args.verbose),
-            end_msg=SKIPPED,
-            end_color=color.YELLOW,
-            use_color=args.color,
-            cols=cols,
-        ))
-        return 0
-    elif hook['alias'] and hook['alias'] in skips:
+    if hook['id'] in skips or hook['alias'] in skips:
         output.write(get_hook_message(
             _hook_msg_start(hook, args.verbose),
             end_msg=SKIPPED,

--- a/pre_commit/commands/run.py
+++ b/pre_commit/commands/run.py
@@ -257,17 +257,20 @@ def run(config_file, store, args, environ=os.environ):
         for repo in repositories(config, store):
             for _, hook in repo.hooks:
                 if (
-                    (not args.hook or hook['id'] == args.hook or (
-                        hook['alias'] and hook['alias'] == args.hook
-                    )) and
-                    (not hook['stages'] or args.hook_stage in hook['stages'])
+                        (
+                            not args.hook or
+                            hook['id'] == args.hook or
+                            hook['alias'] == args.hook
+                        ) and
+                        (
+                            not hook['stages'] or
+                            args.hook_stage in hook['stages']
+                        )
                 ):
                     repo_hooks.append((repo, hook))
 
         if args.hook and not repo_hooks:
-            output.write_line(
-                'No hook with id or alias `{}`'.format(args.hook),
-            )
+            output.write_line('No hook with id `{}`'.format(args.hook))
             return 1
 
         for repo in {repo for repo, _ in repo_hooks}:

--- a/tests/commands/run_test.py
+++ b/tests/commands/run_test.py
@@ -403,25 +403,13 @@ def test_skip_hook(cap_out, store, repo_with_passing_hook):
 def test_skip_aliased_hook(cap_out, store, aliased_repo):
     ret, printed = _do_run(
         cap_out, store, aliased_repo,
-        run_opts(hook='bash_hook'),
-        {'SKIP': 'bash_hook'},
-    )
-    assert ret == 0
-    # Both hooks will run since they share the same ID
-    assert printed.count(b'Bash hook') == 2
-    for msg in (b'Bash hook', b'Skipped'):
-        assert msg in printed
-
-    ret, printed = _do_run(
-        cap_out, store, aliased_repo,
         run_opts(hook='foo_bash'),
         {'SKIP': 'foo_bash'},
     )
     assert ret == 0
-    # Only the aliased hook runs
-    assert printed.count(b'Bash hook') == 1
+    # Only the aliased hook runs and is skipped
     for msg in (b'Bash hook', b'Skipped'):
-        assert msg in printed, printed
+        assert printed.count(msg) == 1
 
 
 def test_hook_id_not_in_non_verbose_output(

--- a/tests/repository_test.py
+++ b/tests/repository_test.py
@@ -831,6 +831,7 @@ def test_manifest_hooks(tempdir_factory, store):
         'exclude': '^$',
         'files': '',
         'id': 'bash_hook',
+        'alias': '',
         'language': 'script',
         'language_version': 'default',
         'log_file': '',


### PR DESCRIPTION
This is the least intrusive change.

We could consider using the alias in the output instead of the ID, but I'll defer any more directions on this PR through it's review comments.