### PR TITLE
Perl hook support

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,6 +24,11 @@ jobs:
     pre_test:
     - powershell: Write-Host "##vso[task.prependpath]$env:CONDA\Scripts"
       displayName: Add conda to PATH
+    - powershell: |
+        Write-Host "##vso[task.prependpath]C:\Strawberry\perl\bin"
+        Write-Host "##vso[task.prependpath]C:\Strawberry\perl\site\bin"
+        Write-Host "##vso[task.prependpath]C:\Strawberry\c\bin"
+      displayName: Add strawberry perl to PATH
 - template: job--python-tox.yml@asottile
   parameters:
     toxenvs: [py37]

--- a/pre_commit/languages/all.py
+++ b/pre_commit/languages/all.py
@@ -11,6 +11,7 @@ from pre_commit.languages import docker_image
 from pre_commit.languages import fail
 from pre_commit.languages import golang
 from pre_commit.languages import node
+from pre_commit.languages import perl
 from pre_commit.languages import pygrep
 from pre_commit.languages import python
 from pre_commit.languages import python_venv
@@ -45,6 +46,7 @@ languages = {
     'fail': Language(name='fail', ENVIRONMENT_DIR=fail.ENVIRONMENT_DIR, get_default_version=fail.get_default_version, healthy=fail.healthy, install_environment=fail.install_environment, run_hook=fail.run_hook),  # noqa: E501
     'golang': Language(name='golang', ENVIRONMENT_DIR=golang.ENVIRONMENT_DIR, get_default_version=golang.get_default_version, healthy=golang.healthy, install_environment=golang.install_environment, run_hook=golang.run_hook),  # noqa: E501
     'node': Language(name='node', ENVIRONMENT_DIR=node.ENVIRONMENT_DIR, get_default_version=node.get_default_version, healthy=node.healthy, install_environment=node.install_environment, run_hook=node.run_hook),  # noqa: E501
+    'perl': Language(name='perl', ENVIRONMENT_DIR=perl.ENVIRONMENT_DIR, get_default_version=perl.get_default_version, healthy=perl.healthy, install_environment=perl.install_environment, run_hook=perl.run_hook),  # noqa: E501
     'pygrep': Language(name='pygrep', ENVIRONMENT_DIR=pygrep.ENVIRONMENT_DIR, get_default_version=pygrep.get_default_version, healthy=pygrep.healthy, install_environment=pygrep.install_environment, run_hook=pygrep.run_hook),  # noqa: E501
     'python': Language(name='python', ENVIRONMENT_DIR=python.ENVIRONMENT_DIR, get_default_version=python.get_default_version, healthy=python.healthy, install_environment=python.install_environment, run_hook=python.run_hook),  # noqa: E501
     'python_venv': Language(name='python_venv', ENVIRONMENT_DIR=python_venv.ENVIRONMENT_DIR, get_default_version=python_venv.get_default_version, healthy=python_venv.healthy, install_environment=python_venv.install_environment, run_hook=python_venv.run_hook),  # noqa: E501

--- a/pre_commit/languages/perl.py
+++ b/pre_commit/languages/perl.py
@@ -1,5 +1,6 @@
 import contextlib
 import os
+import shlex
 from typing import Generator
 from typing import Sequence
 from typing import Tuple
@@ -26,11 +27,11 @@ def get_env_patch(venv: str) -> PatchesT:
     return (
         ('PATH', (os.path.join(venv, 'bin'), os.pathsep, Var('PATH'))),
         ('PERL5LIB', os.path.join(venv, 'lib', 'perl5')),
-        ('PERL_MB_OPT', f'--install_base {venv}'),
+        ('PERL_MB_OPT', f'--install_base {shlex.quote(venv)}'),
         (
             'PERL_MM_OPT', (
-                f'INSTALL_BASE={venv}'
-                ' INSTALLSITEMAN1DIR=none INSTALLSITEMAN3DIR=none'
+                f'INSTALL_BASE={shlex.quote(venv)} '
+                f'INSTALLSITEMAN1DIR=none INSTALLSITEMAN3DIR=none'
             ),
         ),
     )

--- a/pre_commit/languages/perl.py
+++ b/pre_commit/languages/perl.py
@@ -1,0 +1,66 @@
+import contextlib
+import os
+from typing import Generator
+from typing import Sequence
+from typing import Tuple
+
+from pre_commit.envcontext import envcontext
+from pre_commit.envcontext import PatchesT
+from pre_commit.envcontext import Var
+from pre_commit.hook import Hook
+from pre_commit.languages import helpers
+from pre_commit.prefix import Prefix
+from pre_commit.util import clean_path_on_failure
+
+ENVIRONMENT_DIR = 'perl_env'
+get_default_version = helpers.basic_get_default_version
+healthy = helpers.basic_healthy
+
+
+def _envdir(prefix: Prefix, version: str) -> str:
+    directory = helpers.environment_dir(ENVIRONMENT_DIR, version)
+    return prefix.path(directory)
+
+
+def get_env_patch(venv: str) -> PatchesT:
+    return (
+        ('PATH', (os.path.join(venv, 'bin'), os.pathsep, Var('PATH'))),
+        ('PERL5LIB', os.path.join(venv, 'lib', 'perl5')),
+        ('PERL_MB_OPT', f'--install_base {venv}'),
+        (
+            'PERL_MM_OPT', (
+                f'INSTALL_BASE={venv}'
+                ' INSTALLSITEMAN1DIR=none INSTALLSITEMAN3DIR=none'
+            ),
+        ),
+    )
+
+
+@contextlib.contextmanager
+def in_env(
+        prefix: Prefix,
+        language_version: str,
+) -> Generator[None, None, None]:
+    with envcontext(get_env_patch(_envdir(prefix, language_version))):
+        yield
+
+
+def install_environment(
+        prefix: Prefix, version: str, additional_dependencies: Sequence[str],
+) -> None:
+    helpers.assert_version_default('perl', version)
+
+    with clean_path_on_failure(_envdir(prefix, version)):
+        with in_env(prefix, version):
+            helpers.run_setup_cmd(
+                prefix, ('cpan', '-T', '.', *additional_dependencies),
+            )
+
+
+def run_hook(
+        hook: 'Hook',
+        file_args: Sequence[str],
+        color: bool,
+) -> Tuple[int, bytes]:
+    with in_env(hook.prefix, hook.language_version):
+        return helpers.run_xargs(hook, hook.cmd, file_args, color=color)

--- a/pre_commit/resources/empty_template_Makefile.PL
+++ b/pre_commit/resources/empty_template_Makefile.PL
@@ -1,0 +1,6 @@
+use ExtUtils::MakeMaker;
+
+WriteMakefile(
+    NAME => "PreCommitDummy",
+    VERSION => "0.0.1",
+);

--- a/pre_commit/store.py
+++ b/pre_commit/store.py
@@ -184,6 +184,7 @@ class Store:
     LOCAL_RESOURCES = (
         'Cargo.toml', 'main.go', 'main.rs', '.npmignore', 'package.json',
         'pre_commit_dummy_package.gemspec', 'setup.py', 'environment.yml',
+        'Makefile.PL',
     )
 
     def make_local(self, deps: Sequence[str]) -> str:

--- a/testing/gen-languages-all
+++ b/testing/gen-languages-all
@@ -2,8 +2,9 @@
 import sys
 
 LANGUAGES = [
-    'conda', 'docker', 'docker_image', 'fail', 'golang', 'node', 'pygrep',
-    'python', 'python_venv', 'ruby', 'rust', 'script', 'swift', 'system',
+    'conda', 'docker', 'docker_image', 'fail', 'golang', 'node', 'perl',
+    'pygrep', 'python', 'python_venv', 'ruby', 'rust', 'script', 'swift',
+    'system',
 ]
 FIELDS = [
     'ENVIRONMENT_DIR', 'get_default_version', 'healthy', 'install_environment',

--- a/testing/resources/perl_hooks_repo/.gitignore
+++ b/testing/resources/perl_hooks_repo/.gitignore
@@ -1,0 +1,7 @@
+/MYMETA.json
+/MYMETA.yml
+/Makefile
+/PreCommitHello-*.tar.*
+/PreCommitHello-*/
+/blib/
+/pm_to_blib

--- a/testing/resources/perl_hooks_repo/.pre-commit-hooks.yaml
+++ b/testing/resources/perl_hooks_repo/.pre-commit-hooks.yaml
@@ -1,0 +1,5 @@
+-   id: perl-hook
+    name: perl example hook
+    entry: pre-commit-perl-hello
+    language: perl
+    files: ''

--- a/testing/resources/perl_hooks_repo/MANIFEST
+++ b/testing/resources/perl_hooks_repo/MANIFEST
@@ -1,0 +1,4 @@
+MANIFEST
+Makefile.PL
+bin/pre-commit-perl-hello
+lib/PreCommitHello.pm

--- a/testing/resources/perl_hooks_repo/Makefile.PL
+++ b/testing/resources/perl_hooks_repo/Makefile.PL
@@ -1,0 +1,10 @@
+use strict;
+use warnings;
+
+use ExtUtils::MakeMaker;
+
+WriteMakefile(
+    NAME => "PreCommitHello",
+    VERSION_FROM => "lib/PreCommitHello.pm",
+    EXE_FILES => [qw(bin/pre-commit-perl-hello)],
+);

--- a/testing/resources/perl_hooks_repo/bin/pre-commit-perl-hello
+++ b/testing/resources/perl_hooks_repo/bin/pre-commit-perl-hello
@@ -1,0 +1,7 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use PreCommitHello;
+
+PreCommitHello::hello();

--- a/testing/resources/perl_hooks_repo/lib/PreCommitHello.pm
+++ b/testing/resources/perl_hooks_repo/lib/PreCommitHello.pm
@@ -1,0 +1,12 @@
+package PreCommitHello;
+
+use strict;
+use warnings;
+
+our $VERSION = "0.1.0";
+
+sub hello {
+    print "Hello from perl-commit Perl!\n";
+}
+
+1;

--- a/tests/repository_test.py
+++ b/tests/repository_test.py
@@ -883,3 +883,20 @@ def test_perl_hook(tempdir_factory, store):
         tempdir_factory, store, 'perl_hooks_repo',
         'perl-hook', [], b'Hello from perl-commit Perl!\n',
     )
+
+
+def test_local_perl_additional_dependencies(store):
+    config = {
+        'repo': 'local',
+        'hooks': [{
+            'id': 'hello',
+            'name': 'hello',
+            'entry': 'perltidy --version',
+            'language': 'perl',
+            'additional_dependencies': ['SHANCOCK/Perl-Tidy-20200110.tar.gz'],
+        }],
+    }
+    hook = _get_hook(config, store, 'hello')
+    ret, out = _hook_run(hook, (), color=False)
+    assert ret == 0
+    assert _norm_out(out).startswith(b'This is perltidy, v20200110')

--- a/tests/repository_test.py
+++ b/tests/repository_test.py
@@ -876,3 +876,10 @@ def test_manifest_hooks(tempdir_factory, store):
         types=['file'],
         verbose=False,
     )
+
+
+def test_perl_hook(tempdir_factory, store):
+    _test_hook_repo(
+        tempdir_factory, store, 'perl_hooks_repo',
+        'perl-hook', [], b'Hello from perl-commit Perl!\n',
+    )


### PR DESCRIPTION
Here's a first cut for supporting Perl hooks. Appears to work for me with this .pre-commit-hooks.yaml locally added to a https://github.com/perltidy/perltidy clone + the usual config to use it elsewhere:
```yaml
- id: perltidy
  name: perltidy
  entry: perltidy --nostandard-output --backup-and-modify-in-place
  language: perl
  types: [perl]
```
No tests yet, haven't taken a look what it would take to add some. Throwing this here for comments already anyway.