### PR TITLE
Use official GitLab cloning locations

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
     -   id: name-tests-test
     -   id: requirements-txt-fixer
     -   id: double-quote-string-fixer
--   repo: https://gitlab.com/pycqa/flake8
+-   repo: https://gitlab.com/pycqa/flake8.git
     rev: 3.7.7
     hooks:
     -   id: flake8


### PR DESCRIPTION
Avoid failure to clone repository with older versions of git by using
official cloning url (as exposed by GitLab itself in their web
interface).

References:
- https://stackoverflow.com/questions/32533379
- https://gitlab.com/gitlab-org/gitlab/issues/29629

Fixes: #1206