### PR TITLE
Use current version of Python for Windows by default

### DIFF
--- a/pre_commit/commands/install_uninstall.py
+++ b/pre_commit/commands/install_uninstall.py
@@ -49,7 +49,7 @@ def is_our_script(filename):
 
 def shebang():
     if sys.platform == 'win32':
-        py = 'python'
+        py = 'python{}'.format(sys.version_info[0])
     else:
         # Homebrew/homebrew-core#35825: be more timid about appropriate `PATH`
         path_choices = [p for p in os.defpath.split(os.pathsep) if p]
@@ -62,7 +62,7 @@ def shebang():
                 py = exe
                 break
         else:
-            py = 'python'
+            py = 'python{}'.format(sys.version_info[0])
     return '#!/usr/bin/env {}'.format(py)
 
 

--- a/pre_commit/commands/install_uninstall.py
+++ b/pre_commit/commands/install_uninstall.py
@@ -14,6 +14,7 @@ from pre_commit.clientlib import load_config
 from pre_commit.repository import all_hooks
 from pre_commit.repository import install_hook_envs
 from pre_commit.util import cmd_output
+from pre_commit.util import is_mingw
 from pre_commit.util import make_executable
 from pre_commit.util import mkdirp
 from pre_commit.util import resource_text
@@ -48,8 +49,8 @@ def is_our_script(filename):
 
 
 def shebang():
-    if sys.platform == 'win32':
-        py = 'python{}'.format(sys.version_info[0])
+    if sys.platform == 'win32' and not is_mingw():
+        py = 'python'
     else:
         # Homebrew/homebrew-core#35825: be more timid about appropriate `PATH`
         path_choices = [p for p in os.defpath.split(os.pathsep) if p]

--- a/pre_commit/git.py
+++ b/pre_commit/git.py
@@ -5,6 +5,8 @@ import os.path
 import sys
 
 from pre_commit.util import cmd_output
+from pre_commit.util import fix_mingw_path
+from pre_commit.util import is_mingw
 
 
 logger = logging.getLogger(__name__)
@@ -36,7 +38,12 @@ def no_git_env(_env=None):
 
 
 def get_root():
-    return cmd_output('git', 'rev-parse', '--show-toplevel')[1].strip()
+    return fix_mingw_path(
+        cmd_output(
+            'git', 'rev-parse',
+            '--show-toplevel',
+        )[1].strip(),
+    )
 
 
 def get_git_dir(git_root='.'):
@@ -159,7 +166,8 @@ def git_path(name, repo='.'):
 
 def check_for_cygwin_mismatch():
     """See https://github.com/pre-commit/pre-commit/issues/354"""
-    if sys.platform in ('cygwin', 'win32'):  # pragma: no cover (windows)
+    if sys.platform in ('cygwin', 'win32') and \
+            not is_mingw():  # pragma: no cover (windows)
         is_cygwin_python = sys.platform == 'cygwin'
         toplevel = cmd_output('git', 'rev-parse', '--show-toplevel')[1]
         is_cygwin_git = toplevel.startswith('/')

--- a/pre_commit/resources/hook-tmpl
+++ b/pre_commit/resources/hook-tmpl
@@ -6,6 +6,7 @@ import distutils.spawn
 import os
 import subprocess
 import sys
+import sysconfig
 
 # work around https://github.com/Homebrew/homebrew-core/issues/30445
 os.environ.pop('__PYVENV_LAUNCHER__', None)
@@ -76,7 +77,10 @@ def _run_legacy():
 
 def _validate_config():
     cmd = ('git', 'rev-parse', '--show-toplevel')
-    top_level = subprocess.check_output(cmd).decode('UTF-8').strip()
+    top_level = fix_mingw_path(
+        subprocess.check_output(cmd).decode('UTF-8').
+        strip(),
+    )
     cfg = os.path.join(top_level, CONFIG)
     if os.path.isfile(cfg):
         pass
@@ -175,6 +179,21 @@ if sys.version_info < (3, 7):  # https://bugs.python.org/issue25942
         return subprocess.Popen(cmd).wait()
 else:
     _subprocess_call = subprocess.call
+
+
+def is_mingw():
+    """Check whether platform is mingw or not."""
+    return sysconfig.get_platform() in 'mingw'
+
+
+def fix_mingw_path(path):
+    """Convert cygwin path to mingw-style path"""
+    if is_mingw():
+        path = subprocess.check_output([
+            'cygpath', '-m',
+            path,
+        ]).decode().strip()
+    return path
 
 
 def main():

--- a/pre_commit/util.py
+++ b/pre_commit/util.py
@@ -7,6 +7,7 @@ import shutil
 import stat
 import subprocess
 import sys
+import sysconfig
 import tempfile
 
 import six
@@ -175,3 +176,16 @@ def rmtree(path):
 def parse_version(s):
     """poor man's version comparison"""
     return tuple(int(p) for p in s.split('.'))
+
+
+def is_mingw():
+    """Check whether platform is mingw or not."""
+    return sysconfig.get_platform() in 'mingw'
+
+
+def fix_mingw_path(path):
+    """Convert cygwin path to mingw-style path"""
+    if is_mingw():
+        _return, path, _output = cmd_output('cygpath', '-m', path)
+        path = path.strip()
+    return path


### PR DESCRIPTION
By default, Windows used `python` without version identifier. This patch specifies to use the current version of Python for Windows.