### PR TITLE
Make verbose output less special

### DIFF
--- a/pre_commit/color.py
+++ b/pre_commit/color.py
@@ -15,6 +15,7 @@ RED = '\033[41m'
 GREEN = '\033[42m'
 YELLOW = '\033[43;30m'
 TURQUOISE = '\033[46;30m'
+SUBTLE = '\033[2m'
 NORMAL = '\033[0m'
 
 

--- a/pre_commit/xargs.py
+++ b/pre_commit/xargs.py
@@ -135,17 +135,9 @@ def xargs(cmd, varargs, **kwargs):
         results = thread_map(run_cmd_partition, partitions)
 
         for proc_retcode, proc_out, _ in results:
-            # This is *slightly* too clever so I'll explain it.
-            # First the xor boolean table:
-            #     T | F |
-            #   +-------+
-            # T | F | T |
-            # --+-------+
-            # F | T | F |
-            # --+-------+
-            # When negate is True, it has the effect of flipping the return
-            # code. Otherwise, the returncode is unchanged.
-            retcode |= bool(proc_retcode) ^ negate
+            if negate:
+                proc_retcode = not proc_retcode
+            retcode = max(retcode, proc_retcode)
             stdout += proc_out
 
     return retcode, stdout

--- a/tests/commands/run_test.py
+++ b/tests/commands/run_test.py
@@ -94,7 +94,7 @@ def test_run_all_hooks_failing(cap_out, store, repo_with_failing_hook):
         (
             b'Failing hook',
             b'Failed',
-            b'hookid: failing_hook',
+            b'hook id: failing_hook',
             b'Fail\nfoo.py\n',
         ),
         expected_ret=1,
@@ -125,14 +125,14 @@ def test_hook_that_modifies_but_returns_zero(cap_out, store, tempdir_factory):
                 # The first should fail
                 b'Failed',
                 # With a modified file (default message + the hook's output)
-                b'Files were modified by this hook. Additional output:\n\n'
+                b'- files were modified by this hook\n\n'
                 b'Modified: foo.py',
                 # The next hook should pass despite the first modifying
                 b'Passed',
                 # The next hook should fail
                 b'Failed',
                 # bar.py was modified, but provides no additional output
-                b'Files were modified by this hook.\n',
+                b'- files were modified by this hook\n',
             ),
             1,
             True,
@@ -176,7 +176,7 @@ def test_global_exclude(cap_out, store, tempdir_factory):
         ret, printed = _do_run(cap_out, store, git_path, opts)
         assert ret == 0
         # Does not contain foo.py since it was excluded
-        expected = b'hookid: bash_hook\n\nbar.py\nHello World\n\n'
+        expected = b'- hook id: bash_hook\n\nbar.py\nHello World\n\n'
         assert printed.endswith(expected)
 
 
@@ -192,7 +192,7 @@ def test_global_files(cap_out, store, tempdir_factory):
         ret, printed = _do_run(cap_out, store, git_path, opts)
         assert ret == 0
         # Does not contain foo.py since it was not included
-        expected = b'hookid: bash_hook\n\nbar.py\nHello World\n\n'
+        expected = b'- hook id: bash_hook\n\nbar.py\nHello World\n\n'
         assert printed.endswith(expected)
 
 
@@ -422,23 +422,21 @@ def test_merge_conflict_resolved(cap_out, store, in_merge_conflict):
 
 
 @pytest.mark.parametrize(
-    ('hooks', 'verbose', 'expected'),
+    ('hooks', 'expected'),
     (
-        ([], True, 80),
-        ([auto_namedtuple(id='a', name='a' * 51)], False, 81),
-        ([auto_namedtuple(id='a', name='a' * 51)], True, 85),
+        ([], 80),
+        ([auto_namedtuple(id='a', name='a' * 51)], 81),
         (
             [
                 auto_namedtuple(id='a', name='a' * 51),
                 auto_namedtuple(id='b', name='b' * 52),
             ],
-            False,
             82,
         ),
     ),
 )
-def test_compute_cols(hooks, verbose, expected):
-    assert _compute_cols(hooks, verbose) == expected
+def test_compute_cols(hooks, expected):
+    assert _compute_cols(hooks) == expected
 
 
 @pytest.mark.parametrize(
@@ -492,7 +490,7 @@ def test_hook_id_in_verbose_output(cap_out, store, repo_with_passing_hook):
     ret, printed = _do_run(
         cap_out, store, repo_with_passing_hook, run_opts(verbose=True),
     )
-    assert b'[bash_hook] Bash hook' in printed
+    assert b'- hook id: bash_hook' in printed
 
 
 def test_multiple_hooks_same_id(cap_out, store, repo_with_passing_hook):

--- a/tests/commands/try_repo_test.py
+++ b/tests/commands/try_repo_test.py
@@ -54,15 +54,17 @@ def test_try_repo_repo_only(cap_out, tempdir_factory):
         '    -   id: bash_hook3\n$',
         config,
     )
-    assert rest == (
-        '[bash_hook] Bash hook................................(no files to check)Skipped\n'  # noqa: E501
-        '[bash_hook2] Bash hook...................................................Passed\n'  # noqa: E501
-        'hookid: bash_hook2\n'
-        '\n'
-        'test-file\n'
-        '\n'
-        '[bash_hook3] Bash hook...............................(no files to check)Skipped\n'  # noqa: E501
-    )
+    assert rest == '''\
+Bash hook............................................(no files to check)Skipped
+- hook id: bash_hook
+Bash hook................................................................Passed
+- hook id: bash_hook2
+
+test-file
+
+Bash hook............................................(no files to check)Skipped
+- hook id: bash_hook3
+'''
 
 
 def test_try_repo_with_specific_hook(cap_out, tempdir_factory):
@@ -77,7 +79,10 @@ def test_try_repo_with_specific_hook(cap_out, tempdir_factory):
         '    -   id: bash_hook\n$',
         config,
     )
-    assert rest == '[bash_hook] Bash hook................................(no files to check)Skipped\n'  # noqa: E501
+    assert rest == '''\
+Bash hook............................................(no files to check)Skipped
+- hook id: bash_hook
+'''
 
 
 def test_try_repo_relative_path(cap_out, tempdir_factory):

--- a/tests/repository_test.py
+++ b/tests/repository_test.py
@@ -221,7 +221,7 @@ def test_run_a_failing_docker_hook(tempdir_factory, store):
         'docker-hook-failing',
         ['Hello World from docker'],
         mock.ANY,  # an error message about `bork` not existing
-        expected_return_code=1,
+        expected_return_code=127,
     )
 
 

--- a/tests/xargs_test.py
+++ b/tests/xargs_test.py
@@ -178,6 +178,10 @@ def test_xargs_retcode_normal():
     ret, _ = xargs.xargs(exit_cmd, ('0', '1'), _max_length=max_length)
     assert ret == 1
 
+    # takes the maximum return code
+    ret, _ = xargs.xargs(exit_cmd, ('0', '5', '1'), _max_length=max_length)
+    assert ret == 5
+
 
 def test_xargs_concurrency():
     bash_cmd = parse_shebang.normalize_cmd(('bash', '-c'))


### PR DESCRIPTION
Other side-effects of this change:
- the return code of an individual hook is shown
- the *maximum* return code is the one which is used (this should make it easier to debug for instance [this issue](https://github.com/pre-commit/pre-commit-hooks/issues/430))

### old verbose

(hard to tell here, but the old verbose changes the width of what gets rendered)

![Capture10](https://user-images.githubusercontent.com/1810591/71384441-2425ca80-2596-11ea-8efb-b5feeab97d76.PNG)

### new verbose

![Capture8](https://user-images.githubusercontent.com/1810591/71384438-238d3400-2596-11ea-8244-20dc13a589be.PNG)

### new non-verbose

![Capture9](https://user-images.githubusercontent.com/1810591/71384439-238d3400-2596-11ea-90ae-cb17f9b67e0b.PNG)

