### PR TITLE
Fix git reference for tags to get actual latest tag

### DIFF
--- a/pre_commit/commands/autoupdate.py
+++ b/pre_commit/commands/autoupdate.py
@@ -41,7 +41,11 @@ def _update_repo(repo_config, store, tags_only):
         git.init_repo(repo_path, repo_config['repo'])
         cmd_output_b('git', 'fetch', 'origin', 'HEAD', '--tags', cwd=repo_path)
 
-        tag_cmd = ('git', 'describe', 'FETCH_HEAD', '--tags')
+        # Get the latest tagged commit
+        latest_tag_cmd = ('git', 'rev-list', '--tags', '--max-count=1')
+        latest_tagged = cmd_output(*latest_tag_cmd, cwd=repo_path)[1].strip()
+
+        tag_cmd = ('git', 'describe', latest_tagged, '--tags')
         if tags_only:
             tag_cmd += ('--abbrev=0',)
         else:


### PR DESCRIPTION
I've been running pre-commit with the isort hook, whose pypi package is at [4.3.21](https://pypi.org/project/isort/#history), but whose latest tag is [4.3.21-2](https://github.com/timothycrosley/isort/releases), a hotfix re-release of 4.3.21.

This causes issues with pre-commit always thinking the latest commit is the other tag, when the config is set to `4.3.21`, it wants to upgrade to tag `4.3.21-2`, and when it's set to `4.3.21-2`, it wants to "upgrade" to tag `4.3.21`. This adds a git check to list the latest tag, and bases the `git describe` command on that instead of `FETCH_HEAD`, which fixes the issue for me with isort reliably.

A reproducible `.pre-commit-config.yaml`:
```yaml
repos:
  - repo: https://github.com/timothycrosley/isort
    rev: 4.3.21-2
    hooks:
      - id: isort
        additional_dependencies: ["toml"]
```