### PR TITLE
Allow --hook-type to be specified multiple times

### DIFF
--- a/pre_commit/commands/init_templatedir.py
+++ b/pre_commit/commands/init_templatedir.py
@@ -8,10 +8,10 @@ from pre_commit.util import cmd_output
 logger = logging.getLogger('pre_commit')
 
 
-def init_templatedir(config_file, store, directory, hook_type):
+def init_templatedir(config_file, store, directory, hook_types):
     install(
-        config_file, store, overwrite=True, hook_type=hook_type,
-        skip_on_missing_config=True, git_dir=directory,
+        config_file, store, hook_types=hook_types,
+        overwrite=True, skip_on_missing_config=True, git_dir=directory,
     )
     try:
         _, out, _ = cmd_output('git', 'config', 'init.templateDir')

--- a/pre_commit/main.py
+++ b/pre_commit/main.py
@@ -60,7 +60,8 @@ def _add_hook_type_option(parser):
         '-t', '--hook-type', choices=(
             'pre-commit', 'pre-push', 'prepare-commit-msg', 'commit-msg',
         ),
-        default='pre-commit',
+        action='append',
+        dest='hook_types',
     )
 
 
@@ -120,6 +121,11 @@ def _adjust_args_and_chdir(args):
         args.files = [os.path.relpath(filename) for filename in args.files]
     if args.command == 'try-repo' and os.path.exists(args.repo):
         args.repo = os.path.relpath(args.repo)
+    if (
+            args.command in {'install', 'uninstall', 'init-templatedir'} and
+            not args.hook_types
+    ):
+        args.hook_types = ['pre-commit']
 
 
 def main(argv=None):
@@ -299,14 +305,14 @@ def main(argv=None):
         elif args.command == 'install':
             return install(
                 args.config, store,
+                hook_types=args.hook_types,
                 overwrite=args.overwrite, hooks=args.install_hooks,
-                hook_type=args.hook_type,
                 skip_on_missing_config=args.allow_missing_config,
             )
         elif args.command == 'init-templatedir':
             return init_templatedir(
-                args.config, store,
-                args.directory, hook_type=args.hook_type,
+                args.config, store, args.directory,
+                hook_types=args.hook_types,
             )
         elif args.command == 'install-hooks':
             return install_hooks(args.config, store)
@@ -319,7 +325,7 @@ def main(argv=None):
         elif args.command == 'try-repo':
             return try_repo(args)
         elif args.command == 'uninstall':
-            return uninstall(hook_type=args.hook_type)
+            return uninstall(hook_types=args.hook_types)
         else:
             raise NotImplementedError(
                 'Command {} not implemented.'.format(args.command),

--- a/tests/commands/init_templatedir_test.py
+++ b/tests/commands/init_templatedir_test.py
@@ -16,7 +16,7 @@ from testing.util import git_commit
 
 def test_init_templatedir(tmpdir, tempdir_factory, store, cap_out):
     target = str(tmpdir.join('tmpl'))
-    init_templatedir(C.CONFIG_FILE, store, target, hook_type='pre-commit')
+    init_templatedir(C.CONFIG_FILE, store, target, hook_types=['pre-commit'])
     lines = cap_out.get().splitlines()
     assert lines[0].startswith('pre-commit installed at ')
     assert lines[1] == (
@@ -45,7 +45,9 @@ def test_init_templatedir_already_set(tmpdir, tempdir_factory, store, cap_out):
     tmp_git_dir = git_dir(tempdir_factory)
     with cwd(tmp_git_dir):
         cmd_output('git', 'config', 'init.templateDir', target)
-        init_templatedir(C.CONFIG_FILE, store, target, hook_type='pre-commit')
+        init_templatedir(
+            C.CONFIG_FILE, store, target, hook_types=['pre-commit'],
+        )
 
     lines = cap_out.get().splitlines()
     assert len(lines) == 1
@@ -57,7 +59,9 @@ def test_init_templatedir_not_set(tmpdir, store, cap_out):
     with envcontext([('HOME', str(tmpdir))]):
         with tmpdir.join('tmpl').ensure_dir().as_cwd():
             # we have not set init.templateDir so this should produce a warning
-            init_templatedir(C.CONFIG_FILE, store, '.', hook_type='pre-commit')
+            init_templatedir(
+                C.CONFIG_FILE, store, '.', hook_types=['pre-commit'],
+            )
 
     lines = cap_out.get().splitlines()
     assert len(lines) == 3
@@ -73,7 +77,7 @@ def test_init_templatedir_expanduser(tmpdir, tempdir_factory, store, cap_out):
         cmd_output('git', 'config', 'init.templateDir', '~/templatedir')
         with mock.patch.object(os.path, 'expanduser', return_value=target):
             init_templatedir(
-                C.CONFIG_FILE, store, target, hook_type='pre-commit',
+                C.CONFIG_FILE, store, target, hook_types=['pre-commit'],
             )
 
     lines = cap_out.get().splitlines()

--- a/tests/commands/run_test.py
+++ b/tests/commands/run_test.py
@@ -525,7 +525,7 @@ def test_stdout_write_bug_py26(repo_with_failing_hook, store, tempdir_factory):
             config['repos'][0]['hooks'][0]['args'] = ['☃']
         stage_a_file()
 
-        install(C.CONFIG_FILE, store)
+        install(C.CONFIG_FILE, store, hook_types=['pre-commit'])
 
         # Have to use subprocess because pytest monkeypatches sys.stdout
         _, stdout, _ = git_commit(
@@ -555,7 +555,7 @@ def test_lots_of_files(store, tempdir_factory):
             open(filename, 'w').close()
 
         cmd_output('git', 'add', '.')
-        install(C.CONFIG_FILE, store)
+        install(C.CONFIG_FILE, store, hook_types=['pre-commit'])
 
         git_commit(
             fn=cmd_output_mocked_pre_commit_home,


### PR DESCRIPTION
Resolves #1139

took this opportunity to also make `hook_types` required to make the api less pre-commit-hook-specific