### PR TITLE
don't unset GIT_EXEC_PATH

### DIFF
--- a/pre_commit/git.py
+++ b/pre_commit/git.py
@@ -29,7 +29,8 @@ def no_git_env():
     # GIT_INDEX_FILE: Causes 'error invalid object ...' during commit
     return {
         k: v for k, v in os.environ.items()
-        if not k.startswith('GIT_') or k in {'GIT_SSH', 'GIT_SSH_COMMAND'}
+        if not k.startswith('GIT_') or
+        k in {'GIT_EXEC_PATH', 'GIT_SSH', 'GIT_SSH_COMMAND'}
     }
 
 


### PR DESCRIPTION
This env may be required for git to work; unsetting it can cause clone, submodule commands, etc. to fail

occurs with bundled git, e.g. Fork or SmartGit git clients

This appears to be needed to fix #664, where setting GIT_EXEC_PATH is recommended. Fork rightly does this, however pre-commit is stripping GIT_EXEC_PATH, preventing it from fixing the issue even when it is set.

Logs:

```
[INFO] Initializing environment for https://github.com/asottile/reorder_python_imports.
An unexpected error has occurred: CalledProcessError: Command: ('/Applications/Fork.app/Contents/Resources/git-instance/libexec/git-core/git', 'submodule', 'update', '--init', '--recursive')
Return code: 1
Expected return code: 0
Output: (none)
Errors:
    /Applications/Fork.app/Contents/Resources/git-instance/libexec/git-core/git-sh-setup: line 46: /usr/local/git/libexec/git-core/git-sh-i18n: No such file or directory


Check the log at $HOME/.cache/pre-commit/pre-commit.log
```