### PR TITLE
Require new virtualenv

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
         'pyyaml',
         'six',
         'toml',
-        'virtualenv',
+        'virtualenv>=15.2',
     ],
     extras_require={
         ':python_version<"3.2"': ['futures'],


### PR DESCRIPTION
I'd like to start using metadata-based setup (`setup.cfg`) and this is the
minimum virtualenv version needed to build those.