### PR TITLE
Add completions for CLI

### DIFF
--- a/pre_commit/main.py
+++ b/pre_commit/main.py
@@ -5,6 +5,8 @@ import logging
 import os
 import sys
 
+import argcomplete
+
 import pre_commit.constants as C
 from pre_commit import color
 from pre_commit import five
@@ -268,6 +270,9 @@ def main(argv=None):
     # argparse doesn't really provide a way to use a `default` subparser
     if len(argv) == 0:
         argv = ['run']
+
+    argcomplete.autocomplete(parser)
+
     args = parser.parse_args(argv)
 
     if args.command == 'help' and args.help_cmd:

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,6 +35,7 @@ install_requires =
     virtualenv>=15.2
     futures; python_version<"3.2"
     importlib-resources; python_version<"3.7"
+    argcomplete
 python_requires = >=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*
 
 [options.entry_points]


### PR DESCRIPTION
Uses[ `argcomplete`](https://github.com/kislyuk/argcomplete) to trivially add basic completions to the cli.

This allows things like:

```
$ pre-commit <TAB>
--help     -V          gc                install         run            uninstall
--version  autoupdate  help              install-hooks   sample-config
-h         clean       init-templatedir  migrate-config  try-repo
```

And
```
$ pre-commit install --hook-type <TAB>
commit-msg  pre-commit  pre-push  prepare-commit-msg
```

Which can be tab toggled through once the correct completions are registered (at least in `fish`, I didn't try other shells yet).

This is pretty basic (as might be expected from adding 2 simple lines of code!!!), it would be really nice to do a bit more, such as getting a list of the available hooks and completing `pre-commit run <TAB>` with them.

Also, at least with `click` CLIs, you should be able to get help messages showing up (in `fish` at least) which is nicer than this. Of course, this would require a rewrite of the parser code to use click...

Any opinions about this sort of functionality? 