### PR TITLE
Activate conda environment in pre-commit hook.

### DIFF
--- a/pre_commit/main.py
+++ b/pre_commit/main.py
@@ -250,6 +250,13 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
             'or exit with a failure code.'
         ),
     )
+    install_parser.add_argument(
+        '--hooks-activate-conda', action='store_true', default=False,
+        help=(
+            'Whether to activate conda environment before calling pre-commit'
+            'within hooks.'
+        ),
+    )
 
     install_hooks_parser = subparsers.add_parser(
         'install-hooks',
@@ -357,6 +364,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
                 overwrite=args.overwrite,
                 hooks=args.install_hooks,
                 skip_on_missing_config=args.allow_missing_config,
+                hooks_activate_conda=args.hooks_activate_conda,
             )
         elif args.command == 'init-templatedir':
             return init_templatedir(

--- a/pre_commit/resources/hook-tmpl
+++ b/pre_commit/resources/hook-tmpl
@@ -18,6 +18,8 @@ os.environ.pop('__PYVENV_LAUNCHER__', None)
 
 # start templated
 INSTALL_PYTHON = ''
+INSTALL_CONDA = ''
+INSTALL_CONDA_PREFIX = ''
 ARGS = ['hook-impl']
 # end templated
 ARGS.extend(('--hook-dir', os.path.realpath(os.path.dirname(__file__))))
@@ -25,7 +27,9 @@ ARGS.append('--')
 ARGS.extend(sys.argv[1:])
 
 DNE = '`pre-commit` not found.  Did you forget to activate your virtualenv?'
-if os.access(INSTALL_PYTHON, os.X_OK):
+if os.access(INSTALL_CONDA, os.X_OK):
+    CMD = [INSTALL_CONDA, 'run', '-p', INSTALL_CONDA_PREFIX, 'pre-commit']
+elif os.access(INSTALL_PYTHON, os.X_OK):
     CMD = [INSTALL_PYTHON, '-mpre_commit']
 elif which('pre-commit'):
     CMD = ['pre-commit']


### PR DESCRIPTION
Save conda environment that was active during conda install when using
option --hooks-activate-conda. The saved environment will be activated
before calling pre-commit hooks.

Especially on Windows, more and more actions within a conda environment
require the conda environment to be activated. Thus saving just the
python executable is not enough any more.

There is currently one downside of using the option
--hooks-activate-conda. It uses "conda run" which will only show
console output after the run is completed. We have a pull request to
conda open which introduces an option to show interactive console
output in conda run. Once this is approved, it might be ok to make this
option the default behaviour.