### PR TITLE
Fix try-repo relpath while in a sub-directory

### DIFF
--- a/pre_commit/main.py
+++ b/pre_commit/main.py
@@ -94,12 +94,16 @@ def _adjust_args_and_chdir(args):
         args.config = os.path.abspath(args.config)
     if args.command in {'run', 'try-repo'}:
         args.files = [os.path.abspath(filename) for filename in args.files]
+    if args.command == 'try-repo' and os.path.exists(args.repo):
+        args.repo = os.path.abspath(args.repo)
 
     os.chdir(git.get_root())
 
     args.config = os.path.relpath(args.config)
     if args.command in {'run', 'try-repo'}:
         args.files = [os.path.relpath(filename) for filename in args.files]
+    if args.command == 'try-repo' and os.path.exists(args.repo):
+        args.repo = os.path.relpath(args.repo)
 
 
 def main(argv=None):

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -47,6 +47,17 @@ def test_adjust_args_and_chdir_non_relative_config(in_git_dir):
     assert args.config == C.CONFIG_FILE
 
 
+def test_adjust_args_try_repo_repo_relative(in_git_dir):
+    in_git_dir.join('foo').ensure_dir().chdir()
+
+    args = Args(command='try-repo', repo='../foo', files=[])
+    assert os.path.exists(args.repo)
+    main._adjust_args_and_chdir(args)
+    assert os.getcwd() == in_git_dir
+    assert os.path.exists(args.repo)
+    assert args.repo == 'foo'
+
+
 FNS = (
     'autoupdate', 'clean', 'install', 'install_hooks', 'migrate_config', 'run',
     'sample_config', 'uninstall',


### PR DESCRIPTION
before this change, an error as follows would occur (I have `./pre-commit` and `./pre-commit-hooks` cloned side-by-side, I am inside the `./pre-commit/pre_commit` directory)

```
$ pre-commit try-repo ../../pre-commit-hooks/ trailing-whitespace
An unexpected error has occurred: CalledProcessError: Command: ('/usr/bin/git', 'ls-remote', '--exit-code', '../../pre-commit-hooks/', 'HEAD')
Return code: 128
Expected return code: 0
Output: (none)
Errors: 
    fatal: '../../pre-commit-hooks/' does not appear to be a git repository
    fatal: Could not read from remote repository.
    
    Please make sure you have the correct access rights
    and the repository exists.
    

Check the log at /home/asottile/.cache/pre-commit/pre-commit.log
```

After

```
$ pre-commit try-repo ../../pre-commit-hooks/ trailing-whitespace
===============================================================================
Using config:
===============================================================================
repos:
-   repo: ../pre-commit-hooks
    rev: c8bad492e1b1d65d9126dba3fe3bd49a5a52b9d6
    hooks:
    -   id: trailing-whitespace
===============================================================================
[INFO] Initializing environment for ../pre-commit-hooks.
[INFO] Installing environment for ../pre-commit-hooks.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
Trim Trailing Whitespace.............................(no files to check)Skipped
```