### PR TITLE
Several fixes for init-templatedir

### DIFF
--- a/pre_commit/commands/init_templatedir.py
+++ b/pre_commit/commands/init_templatedir.py
@@ -2,6 +2,7 @@ import logging
 import os.path
 
 from pre_commit.commands.install_uninstall import install
+from pre_commit.util import CalledProcessError
 from pre_commit.util import cmd_output
 
 logger = logging.getLogger('pre_commit')
@@ -12,9 +13,14 @@ def init_templatedir(config_file, store, directory, hook_type):
         config_file, store, overwrite=True, hook_type=hook_type,
         skip_on_missing_config=True, git_dir=directory,
     )
-    _, out, _ = cmd_output('git', 'config', 'init.templateDir', retcode=None)
+    try:
+        _, out, _ = cmd_output('git', 'config', 'init.templateDir')
+    except CalledProcessError:
+        configured_path = None
+    else:
+        configured_path = os.path.realpath(out.strip())
     dest = os.path.realpath(directory)
-    if os.path.realpath(out.strip()) != dest:
+    if configured_path != dest:
         logger.warning('`init.templateDir` not set to the target directory')
         logger.warning(
             'maybe `git config --global init.templateDir {}`?'.format(dest),

--- a/pre_commit/commands/init_templatedir.py
+++ b/pre_commit/commands/init_templatedir.py
@@ -18,7 +18,7 @@ def init_templatedir(config_file, store, directory, hook_type):
     except CalledProcessError:
         configured_path = None
     else:
-        configured_path = os.path.realpath(out.strip())
+        configured_path = os.path.realpath(os.path.expanduser(out.strip()))
     dest = os.path.realpath(directory)
     if configured_path != dest:
         logger.warning('`init.templateDir` not set to the target directory')

--- a/pre_commit/main.py
+++ b/pre_commit/main.py
@@ -36,6 +36,9 @@ logger = logging.getLogger('pre_commit')
 os.environ.pop('__PYVENV_LAUNCHER__', None)
 
 
+COMMANDS_NO_GIT = {'clean', 'gc', 'init-templatedir', 'sample-config'}
+
+
 def _add_color_option(parser):
     parser.add_argument(
         '--color', default=os.environ.get('PRE_COMMIT_COLOR', 'auto'),
@@ -273,7 +276,7 @@ def main(argv=None):
         parser.parse_args(['--help'])
 
     with error_handler(), logging_handler(args.color):
-        if args.command not in {'clean', 'gc', 'sample-config'}:
+        if args.command not in COMMANDS_NO_GIT:
             _adjust_args_and_chdir(args)
 
         git.check_for_cygwin_mismatch()

--- a/tests/commands/init_templatedir_test.py
+++ b/tests/commands/init_templatedir_test.py
@@ -47,3 +47,17 @@ def test_init_templatedir_already_set(tmpdir, tempdir_factory, store, cap_out):
     lines = cap_out.get().splitlines()
     assert len(lines) == 1
     assert lines[0].startswith('pre-commit installed at')
+
+
+def test_init_templatedir_not_set(tmpdir, store, cap_out):
+    # set HOME to ignore the current `.gitconfig`
+    with envcontext([('HOME', str(tmpdir))]):
+        with tmpdir.join('tmpl').ensure_dir().as_cwd():
+            # we have not set init.templateDir so this should produce a warning
+            init_templatedir(C.CONFIG_FILE, store, '.', hook_type='pre-commit')
+
+    lines = cap_out.get().splitlines()
+    assert len(lines) == 3
+    assert lines[1] == (
+        '[WARNING] `init.templateDir` not set to the target directory'
+    )

--- a/tests/commands/init_templatedir_test.py
+++ b/tests/commands/init_templatedir_test.py
@@ -1,4 +1,7 @@
+import os.path
 import subprocess
+
+import mock
 
 import pre_commit.constants as C
 from pre_commit.commands.init_templatedir import init_templatedir
@@ -61,3 +64,18 @@ def test_init_templatedir_not_set(tmpdir, store, cap_out):
     assert lines[1] == (
         '[WARNING] `init.templateDir` not set to the target directory'
     )
+
+
+def test_init_templatedir_expanduser(tmpdir, tempdir_factory, store, cap_out):
+    target = str(tmpdir.join('tmpl'))
+    tmp_git_dir = git_dir(tempdir_factory)
+    with cwd(tmp_git_dir):
+        cmd_output('git', 'config', 'init.templateDir', '~/templatedir')
+        with mock.patch.object(os.path, 'expanduser', return_value=target):
+            init_templatedir(
+                C.CONFIG_FILE, store, target, hook_type='pre-commit',
+            )
+
+    lines = cap_out.get().splitlines()
+    assert len(lines) == 1
+    assert lines[0].startswith('pre-commit installed at')


### PR DESCRIPTION
- before this, it required a `git` repo to run, but it wasn't read at all
- before this, if the destination templatedir was at `.` and the setting was unset, pre-commit would not warn
- before this, pre-commit would not properly use `expanduser` like `git` does.  Resolves #1096 