### PR TITLE
Switch from deprecated docs-off args to --no-document

### DIFF
--- a/pre_commit/languages/ruby.py
+++ b/pre_commit/languages/ruby.py
@@ -118,7 +118,7 @@ def install_environment(
             )
             helpers.run_setup_cmd(
                 prefix,
-                ('gem', 'install', '--no-ri', '--no-rdoc') +
+                ('gem', 'install', '--no-document') +
                 prefix.star('.gem') + additional_dependencies,
             )
 


### PR DESCRIPTION
this will break old versions of `gem`, but without it it breaks new versions of gem 🤷‍♂️ 