### PR TITLE
Added two new options that allow for file modifications

### DIFF
--- a/pre_commit/commands/run.py
+++ b/pre_commit/commands/run.py
@@ -129,7 +129,7 @@ def _run_single_hook(classifier, hook, args, skips, cols, use_color):
     diff_after = cmd_output_b('git', 'diff', '--no-ext-diff', retcode=None)
 
     file_modifications = diff_before != diff_after
-    modified_ok = args.modified_files_ok
+    modified_ok = args.modified_files_ok or args.add_modified
 
     # If the hook makes changes, fail the commit
     if not modified_ok and file_modifications:
@@ -168,6 +168,10 @@ def _run_single_hook(classifier, hook, args, skips, cols, use_color):
         if out.strip():
             output.write_line(out.strip(), logfile_name=hook.log_file)
         output.write_line()
+
+    if file_modifications and modified_ok:
+        output.write_line('Adding modified files to index\n')
+        git.add_all()
 
     return retcode
 

--- a/pre_commit/commands/run.py
+++ b/pre_commit/commands/run.py
@@ -129,15 +129,20 @@ def _run_single_hook(classifier, hook, args, skips, cols, use_color):
     diff_after = cmd_output_b('git', 'diff', '--no-ext-diff', retcode=None)
 
     file_modifications = diff_before != diff_after
+    modified_ok = args.modified_files_ok
 
     # If the hook makes changes, fail the commit
-    if file_modifications:
+    if not modified_ok and file_modifications:
         retcode = 1
 
-    if retcode:
+    if retcode and not modified_ok:
         retcode = 1
         print_color = color.RED
         pass_fail = 'Failed'
+    elif file_modifications and modified_ok:
+        retcode = 0
+        print_color = color.YELLOW
+        pass_fail = 'Edited'
     else:
         retcode = 0
         print_color = color.GREEN

--- a/pre_commit/git.py
+++ b/pre_commit/git.py
@@ -192,3 +192,8 @@ def check_for_cygwin_mismatch():
                     exe_type[is_cygwin_python], exe_type[is_cygwin_git],
                 ),
             )
+
+
+def add_all(repo='.'):
+    cmd = ('git', 'add', '.')
+    cmd_output(*cmd, cwd=repo)

--- a/pre_commit/main.py
+++ b/pre_commit/main.py
@@ -101,6 +101,13 @@ def _add_run_options(parser):
         '--show-diff-on-failure', action='store_true',
         help='When hooks fail, run `git diff` directly afterward.',
     )
+    parser.add_argument(
+        '--modified-files-ok', '-m', action='store_true',
+        default='PRE_COMMIT_MODIFIED_FILES_OK' in os.environ,
+        help="File modification by hooks won't be equated with failure. "
+             'Equivalent to setting the environment variable '
+             'PRE_COMMIT_MODIFIED_FILES_OK=true.',
+    )
     mutex_group = parser.add_mutually_exclusive_group(required=False)
     mutex_group.add_argument(
         '--all-files', '-a', action='store_true', default=False,

--- a/pre_commit/main.py
+++ b/pre_commit/main.py
@@ -108,6 +108,15 @@ def _add_run_options(parser):
              'Equivalent to setting the environment variable '
              'PRE_COMMIT_MODIFIED_FILES_OK=true.',
     )
+    parser.add_argument(
+        '--add-modified', action='store_true',
+        default='PRE_COMMIT_ADD_MODIFIED_FILES' in os.environ,
+        help='Any file modifications made by hooks will be automatically '
+             'added to the index unless any hook fails. When set, file '
+             "modification by hooks won't be equated with failure (same as if "
+             '--modified-files-ok is set). Equivalent to setting the '
+             'environment variable PRE_COMMIT_ADD_MODIFIED_FILES=true.',
+    )
     mutex_group = parser.add_mutually_exclusive_group(required=False)
     mutex_group.add_argument(
         '--all-files', '-a', action='store_true', default=False,

--- a/testing/util.py
+++ b/testing/util.py
@@ -108,6 +108,7 @@ def run_opts(
         show_diff_on_failure=False,
         commit_msg_filename='',
         modified_files_ok=False,
+        add_modified=False,
 ):
     # These are mutually exclusive
     assert not (all_files and files)
@@ -123,6 +124,7 @@ def run_opts(
         show_diff_on_failure=show_diff_on_failure,
         commit_msg_filename=commit_msg_filename,
         modified_files_ok=modified_files_ok,
+        add_modified=add_modified,
     )
 
 

--- a/testing/util.py
+++ b/testing/util.py
@@ -107,6 +107,7 @@ def run_opts(
         hook_stage='commit',
         show_diff_on_failure=False,
         commit_msg_filename='',
+        modified_files_ok=False,
 ):
     # These are mutually exclusive
     assert not (all_files and files)
@@ -121,6 +122,7 @@ def run_opts(
         hook_stage=hook_stage,
         show_diff_on_failure=show_diff_on_failure,
         commit_msg_filename=commit_msg_filename,
+        modified_files_ok=modified_files_ok,
     )
 
 


### PR DESCRIPTION
This PR introduces two new options to pre-commit that do not change the program's default behavior, but allow users to either specify command-line options or set environment variables to do two things:

1. `--modified-files-ok` / `PRE_COMMIT_MODIFIED_FILES_OK`: When specified/set, pre-commit no longer classifies it as a failure when hooks have a non-zero exit status or when hooks modify files (the former is required to accommodate the latter). What this means in practice is that when pre-commit is invoked from a `git commit` command, it will not prevent the commit from proceeding if a hook modifies a file.

2. `--add-modified-files` / `PRE_COMMIT_ADD_MODIFIED_FILES`: When specified/set, this first activates the `--modified-files-ok` option and then if any files are modified by hooks, pre-commit stages those modifications. This means that when a user invokes pre-commit as part of a `git commit` command, modifications made by hooks will be included in the commit and the commit command will be allowed to continue. The down side of activating this option is that if there are any un-staged changes (stashed by pre-commit) that conflict with the changes made by the hooks, then the stashed changes can be lost. I would welcome feedback or suggestions on how to prevent this.

The objective of this work is to make using pre-commit a more seamless experience. I recently suggested to my co-workers that we start using pre-commit, and I had one particularly grumpy co-worker strongly object based on the fact that if the hooks made modifications, he would be required to manually stage those modifications and execute `git commit` a second time. I'm hoping that many others will see value in the simplified workflow enabled by these options just like I hope my co-worker doesn't have anything else to protest about... one can dream, right?

I've added the necessary changes to the test cases to ensure these changes don't break any existing tests. I've also used these options and verified they function as expected.