### PR TITLE
Fix crash on `pre-commit migrate-config` when configuration is empty

### DIFF
--- a/pre_commit/commands/migrate_config.py
+++ b/pre_commit/commands/migrate_config.py
@@ -22,9 +22,8 @@ def _migrate_map(contents):
     lines = contents.splitlines(True)
     i = 0
     # Only loop on non empty configuration file
-    if i < len(lines):
-        while _is_header_line(lines[i]):
-            i += 1
+    while i < len(lines) and _is_header_line(lines[i]):
+        i += 1
 
     header = ''.join(lines[:i])
     rest = ''.join(lines[i:])

--- a/pre_commit/commands/migrate_config.py
+++ b/pre_commit/commands/migrate_config.py
@@ -21,8 +21,10 @@ def _migrate_map(contents):
     # Find the first non-header line
     lines = contents.splitlines(True)
     i = 0
-    while _is_header_line(lines[i]):
-        i += 1
+    # Only loop on non empty configuration file
+    if i < len(lines):
+        while _is_header_line(lines[i]):
+            i += 1
 
     header = ''.join(lines[:i])
     rest = ''.join(lines[i:])

--- a/tests/commands/migrate_config_test.py
+++ b/tests/commands/migrate_config_test.py
@@ -148,6 +148,7 @@ def test_migrate_config_sha_to_rev(tmpdir):
         '    hooks: []\n'
     )
 
+    
 @pytest.mark.parametrize('contents', ('', '\n'))
 def test_empty_configuration_file_user_error(tmpdir, contents):
     cfg = tmpdir.join(C.CONFIG_FILE)

--- a/tests/commands/migrate_config_test.py
+++ b/tests/commands/migrate_config_test.py
@@ -147,3 +147,12 @@ def test_migrate_config_sha_to_rev(tmpdir):
         '    rev: v1.2.0\n'
         '    hooks: []\n'
     )
+
+@pytest.mark.parametrize('contents', ('', '\n'))
+def test_empty_configuration_file_user_error(tmpdir, contents):
+    cfg = tmpdir.join(C.CONFIG_FILE)
+    cfg.write(contents)
+    with tmpdir.as_cwd():
+        assert not migrate_config(C.CONFIG_FILE)
+    # even though the config is invalid, this should be a noop
+    assert cfg.read() == contents

--- a/tests/commands/migrate_config_test.py
+++ b/tests/commands/migrate_config_test.py
@@ -148,7 +148,7 @@ def test_migrate_config_sha_to_rev(tmpdir):
         '    hooks: []\n'
     )
 
-    
+
 @pytest.mark.parametrize('contents', ('', '\n'))
 def test_empty_configuration_file_user_error(tmpdir, contents):
     cfg = tmpdir.join(C.CONFIG_FILE)


### PR DESCRIPTION
Added if statement to migrate_config.py to prevent looping through header lines if configuration file is empty.

Resolves #929