### PR TITLE
Fix python.healthy() check with stdlib module clashes

### DIFF
--- a/pre_commit/languages/python.py
+++ b/pre_commit/languages/python.py
@@ -147,6 +147,7 @@ def py_interface(_dir, _make_venv):
             retcode, _, _ = cmd_output_b(
                 'python', '-c',
                 'import ctypes, datetime, io, os, ssl, weakref',
+                cwd='/',
                 retcode=None,
             )
         return retcode == 0

--- a/tests/languages/python_test.py
+++ b/tests/languages/python_test.py
@@ -7,7 +7,9 @@ import sys
 import mock
 import pytest
 
+import pre_commit.constants as C
 from pre_commit.languages import python
+from pre_commit.prefix import Prefix
 
 
 def test_norm_version_expanduser():
@@ -48,3 +50,11 @@ def test_find_by_sys_executable(exe, realpath, expected):
         with mock.patch.object(os.path, 'realpath', return_value=realpath):
             with mock.patch.object(python, 'find_executable', lambda x: x):
                 assert python._find_by_sys_executable() == expected
+
+
+def test_healthy_types_py_in_cwd(tmpdir):
+    with tmpdir.as_cwd():
+        # even if a `types.py` file exists, should still be healthy
+        tmpdir.join('types.py').ensure()
+        # this env doesn't actually exist (for test speed purposes)
+        assert python.healthy(Prefix(str(tmpdir)), C.DEFAULT) is True


### PR DESCRIPTION
locally someone had `types/__init__.py` which caused the `healthy()` check to continually fail and recreate. this at least pushes the problem further down into hooks where an error message will give something googleable