### PR TITLE
Switch from NO_COLOR to PRE_COMMIT_COLOR environment variable

### DIFF
--- a/pre_commit/color.py
+++ b/pre_commit/color.py
@@ -48,9 +48,6 @@ def use_color(setting):
     if setting not in COLOR_CHOICES:
         raise InvalidColorSetting(setting)
 
-    if 'NO_COLOR' in os.environ:
-        return False
-
     return (
         setting == 'always' or
         (setting == 'auto' and sys.stdout.isatty() and terminal_supports_color)

--- a/pre_commit/color.py
+++ b/pre_commit/color.py
@@ -48,7 +48,7 @@ def use_color(setting):
     if setting not in COLOR_CHOICES:
         raise InvalidColorSetting(setting)
 
-    if 'NO_COLOR' in os.environ and os.environ['NO_COLOR']:
+    if 'NO_COLOR' in os.environ:
         return False
 
     return (

--- a/pre_commit/color.py
+++ b/pre_commit/color.py
@@ -48,7 +48,7 @@ def use_color(setting):
     if setting not in COLOR_CHOICES:
         raise InvalidColorSetting(setting)
 
-    if os.environ.get('NO_COLOR'):
+    if 'NO_COLOR' in os.environ and os.environ['NO_COLOR']:
         return False
 
     return (

--- a/pre_commit/main.py
+++ b/pre_commit/main.py
@@ -38,7 +38,8 @@ os.environ.pop('__PYVENV_LAUNCHER__', None)
 
 def _add_color_option(parser):
     parser.add_argument(
-        '--color', default='auto', type=color.use_color,
+        '--color', default=os.environ.get('PRE_COMMIT_COLOR', 'auto'),
+        type=color.use_color,
         metavar='{' + ','.join(color.COLOR_CHOICES) + '}',
         help='Whether to use color in output.  Defaults to `%(default)s`.',
     )

--- a/tests/color_test.py
+++ b/tests/color_test.py
@@ -54,7 +54,9 @@ def test_use_color_raises_if_given_shenanigans():
 
 
 def test_no_color_env_unset():
-    with mock.patch.dict(os.environ, clear=True):
+    with mock.patch.dict(os.environ):
+        if 'NO_COLOR' in os.environ:
+            del os.environ['NO_COLOR']
         assert use_color('always') is True
 
 

--- a/tests/color_test.py
+++ b/tests/color_test.py
@@ -1,6 +1,5 @@
 from __future__ import unicode_literals
 
-import os
 import sys
 
 import mock
@@ -51,20 +50,3 @@ def test_use_color_tty_without_color_support():
 def test_use_color_raises_if_given_shenanigans():
     with pytest.raises(InvalidColorSetting):
         use_color('herpaderp')
-
-
-def test_no_color_env_unset():
-    with mock.patch.dict(os.environ):
-        if 'NO_COLOR' in os.environ:
-            del os.environ['NO_COLOR']
-        assert use_color('always') is True
-
-
-def test_no_color_env_empty():
-    with mock.patch.dict(os.environ, NO_COLOR=''):
-        assert use_color('always') is True
-
-
-def test_no_color_env_non_empty():
-    with mock.patch.dict(os.environ, NO_COLOR=' '):
-        assert use_color('always') is False


### PR DESCRIPTION
This reverts all changes made by #1092 and replaces them by a change that simply overwrites the default value of the --color option with the value of the PRE_COMMIT_COLOR environment variable, if it is defined. As requested by @asottile in #1073.