### PR TITLE
Stabilize python default version lookup

### DIFF
--- a/pre_commit/languages/python.py
+++ b/pre_commit/languages/python.py
@@ -43,14 +43,13 @@ def _find_by_py_launcher(version):  # pragma: no cover (windows only)
             pass
 
 
-def _get_default_version():  # pragma: no cover (platform dependent)
+def _find_by_sys_executable():
     def _norm(path):
         _, exe = os.path.split(path.lower())
         exe, _, _ = exe.partition('.exe')
         if find_executable(exe) and exe not in {'python', 'pythonw'}:
             return exe
 
-    # First attempt from `sys.executable` (or the realpath)
     # On linux, I see these common sys.executables:
     #
     # system `python`: /usr/bin/python -> python2.7
@@ -59,10 +58,17 @@ def _get_default_version():  # pragma: no cover (platform dependent)
     # virtualenv v -ppython2: v/bin/python -> python2
     # virtualenv v -ppython2.7: v/bin/python -> python2.7
     # virtualenv v -ppypy: v/bin/python -> v/bin/pypy
-    for path in {sys.executable, os.path.realpath(sys.executable)}:
+    for path in (sys.executable, os.path.realpath(sys.executable)):
         exe = _norm(path)
         if exe:
             return exe
+    return None
+
+
+def _get_default_version():  # pragma: no cover (platform dependent)
+
+    # First attempt from `sys.executable` (or the realpath)
+    exe = _find_by_sys_executable()
 
     # Next try the `pythonX.X` executable
     exe = 'python{}.{}'.format(*sys.version_info)

--- a/pre_commit/languages/python.py
+++ b/pre_commit/languages/python.py
@@ -66,7 +66,6 @@ def _find_by_sys_executable():
 
 
 def _get_default_version():  # pragma: no cover (platform dependent)
-
     # First attempt from `sys.executable` (or the realpath)
     exe = _find_by_sys_executable()
 

--- a/pre_commit/languages/python.py
+++ b/pre_commit/languages/python.py
@@ -68,6 +68,8 @@ def _find_by_sys_executable():
 def _get_default_version():  # pragma: no cover (platform dependent)
     # First attempt from `sys.executable` (or the realpath)
     exe = _find_by_sys_executable()
+    if exe:
+        return exe
 
     # Next try the `pythonX.X` executable
     exe = 'python{}.{}'.format(*sys.version_info)

--- a/tests/languages/python_test.py
+++ b/tests/languages/python_test.py
@@ -44,6 +44,12 @@ def test_sys_executable_matches_does_not_match(v):
     ),
 )
 def test_find_by_sys_executable(exe, realpath, expected):
+    def mocked_find_executable(exe):
+        return exe.rpartition('/')[2]
     with mock.patch.object(sys, 'executable', exe):
         with mock.patch('os.path.realpath', return_value=realpath):
-            assert python._find_by_sys_executable() == expected
+            with mock.patch(
+                'pre_commit.parse_shebang.find_executable',
+                side_effect=mocked_find_executable,
+            ):
+                assert python._find_by_sys_executable() == expected

--- a/tests/languages/python_test.py
+++ b/tests/languages/python_test.py
@@ -32,3 +32,18 @@ def test_sys_executable_matches(v):
 def test_sys_executable_matches_does_not_match(v):
     with mock.patch.object(sys, 'version_info', (3, 6, 7)):
         assert not python._sys_executable_matches(v)
+
+
+@pytest.mark.parametrize(
+    'exe,realpath,expected', (
+        ('/usr/bin/python3', '/usr/bin/python3.7', 'python3'),
+        ('/usr/bin/python', '/usr/bin/python3.7', 'python3.7'),
+        ('/usr/bin/python', '/usr/bin/python', None),
+        ('/usr/bin/python3.6m', '/usr/bin/python3.6m', 'python3.6m'),
+        ('v/bin/python', 'v/bin/pypy', 'pypy'),
+    ),
+)
+def test_find_by_sys_executable(exe, realpath, expected):
+    with mock.patch.object(sys, 'executable', exe):
+        with mock.patch('os.path.realpath', return_value=realpath):
+            assert python._find_by_sys_executable() == expected

--- a/tests/languages/python_test.py
+++ b/tests/languages/python_test.py
@@ -7,7 +7,7 @@ import sys
 import mock
 import pytest
 
-import pre_commit.parse_shebang
+from pre_commit import parse_shebang
 from pre_commit.languages import python
 
 
@@ -50,7 +50,7 @@ def test_find_by_sys_executable(exe, realpath, expected):
     with mock.patch.object(sys, 'executable', exe):
         with mock.patch.object(os.path, 'realpath', return_value=realpath):
             with mock.patch.object(
-                pre_commit.parse_shebang, 'find_executable',
+                parse_shebang, 'find_executable',
                 side_effect=mocked_find_executable,
             ):
                 assert python._find_by_sys_executable() == expected

--- a/tests/languages/python_test.py
+++ b/tests/languages/python_test.py
@@ -7,6 +7,7 @@ import sys
 import mock
 import pytest
 
+import pre_commit.parse_shebang
 from pre_commit.languages import python
 
 
@@ -35,7 +36,7 @@ def test_sys_executable_matches_does_not_match(v):
 
 
 @pytest.mark.parametrize(
-    'exe,realpath,expected', (
+    ('exe', 'realpath', 'expected'), (
         ('/usr/bin/python3', '/usr/bin/python3.7', 'python3'),
         ('/usr/bin/python', '/usr/bin/python3.7', 'python3.7'),
         ('/usr/bin/python', '/usr/bin/python', None),
@@ -47,9 +48,9 @@ def test_find_by_sys_executable(exe, realpath, expected):
     def mocked_find_executable(exe):
         return exe.rpartition('/')[2]
     with mock.patch.object(sys, 'executable', exe):
-        with mock.patch('os.path.realpath', return_value=realpath):
-            with mock.patch(
-                'pre_commit.parse_shebang.find_executable',
+        with mock.patch.object(os.path, 'realpath', return_value=realpath):
+            with mock.patch.object(
+                pre_commit.parse_shebang, 'find_executable',
                 side_effect=mocked_find_executable,
             ):
                 assert python._find_by_sys_executable() == expected

--- a/tests/languages/python_test.py
+++ b/tests/languages/python_test.py
@@ -7,7 +7,6 @@ import sys
 import mock
 import pytest
 
-from pre_commit import parse_shebang
 from pre_commit.languages import python
 
 
@@ -45,12 +44,7 @@ def test_sys_executable_matches_does_not_match(v):
     ),
 )
 def test_find_by_sys_executable(exe, realpath, expected):
-    def mocked_find_executable(exe):
-        return exe.rpartition('/')[2]
     with mock.patch.object(sys, 'executable', exe):
         with mock.patch.object(os.path, 'realpath', return_value=realpath):
-            with mock.patch.object(
-                parse_shebang, 'find_executable',
-                side_effect=mocked_find_executable,
-            ):
+            with mock.patch.object(python, 'find_executable', lambda x: x):
                 assert python._find_by_sys_executable() == expected


### PR DESCRIPTION
For example, for sys.executable:
>   /usr/bin/python3 -> python3.7

...the default lookup may return either `python3` or `python3.7`. Make the order deterministic by iterating over tuple, not set, of candidates.