### PR TITLE
Fix handling of SIGINT in hook script

### DIFF
--- a/pre_commit/resources/hook-tmpl
+++ b/pre_commit/resources/hook-tmpl
@@ -170,15 +170,24 @@ def _opts(stdin):
     return ('--config', CONFIG, '--hook-stage', stage) + fns[HOOK_TYPE](stdin)
 
 
+if sys.version_info < (3, 7):  # https://bugs.python.org/issue25942
+    def _subprocess_call(cmd):  # this is the python 2.7 implementation
+        return subprocess.Popen(cmd).wait()
+else:
+    _subprocess_call = subprocess.call
+
+
 def main():
     retv, stdin = _run_legacy()
     try:
         _validate_config()
-        return retv | subprocess.call(_exe() + _opts(stdin))
+        return retv | _subprocess_call(_exe() + _opts(stdin))
     except EarlyExit:
         return retv
     except FatalError as e:
         print(e.args[0])
+        return 1
+    except KeyboardInterrupt:
         return 1
 
 


### PR DESCRIPTION
Resolves #1026

Test Plan:

- Stage a change
- Have an unstaged changed
- Run `git commit`
- `^C` while the commit is running
- Verify that the patch gets re-applied


_Ideally there isn't output spew, but that seemed unavoidable on windows_