### PR TITLE
fix prog arg to return correct version

### DIFF
--- a/pre_commit/main.py
+++ b/pre_commit/main.py
@@ -148,7 +148,7 @@ def _adjust_args_and_chdir(args):
 def main(argv=None):
     argv = argv if argv is not None else sys.argv[1:]
     argv = [five.to_text(arg) for arg in argv]
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(prog='pre_commit')
 
     # https://stackoverflow.com/a/8521644/812183
     parser.add_argument(

--- a/pre_commit/main.py
+++ b/pre_commit/main.py
@@ -148,7 +148,7 @@ def _adjust_args_and_chdir(args):
 def main(argv=None):
     argv = argv if argv is not None else sys.argv[1:]
     argv = [five.to_text(arg) for arg in argv]
-    parser = argparse.ArgumentParser(prog='pre_commit')
+    parser = argparse.ArgumentParser(prog='pre-commit')
 
     # https://stackoverflow.com/a/8521644/812183
     parser.add_argument(


### PR DESCRIPTION
See issue #1273 

Fixes output when running `--version`.

Before
```bash
python -m pre_commit --version
__main__.py 1.20.0
```

After
```bash
python -m pre_commit --version
pre-commit 1.21.0
```