### PR TITLE
Fix shallow fetch by checking out FETCH_HEAD

### DIFF
--- a/pre_commit/store.py
+++ b/pre_commit/store.py
@@ -142,15 +142,15 @@ class Store(object):
         git_cmd('checkout', ref)
         git_cmd('submodule', 'update', '--init', '--recursive')
 
-    def _shallow_clone(self, ref, git_cmd):  # pragma: windows no cover
+    def _shallow_clone(self, ref, git_cmd):
         """Perform a shallow clone of a repository and its submodules """
 
         git_config = 'protocol.version=2'
         git_cmd('-c', git_config, 'fetch', 'origin', ref, '--depth=1')
-        git_cmd('checkout', ref)
+        git_cmd('checkout', 'FETCH_HEAD')
         git_cmd(
-            '-c', git_config, 'submodule', 'update', '--init',
-            '--recursive', '--depth=1',
+            '-c', git_config, 'submodule', 'update', '--init', '--recursive',
+            '--depth=1',
         )
 
     def clone(self, repo, ref, deps=()):


### PR DESCRIPTION
I don't think this was actually succeeding before:

```console
$ bash -x t2.sh
+ set -euxo pipefail
+ git --version
git version 2.20.1 (Apple Git-117)
+ rm -rf repo1
+ git init repo1
Initialized empty Git repository in /private/tmp/x/repo1/.git/
+ cd repo1
+ git remote add origin https://github.com/asottile/pyupgrade
+ git -c protocol.version=2 fetch origin v1.20.1 --depth=1
remote: Enumerating objects: 38, done.
remote: Counting objects: 100% (38/38), done.
remote: Compressing objects: 100% (32/32), done.
remote: Total 38 (delta 4), reused 27 (delta 3), pack-reused 0
Unpacking objects: 100% (38/38), done.
From https://github.com/asottile/pyupgrade
 * tag               v1.20.1    -> FETCH_HEAD
+ git checkout v1.20.1
error: pathspec 'v1.20.1' did not match any file(s) known to git
```