### PR TITLE
WIP: Added config parameter hide_skipped

### DIFF
--- a/pre_commit/clientlib.py
+++ b/pre_commit/clientlib.py
@@ -262,6 +262,7 @@ CONFIG_SCHEMA = cfgv.Map(
     ),
     cfgv.Optional('exclude', cfgv.check_regex, '^$'),
     cfgv.Optional('fail_fast', cfgv.check_bool, False),
+    cfgv.Optional('hide_skipped', cfgv.check_bool, False),
     cfgv.Optional(
         'minimum_pre_commit_version',
         cfgv.check_and(cfgv.check_string, check_min_version),
@@ -274,6 +275,7 @@ CONFIG_SCHEMA = cfgv.Map(
             'default_stages',
             'exclude',
             'fail_fast',
+            'hide_skipped',
             'minimum_pre_commit_version',
         ),
         warn_unknown_keys_root,

--- a/pre_commit/output.py
+++ b/pre_commit/output.py
@@ -67,12 +67,21 @@ def get_hook_message(
 stdout_byte_stream = getattr(sys.stdout, 'buffer', sys.stdout)
 
 
-def write(s, stream=stdout_byte_stream):
+def write(s, stream=stdout_byte_stream, cond=True):
+    if not cond:
+        return
     stream.write(five.to_bytes(s))
     stream.flush()
 
 
-def write_line(s=None, stream=stdout_byte_stream, logfile_name=None):
+def write_line(
+        s=None,
+        stream=stdout_byte_stream,
+        logfile_name=None,
+        cond=True,
+):
+    if not cond:
+        return
     output_streams = [stream]
     if logfile_name:
         ctx = open(logfile_name, 'ab')

--- a/testing/resources/all_statuses_hooks_repo/.pre-commit-hooks.yaml
+++ b/testing/resources/all_statuses_hooks_repo/.pre-commit-hooks.yaml
@@ -1,0 +1,15 @@
+-   id: passing_hook
+    name: Passing hook
+    entry: bin/hook.sh
+    args: ['0']
+    language: script
+-   id: failing_hook
+    name: Failing hook
+    entry: bin/hook.sh
+    args: ['1']
+    language: script
+-   id: skipping_hook
+    name: Skipping hook
+    entry: bin/hook.sh
+    language: script
+    files: 'no-exist-file'

--- a/testing/resources/all_statuses_hooks_repo/bin/hook.sh
+++ b/testing/resources/all_statuses_hooks_repo/bin/hook.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+echo $@
+echo 'Hello World'
+exit $1

--- a/tests/clientlib_test.py
+++ b/tests/clientlib_test.py
@@ -315,3 +315,24 @@ def test_warn_additional(schema):
         x for x in schema.items if isinstance(x, cfgv.WarnAdditionalKeys)
     ]
     assert allowed_keys == set(warn_additional.keys)
+
+
+def test_hide_skipped_passing(tmpdir, caplog):
+    f = tmpdir.join('cfg.yaml')
+    f.write(
+        'hide_skipped: True\n'
+        'repos:\n'
+        '-   repo: https://gitlab.com/pycqa/flake8\n'
+        '    rev: 3.7.7\n'
+        '    hooks:\n'
+        '    -   id: flake8\n',
+    )
+    ret_val = validate_config_main((f.strpath,))
+    assert not ret_val
+    assert caplog.record_tuples != [
+        (
+            'pre_commit',
+            logging.WARNING,
+            'Unexpected key(s) present at root: hide_skipped',
+        ),
+    ]


### PR DESCRIPTION
Fix https://github.com/pre-commit/pre-commit/issues/823 

@asottile I thing passing and failing messages are very usefull (and a little hard to hide, cause is hook's name has printed before runs, so we need clear stdout... ).

Let's just hide the `skipped` messages from output!
What I also have to do? 
1. cli arguments?
2. Env support?
3. Change https://pre-commit.com/ and other docs?

