### PR TITLE
Add GIT_SSL_CAINFO environment variable to whitelist.

### DIFF
--- a/pre_commit/git.py
+++ b/pre_commit/git.py
@@ -32,7 +32,7 @@ def no_git_env(_env=None):
     return {
         k: v for k, v in _env.items()
         if not k.startswith('GIT_') or
-        k in {'GIT_EXEC_PATH', 'GIT_SSH', 'GIT_SSH_COMMAND'}
+        k in {'GIT_EXEC_PATH', 'GIT_SSH', 'GIT_SSH_COMMAND', 'GIT_SSL_CAINFO'}
     }
 
 


### PR DESCRIPTION
This commit fixes #1253.