### PR TITLE
Fix NODE_PATH on win32

### DIFF
--- a/pre_commit/languages/node.py
+++ b/pre_commit/languages/node.py
@@ -24,18 +24,20 @@ def _envdir(prefix, version):
 
 
 def get_env_patch(venv):  # pragma: windows no cover
+    lib_dir = 'lib'
     if sys.platform == 'cygwin':  # pragma: no cover
         _, win_venv, _ = cmd_output('cygpath', '-w', venv)
         install_prefix = r'{}\bin'.format(win_venv.strip())
     elif sys.platform == 'win32':  # pragma: no cover
         install_prefix = bin_dir(venv)
+        lib_dir = 'Scripts'
     else:  # pragma: windows no cover
         install_prefix = venv
     return (
         ('NODE_VIRTUAL_ENV', venv),
         ('NPM_CONFIG_PREFIX', install_prefix),
         ('npm_config_prefix', install_prefix),
-        ('NODE_PATH', os.path.join(venv, 'lib', 'node_modules')),
+        ('NODE_PATH', os.path.join(venv, lib_dir, 'node_modules')),
         ('PATH', (bin_dir(venv), os.pathsep, Var('PATH'))),
     )
 


### PR DESCRIPTION
Ran into an issue where specifying additional plugins for eslint using additional_dependencies (as suggested on https://github.com/pre-commit/mirrors-eslint) doesn't work in windows. Node would fail to find any installed plugin.

Turns out on win32 nodeenv installs modules into <venv>/Scripts/node_modules (instead  of <ven>/lib/node_modules). See https://github.com/ekalinin/nodeenv/blob/1.3.3/nodeenv.py#L745