### PR TITLE
WIP: Add quiet mode to pre-commit run

### DIFF
--- a/pre_commit/main.py
+++ b/pre_commit/main.py
@@ -26,7 +26,6 @@ from pre_commit.logging_handler import logging_handler
 from pre_commit.store import Store
 from pre_commit.util import CalledProcessError
 
-
 logger = logging.getLogger('pre_commit')
 
 # https://github.com/pre-commit/pre-commit/issues/217
@@ -34,7 +33,6 @@ logger = logging.getLogger('pre_commit')
 # to install packages to the wrong place.  We don't want anything to deal with
 # pyvenv
 os.environ.pop('__PYVENV_LAUNCHER__', None)
-
 
 COMMANDS_NO_GIT = {'clean', 'gc', 'init-templatedir', 'sample-config'}
 
@@ -52,6 +50,13 @@ def _add_config_option(parser):
     parser.add_argument(
         '-c', '--config', default=C.CONFIG_FILE,
         help='Path to alternate config file',
+    )
+
+
+def _add_quiet_option(parser):
+    parser.add_argument(
+        '-q', '--quiet', action='store_true',
+        help='Enable quiet mode',
     )
 
 
@@ -242,6 +247,7 @@ def main(argv=None):
     _add_color_option(run_parser)
     _add_config_option(run_parser)
     _add_run_options(run_parser)
+    _add_quiet_option(run_parser)
 
     sample_config_parser = subparsers.add_parser(
         'sample-config', help='Produce a sample {} file'.format(C.CONFIG_FILE),

--- a/testing/resources/all_statuses_hooks_repo/.pre-commit-hooks.yaml
+++ b/testing/resources/all_statuses_hooks_repo/.pre-commit-hooks.yaml
@@ -1,0 +1,15 @@
+-   id: passing_hook
+    name: Passing hook
+    entry: bin/hook.sh
+    args: ['0']
+    language: script
+-   id: failing_hook
+    name: Failing hook
+    entry: bin/hook.sh
+    args: ['1']
+    language: script
+-   id: skipping_hook
+    name: Skipping hook
+    entry: bin/hook.sh
+    language: script
+    files: 'no-exist-file'

--- a/testing/resources/all_statuses_hooks_repo/bin/hook.sh
+++ b/testing/resources/all_statuses_hooks_repo/bin/hook.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+echo $@
+echo 'Hello World'
+exit $1

--- a/testing/util.py
+++ b/testing/util.py
@@ -107,6 +107,7 @@ def run_opts(
         hook_stage='commit',
         show_diff_on_failure=False,
         commit_msg_filename='',
+        quiet=False,
 ):
     # These are mutually exclusive
     assert not (all_files and files)
@@ -121,6 +122,7 @@ def run_opts(
         hook_stage=hook_stage,
         show_diff_on_failure=show_diff_on_failure,
         commit_msg_filename=commit_msg_filename,
+        quiet=quiet,
     )
 
 


### PR DESCRIPTION
Add `--quiet` flag ot `pre-commit run` to show only failing hook's messages.

TODO:
- [X] Add `--quiet` flag to `pre-commit run`
- [ ]  Introduce env variable `PRE_COMMIT_QUIET=0|1|false|true` which allow users to enable quiet mode by default in their PC
- [ ] Add option `--output-mode=[normal|quiet]` to `pre-commit install` command 
- [ ] Add docs about flag and option to https://github.com/pre-commit/pre-commit.github.io