### PR TITLE
Allow try-repo to work on bare repositories

### DIFF
--- a/pre_commit/git.py
+++ b/pre_commit/git.py
@@ -141,7 +141,7 @@ def has_diff(*args, **kwargs):
     repo = kwargs.pop('repo', '.')
     assert not kwargs, kwargs
     cmd = ('git', 'diff', '--quiet', '--no-ext-diff') + args
-    return cmd_output_b(*cmd, cwd=repo, retcode=None)[0]
+    return cmd_output_b(*cmd, cwd=repo, retcode=None)[0] == 1
 
 
 def has_core_hookpaths_set():

--- a/tests/commands/try_repo_test.py
+++ b/tests/commands/try_repo_test.py
@@ -98,6 +98,15 @@ def test_try_repo_relative_path(cap_out, tempdir_factory):
         assert not try_repo(try_repo_opts(relative_repo, hook='bash_hook'))
 
 
+def test_try_repo_bare_repo(cap_out, tempdir_factory):
+    repo = make_repo(tempdir_factory, 'modified_file_returns_zero_repo')
+    with cwd(git_dir(tempdir_factory)):
+        _add_test_file()
+        bare_repo = os.path.join(repo, '.git')
+        # previously crashed attempting modification changes
+        assert not try_repo(try_repo_opts(bare_repo, hook='bash_hook'))
+
+
 def test_try_repo_specific_revision(cap_out, tempdir_factory):
     repo = make_repo(tempdir_factory, 'script_hooks_repo')
     ref = git.head_rev(repo)


### PR DESCRIPTION
Resolves #1258 

it's not super useful to `try-repo path/to/bare/.git` but this makes it "work" -- the modified files thing doesn't function but that's fine