### PR TITLE
Added hook-stage print to output for missing hook id

### DIFF
--- a/pre_commit/commands/run.py
+++ b/pre_commit/commands/run.py
@@ -285,7 +285,7 @@ def run(config_file, store, args, environ=os.environ):
         ]
 
         if args.hook and not hooks:
-            output.write_line('No hook with id `{}`'.format(args.hook))
+            output.write_line('No hook with id `{}` in stage `{}`'.format(args.hook, args.hook_stage))
             return 1
 
         install_hook_envs(hooks, store)

--- a/pre_commit/commands/run.py
+++ b/pre_commit/commands/run.py
@@ -285,7 +285,11 @@ def run(config_file, store, args, environ=os.environ):
         ]
 
         if args.hook and not hooks:
-            output.write_line('No hook with id `{}` in stage `{}`'.format(args.hook, args.hook_stage))
+            output.write_line(
+                'No hook with id `{}` in stage `{}`'.format(
+                    args.hook, args.hook_stage,
+                ),
+            )
             return 1
 
         install_hook_envs(hooks, store)

--- a/tests/commands/run_test.py
+++ b/tests/commands/run_test.py
@@ -231,12 +231,17 @@ def test_show_diff_on_failure(
         ({}, (b'Bash hook', b'Passed'), 0, True),
         ({'verbose': True}, (b'foo.py\nHello World',), 0, True),
         ({'hook': 'bash_hook'}, (b'Bash hook', b'Passed'), 0, True),
-        ({'hook': 'nope'}, (b'No hook with id `nope` in stage `commit`',), 1, True),
+        (
+            {'hook': 'nope'},
+            (b'No hook with id `nope` in stage `commit`',),
+            1,
+            True,
+        ),
         (
             {'hook': 'nope', 'hook_stage': 'push'},
             (b'No hook with id `nope` in stage `push`',),
             1,
-            True
+            True,
         ),
         (
             {'all_files': True, 'verbose': True},

--- a/tests/commands/run_test.py
+++ b/tests/commands/run_test.py
@@ -231,7 +231,13 @@ def test_show_diff_on_failure(
         ({}, (b'Bash hook', b'Passed'), 0, True),
         ({'verbose': True}, (b'foo.py\nHello World',), 0, True),
         ({'hook': 'bash_hook'}, (b'Bash hook', b'Passed'), 0, True),
-        ({'hook': 'nope'}, (b'No hook with id `nope`',), 1, True),
+        ({'hook': 'nope'}, (b'No hook with id `nope` in stage `commit`',), 1, True),
+        (
+            {'hook': 'nope', 'hook_stage': 'push'},
+            (b'No hook with id `nope` in stage `push`',),
+            1,
+            True
+        ),
         (
             {'all_files': True, 'verbose': True},
             (b'foo.py',),


### PR DESCRIPTION
Adds the value of `hook-stage` to the error message for a missing hook id to suggest setting a different stage. 

Possible additions before merging:
- Add a prompt to set the hook-stage
- Add a search for the id in different stages to say `Did you mean to use --hook-stage bleh`
- Add tests for more than `commit` and `push`