### PR TITLE
Use pkg_resources instead of importlib_metadata to get installed version

### DIFF
--- a/pre_commit/constants.py
+++ b/pre_commit/constants.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-import importlib_metadata  # TODO: importlib.metadata py38?
+import pkg_resources
 
 CONFIG_FILE = '.pre-commit-config.yaml'
 MANIFEST_FILE = '.pre-commit-hooks.yaml'
@@ -18,7 +18,7 @@ INSTALLED_STATE_VERSION = '1'
 # Bump when modifying `empty_template`
 LOCAL_REPO_VERSION = '1'
 
-VERSION = importlib_metadata.version('pre_commit')
+VERSION = str(pkg_resources.get_distribution('pre-commit').parsed_version)
 
 # `manual` is not invoked by any installed git hook.  See #719
 STAGES = ('commit', 'commit-msg', 'manual', 'push')

--- a/setup.py
+++ b/setup.py
@@ -38,8 +38,6 @@ setup(
         'aspy.yaml',
         'cfgv>=1.4.0',
         'identify>=1.0.0',
-        # if this makes it into python3.8 move to extras_require
-        'importlib-metadata',
         'nodeenv>=0.11.1',
         'pyyaml',
         'six',


### PR DESCRIPTION
Removes importlib-metadata as a dependency.
pkg_resources ships with setuptools, so it should be available
in every reasonably-modern Python environment.