### PR TITLE
Do not run legacy script again when this is the one being executed

### DIFF
--- a/pre_commit/resources/hook-tmpl
+++ b/pre_commit/resources/hook-tmpl
@@ -54,8 +54,10 @@ def _run_legacy():
     else:
         stdin = None
 
-    legacy_hook = os.path.join(HERE, '{}.legacy'.format(HOOK_TYPE))
-    if os.access(legacy_hook, os.X_OK):
+    legacy_script = HOOK_TYPE + '.legacy'
+    is_legacy_executed = os.path.basename(__file__) == legacy_script
+    legacy_hook = os.path.join(HERE, legacy_script)
+    if not is_legacy_executed and os.access(legacy_hook, os.X_OK):
         cmd = _norm_exe(legacy_hook) + (legacy_hook,) + tuple(sys.argv[1:])
         proc = subprocess.Popen(cmd, stdin=subprocess.PIPE if stdin else None)
         proc.communicate(stdin)

--- a/pre_commit/resources/hook-tmpl
+++ b/pre_commit/resources/hook-tmpl
@@ -49,15 +49,22 @@ def _norm_exe(exe):
 
 
 def _run_legacy():
+    if __file__.endswith('.legacy'):
+        raise SystemExit(
+            "bug: pre-commit's script is installed in migration mode\n"
+            'run `pre-commit install -f --hook-type {}` to fix this\n\n'
+            'Please report this bug at '
+            'https://github.com/pre-commit/pre-commit/issues'.format(
+                HOOK_TYPE,
+            ),
+        )
+
     if HOOK_TYPE == 'pre-push':
         stdin = getattr(sys.stdin, 'buffer', sys.stdin).read()
     else:
         stdin = None
 
-    legacy_script = HOOK_TYPE + '.legacy'
-    is_legacy_executed = os.path.basename(__file__) == legacy_script
-    legacy_hook = os.path.join(HERE, legacy_script)
-    assert not is_legacy_executed, __file__
+    legacy_hook = os.path.join(HERE, '{}.legacy'.format(HOOK_TYPE))
     if os.access(legacy_hook, os.X_OK):
         cmd = _norm_exe(legacy_hook) + (legacy_hook,) + tuple(sys.argv[1:])
         proc = subprocess.Popen(cmd, stdin=subprocess.PIPE if stdin else None)

--- a/pre_commit/resources/hook-tmpl
+++ b/pre_commit/resources/hook-tmpl
@@ -57,7 +57,8 @@ def _run_legacy():
     legacy_script = HOOK_TYPE + '.legacy'
     is_legacy_executed = os.path.basename(__file__) == legacy_script
     legacy_hook = os.path.join(HERE, legacy_script)
-    if not is_legacy_executed and os.access(legacy_hook, os.X_OK):
+    assert not is_legacy_executed, __file__
+    if os.access(legacy_hook, os.X_OK):
         cmd = _norm_exe(legacy_hook) + (legacy_hook,) + tuple(sys.argv[1:])
         proc = subprocess.Popen(cmd, stdin=subprocess.PIPE if stdin else None)
         proc.communicate(stdin)


### PR DESCRIPTION
This patch fixes an infinite process recursion when `.git/hooks/pre-commit.legacy` executes itself over and over. I don't know exactly how and why this `pre-commit.legacy` file was created but it is a copy of `.git/hooks/pre-commit`