### PR TITLE
restore testenv:venv section

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,5 @@
 [tox]
+project = pre_commit
 envlist = py27,py36,py37,pypy,pypy3,pre-commit
 
 [testenv]
@@ -9,6 +10,10 @@ commands =
     coverage run -m pytest {posargs:tests}
     coverage report --fail-under 100
     pre-commit install
+
+[testenv:venv]
+envdir = venv-{[tox]project}
+commands =
 
 [testenv:pre-commit]
 skip_install = true

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,4 @@
 [tox]
-project = pre_commit
 envlist = py27,py36,py37,pypy,pypy3,pre-commit
 
 [testenv]
@@ -11,14 +10,14 @@ commands =
     coverage report --fail-under 100
     pre-commit install
 
-[testenv:venv]
-envdir = venv-{[tox]project}
-commands =
-
 [testenv:pre-commit]
 skip_install = true
 deps = pre-commit
 commands = pre-commit run --all-files --show-diff-on-failure
+
+[testenv:venv]
+envdir = venv-pre_commit
+commands =
 
 [pep8]
 ignore = E265,E501,W504


### PR DESCRIPTION
to be able to set the dev environment as described in the [CONTRIBUTING.md](https://github.com/pre-commit/pre-commit/blob/master/CONTRIBUTING.md#setting-up-an-environment)