### PR TITLE
Fix docker based hooks failing on Windows

### DIFF
--- a/pre_commit/languages/docker.py
+++ b/pre_commit/languages/docker.py
@@ -14,8 +14,6 @@ from pre_commit.util import cmd_output
 
 ENVIRONMENT_DIR = 'docker'
 PRE_COMMIT_LABEL = 'PRE_COMMIT'
-FALLBACK_UID = 1000
-FALLBACK_GID = 1000
 get_default_version = helpers.basic_get_default_version
 healthy = helpers.basic_healthy
 
@@ -75,25 +73,18 @@ def install_environment(
         os.mkdir(directory)
 
 
-def getuid():  # pragma: windows no cover
+def get_docker_user():  # pragma: windows no cover
     try:
-        return os.getuid()
+        return '{}:{}'.format(os.getuid(), os.getgid())
     except AttributeError:
-        return FALLBACK_UID
-
-
-def getgid():  # pragma: windows no cover
-    try:
-        return os.getgid()
-    except AttributeError:
-        return FALLBACK_GID
+        return '1000:1000'
 
 
 def docker_cmd():  # pragma: windows no cover
     return (
         'docker', 'run',
         '--rm',
-        '-u', '{}:{}'.format(getuid(), getgid()),
+        '-u', get_docker_user(),
         # https://docs.docker.com/engine/reference/commandline/run/#mount-volumes-from-container-volumes-from
         # The `Z` option tells Docker to label the content with a private
         # unshared label. Only the current container can use a private volume.

--- a/pre_commit/languages/docker.py
+++ b/pre_commit/languages/docker.py
@@ -75,14 +75,14 @@ def install_environment(
         os.mkdir(directory)
 
 
-def getuid():
+def getuid():  # pragma: windows no cover
     try:
         return os.getuid()
     except AttributeError:
         return FALLBACK_UID
 
 
-def getgid():
+def getgid():  # pragma: windows no cover
     try:
         return os.getgid()
     except AttributeError:

--- a/pre_commit/languages/docker.py
+++ b/pre_commit/languages/docker.py
@@ -14,6 +14,8 @@ from pre_commit.util import cmd_output
 
 ENVIRONMENT_DIR = 'docker'
 PRE_COMMIT_LABEL = 'PRE_COMMIT'
+FALLBACK_UID = 1000
+FALLBACK_GID = 1000
 get_default_version = helpers.basic_get_default_version
 healthy = helpers.basic_healthy
 
@@ -73,11 +75,25 @@ def install_environment(
         os.mkdir(directory)
 
 
+def getuid():
+    try:
+        return os.getuid()
+    except AttributeError:
+        return FALLBACK_UID
+
+
+def getgid():
+    try:
+        return os.getgid()
+    except AttributeError:
+        return FALLBACK_GID
+
+
 def docker_cmd():  # pragma: windows no cover
     return (
         'docker', 'run',
         '--rm',
-        '-u', '{}:{}'.format(os.getuid(), os.getgid()),
+        '-u', '{}:{}'.format(getuid(), getgid()),
         # https://docs.docker.com/engine/reference/commandline/run/#mount-volumes-from-container-volumes-from
         # The `Z` option tells Docker to label the content with a private
         # unshared label. Only the current container can use a private volume.

--- a/tests/languages/docker_test.py
+++ b/tests/languages/docker_test.py
@@ -18,12 +18,12 @@ def test_docker_is_running_process_error():
 def test_docker_fallback_uid():
     def invalid_attribute():
         raise AttributeError
-    with mock.patch('os.getuid', invalid_attribute):
+    with mock.patch('os.getuid', invalid_attribute, create=True):
         assert docker.getuid() == docker.FALLBACK_UID
 
 
 def test_docker_fallback_gid():
     def invalid_attribute():
         raise AttributeError
-    with mock.patch('os.getgid', invalid_attribute):
+    with mock.patch('os.getgid', invalid_attribute, create=True):
         assert docker.getgid() == docker.FALLBACK_GID

--- a/tests/languages/docker_test.py
+++ b/tests/languages/docker_test.py
@@ -15,15 +15,12 @@ def test_docker_is_running_process_error():
         assert docker.docker_is_running() is False
 
 
-def test_docker_fallback_uid():
+def test_docker_fallback_user():
     def invalid_attribute():
         raise AttributeError
-    with mock.patch('os.getuid', invalid_attribute, create=True):
-        assert docker.getuid() == docker.FALLBACK_UID
-
-
-def test_docker_fallback_gid():
-    def invalid_attribute():
-        raise AttributeError
-    with mock.patch('os.getgid', invalid_attribute, create=True):
-        assert docker.getgid() == docker.FALLBACK_GID
+    with mock.patch.multiple(
+        'os', create=True,
+        getuid=invalid_attribute,
+        getgid=invalid_attribute,
+    ):
+        assert docker.get_docker_user() == '1000:1000'

--- a/tests/languages/docker_test.py
+++ b/tests/languages/docker_test.py
@@ -13,3 +13,17 @@ def test_docker_is_running_process_error():
         side_effect=CalledProcessError(*(None,) * 4),
     ):
         assert docker.docker_is_running() is False
+
+
+def test_docker_fallback_uid():
+    def invalid_attribute():
+        raise AttributeError
+    with mock.patch('os.getuid', invalid_attribute):
+        assert docker.getuid() == docker.FALLBACK_UID
+
+
+def test_docker_fallback_gid():
+    def invalid_attribute():
+        raise AttributeError
+    with mock.patch('os.getgid', invalid_attribute):
+        assert docker.getgid() == docker.FALLBACK_GID


### PR DESCRIPTION
Fixes #1072

Docker for Windows 
- mounts the volume passed via `-v` always using `root:root` as owner, even if a `-u UID:GID` option is passed
-  newly created files (e.g. via `touch`) also use `root:root` as owner, even if the container is run as non-root user
- read/write access is also provided to non-root users, even if `ls -l` yields `-rwxr-x-r-x`  as file permissions
- files created inside the container appear on the host as if they were created by the user running the docker command

This is because Docker for Windows currently implements host mounted volumes via SMB (see https://docs.docker.com/docker-for-windows/troubleshoot/#volumes), which handles the access to mounted files and does not allow changing permissions from inside the container (see docker/docker.github.io#3298).

Therefore the UID and GID we pass to docker can be chosen arbitrarily, because the owner of files on the host will match the Windows user running docker and not the user in the docker container.

There are also some other caveats when it comes to running linux docker images via Docker for Windows, e.g. you have to be careful about line endings (moby/moby#24388).

With these changes I was able to successfully run a hook on Windows using `language: docker_image` for a personal project of mine, therefore I would like to see something like this getting merged.  

What are your thoughts about this?  