### PR TITLE
azure pipelines now has rust by default on windows

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,10 +20,8 @@ jobs:
     os: windows
     additional_variables:
       COVERAGE_IGNORE_WINDOWS: '# pragma: windows no cover'
-      TOX_TESTENV_PASSENV: COVERAGE_IGNORE_WINDOWS
+      TOX_TESTENV_PASSENV: COVERAGE_IGNORE_WINDOWS RUSTUP_HOME
       TEMP: C:\Temp  # remove when dropping python2
-    pre_test:
-    - template: step--rust-install.yml
 - template: job--python-tox.yml@asottile
   parameters:
     toxenvs: [py37]

--- a/tests/repository_test.py
+++ b/tests/repository_test.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 import os.path
 import re
 import shutil
+import sys
 
 import cfgv
 import mock
@@ -717,6 +718,10 @@ def local_python_config():
     return {'repo': 'local', 'hooks': hooks}
 
 
+@pytest.mark.xfail(  # pragma: windows no cover
+    sys.platform == 'win32',
+    reason='microsoft/azure-pipelines-image-generation#989',
+)
 def test_local_python_repo(store, local_python_config):
     hook = _get_hook(local_python_config, store, 'foo')
     # language_version should have been adjusted to the interpreter version


### PR DESCRIPTION
annoyingly it isn't on the linux agents yet -- apparently my repo will get that on 2019-06-04

I needed to add an additional variable to passenv for windows due to https://github.com/microsoft/azure-pipelines-image-generation/issues/988