### PR TITLE
Check if --config option is a path to a regular file

### DIFF
--- a/pre_commit/main.py
+++ b/pre_commit/main.py
@@ -42,7 +42,11 @@ def _file_path(path):
     elif os.path.exists(path):
         msg = '{} is not a regular file'.format(path)
         raise argparse.ArgumentTypeError(msg)
-    git_path = os.path.join(git.get_root(), path)
+    try:
+        git_path = os.path.join(git.get_root(), path)
+    except CalledProcessError:
+        msg = '{} does not exist'.format(path)
+        raise argparse.ArgumentTypeError(msg)
     if os.path.isfile(git_path):
         return git_path
     else:

--- a/pre_commit/main.py
+++ b/pre_commit/main.py
@@ -58,11 +58,11 @@ def _add_color_option(parser):
     )
 
 
-def _add_config_option(parser):
+def _add_config_option(parser, check=True):
     parser.add_argument(
         '-c', '--config', default=C.CONFIG_FILE,
         help='Path to alternate config file',
-        type=_file_path,
+        type=_file_path if check else str,
     )
 
 
@@ -172,11 +172,11 @@ def main(argv=None):
         'clean', help='Clean out pre-commit files.',
     )
     _add_color_option(clean_parser)
-    _add_config_option(clean_parser)
+    _add_config_option(clean_parser, check=False)
 
     gc_parser = subparsers.add_parser('gc', help='Clean unused cached repos.')
     _add_color_option(gc_parser)
-    _add_config_option(gc_parser)
+    _add_config_option(gc_parser, check=False)
 
     init_templatedir_parser = subparsers.add_parser(
         'init-templatedir',
@@ -186,7 +186,7 @@ def main(argv=None):
         ),
     )
     _add_color_option(init_templatedir_parser)
-    _add_config_option(init_templatedir_parser)
+    _add_config_option(init_templatedir_parser, check=False)
     init_templatedir_parser.add_argument(
         'directory', help='The directory in which to write the hook script.',
     )
@@ -244,7 +244,7 @@ def main(argv=None):
         'sample-config', help='Produce a sample {} file'.format(C.CONFIG_FILE),
     )
     _add_color_option(sample_config_parser)
-    _add_config_option(sample_config_parser)
+    _add_config_option(sample_config_parser, check=False)
 
     try_repo_parser = subparsers.add_parser(
         'try-repo',

--- a/pre_commit/main.py
+++ b/pre_commit/main.py
@@ -42,6 +42,9 @@ def _file_path(path):
     elif os.path.exists(path):
         msg = '{} is not a regular file'.format(path)
         raise argparse.ArgumentTypeError(msg)
+    git_path = os.path.join(git.get_root(), path)
+    if os.path.isfile(git_path):
+        return git_path
     else:
         msg = '{} does not exist'.format(path)
         raise argparse.ArgumentTypeError(msg)

--- a/pre_commit/main.py
+++ b/pre_commit/main.py
@@ -36,6 +36,17 @@ logger = logging.getLogger('pre_commit')
 os.environ.pop('__PYVENV_LAUNCHER__', None)
 
 
+def _file_path(path):
+    if os.path.isfile(path):
+        return path
+    elif os.path.exists(path):
+        msg = '{} is not a regular file'.format(path)
+        raise argparse.ArgumentTypeError(msg)
+    else:
+        msg = '{} does not exist'.format(path)
+        raise argparse.ArgumentTypeError(msg)
+
+
 def _add_color_option(parser):
     parser.add_argument(
         '--color', default='auto', type=color.use_color,
@@ -48,6 +59,7 @@ def _add_config_option(parser):
     parser.add_argument(
         '-c', '--config', default=C.CONFIG_FILE,
         help='Path to alternate config file',
+        type=_file_path,
     )
 
 


### PR DESCRIPTION
This change implements the suggestion made by @asottile in #1037 
I tried to be compatible to the current behavior of `_adjust_args_and_chdir(args)`, therefore we also check if the path points to a file relative to the git root directory.

If there is some interest in getting this merged I will add/fix the required tests.