### PR TITLE
Add osx specific limit for command-line length

### DIFF
--- a/pre_commit/xargs.py
+++ b/pre_commit/xargs.py
@@ -15,6 +15,8 @@ from pre_commit.util import cmd_output
 
 # TODO: properly compute max_length value
 def _get_platform_max_length():
+    if sys.platform == "darwin":
+        return 262144
     # posix minimum
     return 4 * 1024
 

--- a/tests/xargs_test.py
+++ b/tests/xargs_test.py
@@ -36,6 +36,13 @@ def linux_mock():
             yield
 
 
+@pytest.fixture
+def osx_mock():
+    with mock.patch.object(sys, 'getfilesystemencoding', return_value='utf-8'):
+        with mock.patch.object(sys, 'platform', 'darwin'):
+            yield
+
+
 def test_partition_trivial():
     assert xargs.partition(('cmd',), (), 1) == (('cmd',),)
 
@@ -86,6 +93,13 @@ def test_partition_limit_linux(linux_mock):
     varargs = ('😑' * 5,)
     ret = xargs.partition(cmd, varargs, 1, _max_length=30)
     assert ret == (cmd + varargs,)
+
+
+def test_partition_limit_osx(osx_mock):
+    cmd = ('ninechars',)
+    varargs = (('x' * 9,) * 26214)
+    ret = xargs.partition(cmd, varargs, 1)
+    assert ret == (cmd + varargs[0:26213], (cmd + varargs[26213:]))
 
 
 def test_argument_too_long_with_large_unicode(linux_mock):


### PR DESCRIPTION
Limit on OSX is 262144