### PR TITLE
Add pre-commit badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![Build Status](https://dev.azure.com/asottile/asottile/_apis/build/status/pre-commit.pre-commit?branchName=master)](https://dev.azure.com/asottile/asottile/_build/latest?definitionId=21&branchName=master)
 [![Azure DevOps coverage](https://img.shields.io/azure-devops/coverage/asottile/asottile/21/master.svg)](https://dev.azure.com/asottile/asottile/_build/latest?definitionId=21&branchName=master)
+[![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)
 
 ## pre-commit
 


### PR DESCRIPTION
Since I like pretty badges, I decided to request your logo be added to simple-icons (https://github.com/simple-icons/simple-icons/issues/2475) for use with shields.io.

Since I think badges are a perfect way to promote technologies and provide insights, I wanted [your badge to shine](https://github.com/ddelange/pipgrip#development) as well. Having it in your README will maybe also inspire other devs to adopt it and spread the word!

I'm also interested in other wordings than `enabled` or `available`, maybe you have a nice idea?