### PR TITLE
Add advice to "Files were modified…" error

### DIFF
--- a/pre_commit/commands/run.py
+++ b/pre_commit/commands/run.py
@@ -152,7 +152,9 @@ def _run_single_hook(classifier, hook, args, skips, cols):
 
         # Print a message if failing due to file modifications
         if file_modifications:
-            output.write('Files were modified by this hook.')
+            output.write('Files were modified by this hook.' \
+                         'Please review them in Git\'s staging area, ' \
+                         'and repeat the commit.')
 
             if stdout or stderr:
                 output.write_line(' Additional output:')


### PR DESCRIPTION
Would it make sense to include something like this? If yes, please let me know whether the formatting for a string that should not be too long in the source code, but single-line in the out-put is correct.

Afterwards, I'll:

- [ ] update [run_test.py](https://github.com/pre-commit/pre-commit/blob/b8300268bf2d8797f28edf9063d7e5659ad4d535/tests/commands/run_test.py#L126)
