### PR TITLE
mounting the superproject directory in docker and docker_image

### DIFF
--- a/pre_commit/git.py
+++ b/pre_commit/git.py
@@ -40,10 +40,12 @@ def get_root():
 
 
 def get_superproject_root():
-    stdout = cmd_output('git',
-                        'rev-parse',
-                        '--show-superproject-working-tree',
-                        '--show-toplevel')
+    stdout = cmd_output(
+        'git',
+        'rev-parse',
+        '--show-superproject-working-tree',
+        '--show-toplevel',
+    )
     return stdout[1].splitlines()[0].strip()
 
 

--- a/pre_commit/git.py
+++ b/pre_commit/git.py
@@ -39,6 +39,14 @@ def get_root():
     return cmd_output('git', 'rev-parse', '--show-toplevel')[1].strip()
 
 
+def get_superproject_root():
+    stdout = cmd_output('git',
+                        'rev-parse',
+                        '--show-superproject-working-tree',
+                        '--show-toplevel')
+    return stdout[1].splitlines()[0].strip()
+
+
 def get_git_dir(git_root='.'):
     opts = ('--git-common-dir', '--git-dir')
     _, out, _ = cmd_output('git', 'rev-parse', *opts, cwd=git_root)

--- a/pre_commit/languages/docker.py
+++ b/pre_commit/languages/docker.py
@@ -5,7 +5,8 @@ import hashlib
 import os
 
 import pre_commit.constants as C
-from pre_commit import five, git
+from pre_commit import five
+from pre_commit import git
 from pre_commit.languages import helpers
 from pre_commit.util import CalledProcessError
 from pre_commit.util import clean_path_on_failure

--- a/pre_commit/languages/docker.py
+++ b/pre_commit/languages/docker.py
@@ -5,7 +5,7 @@ import hashlib
 import os
 
 import pre_commit.constants as C
-from pre_commit import five
+from pre_commit import five, git
 from pre_commit.languages import helpers
 from pre_commit.util import CalledProcessError
 from pre_commit.util import clean_path_on_failure
@@ -74,6 +74,9 @@ def install_environment(
 
 
 def docker_cmd():  # pragma: windows no cover
+    superproject_dir = git.get_superproject_root()
+    project_dir = git.get_root()
+    project_relpath = os.path.relpath(project_dir, superproject_dir)
     return (
         'docker', 'run',
         '--rm',
@@ -81,8 +84,8 @@ def docker_cmd():  # pragma: windows no cover
         # https://docs.docker.com/engine/reference/commandline/run/#mount-volumes-from-container-volumes-from
         # The `Z` option tells Docker to label the content with a private
         # unshared label. Only the current container can use a private volume.
-        '-v', '{}:/src:rw,Z'.format(os.getcwd()),
-        '--workdir', '/src',
+        '-v', '{}:/src:rw,Z'.format(superproject_dir),
+        '--workdir', os.path.abspath(os.path.join('/src', project_relpath)),
     )
 
 


### PR DESCRIPTION
We need to mount the superproject directory to make it possible to run `pre-commit` inside a submodule