### PR TITLE
Add post-checkout

### DIFF
--- a/pre_commit/commands/hook_impl.py
+++ b/pre_commit/commands/hook_impl.py
@@ -74,6 +74,7 @@ def _ns(
         remote_name: Optional[str] = None,
         remote_url: Optional[str] = None,
         commit_msg_filename: Optional[str] = None,
+        checkout_type: Optional[str] = None,
 ) -> argparse.Namespace:
     return argparse.Namespace(
         color=color,
@@ -84,6 +85,7 @@ def _ns(
         remote_url=remote_url,
         commit_msg_filename=commit_msg_filename,
         all_files=all_files,
+        checkout_type=checkout_type,
         files=(),
         hook=None,
         verbose=False,
@@ -157,6 +159,11 @@ def _run_ns(
         return _ns(hook_type, color, commit_msg_filename=args[0])
     elif hook_type in {'pre-merge-commit', 'pre-commit'}:
         return _ns(hook_type, color)
+    elif hook_type == 'post-checkout':
+        return _ns(
+            hook_type, color, source=args[0], origin=args[1],
+            checkout_type=args[2],
+        )
     else:
         raise AssertionError(f'unexpected hook type: {hook_type}')
 

--- a/pre_commit/commands/run.py
+++ b/pre_commit/commands/run.py
@@ -316,6 +316,9 @@ def run(
         environ['PRE_COMMIT_REMOTE_NAME'] = args.remote_name
         environ['PRE_COMMIT_REMOTE_URL'] = args.remote_url
 
+    if args.checkout_type:
+        environ['PRE_COMMIT_CHECKOUT_TYPE'] = args.checkout_type
+
     with contextlib.ExitStack() as exit_stack:
         if stash:
             exit_stack.enter_context(staged_files_only(store.directory))

--- a/pre_commit/constants.py
+++ b/pre_commit/constants.py
@@ -18,7 +18,7 @@ VERSION = importlib_metadata.version('pre_commit')
 # `manual` is not invoked by any installed git hook.  See #719
 STAGES = (
     'commit', 'merge-commit', 'prepare-commit-msg', 'commit-msg', 'manual',
-    'push',
+    'post-checkout', 'push',
 )
 
 DEFAULT = 'default'

--- a/pre_commit/main.py
+++ b/pre_commit/main.py
@@ -79,7 +79,7 @@ def _add_hook_type_option(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         '-t', '--hook-type', choices=(
             'pre-commit', 'pre-merge-commit', 'pre-push',
-            'prepare-commit-msg', 'commit-msg',
+            'prepare-commit-msg', 'commit-msg', 'post-checkout',
         ),
         action=AppendReplaceDefault,
         default=['pre-commit'],
@@ -92,11 +92,17 @@ def _add_run_options(parser: argparse.ArgumentParser) -> None:
     parser.add_argument('--verbose', '-v', action='store_true', default=False)
     parser.add_argument(
         '--origin', '-o',
-        help="The origin branch's commit_id when using `git push`.",
+        help=(
+            "The origin branch's commit_id when using `git push`.  "
+            'The ref of the previous HEAD when using `git checkout`.'
+        ),
     )
     parser.add_argument(
         '--source', '-s',
-        help="The remote branch's commit_id when using `git push`.",
+        help=(
+            "The remote branch's commit_id when using `git push`.  "
+            'The ref of the new HEAD when using `git checkout`.'
+        ),
     )
     parser.add_argument(
         '--commit-msg-filename',
@@ -122,6 +128,14 @@ def _add_run_options(parser: argparse.ArgumentParser) -> None:
     mutex_group.add_argument(
         '--files', nargs='*', default=[],
         help='Specific filenames to run hooks on.',
+    )
+    parser.add_argument(
+        '--checkout-type',
+        help=(
+            'Indicates whether the checkout was a branch checkout '
+            '(changing branches, flag=1) or a file checkout (retrieving a '
+            'file from the index, flag=0).'
+        ),
     )
 
 

--- a/testing/util.py
+++ b/testing/util.py
@@ -72,6 +72,7 @@ def run_opts(
         hook_stage='commit',
         show_diff_on_failure=False,
         commit_msg_filename='',
+        checkout_type='',
 ):
     # These are mutually exclusive
     assert not (all_files and files)
@@ -88,6 +89,7 @@ def run_opts(
         hook_stage=hook_stage,
         show_diff_on_failure=show_diff_on_failure,
         commit_msg_filename=commit_msg_filename,
+        checkout_type=checkout_type,
     )
 
 

--- a/tests/commands/hook_impl_test.py
+++ b/tests/commands/hook_impl_test.py
@@ -104,6 +104,16 @@ def test_run_ns_commit_msg():
     assert ns.commit_msg_filename == '.git/COMMIT_MSG'
 
 
+def test_run_ns_post_checkout():
+    ns = hook_impl._run_ns('post-checkout', True, ('a', 'b', 'c'), b'')
+    assert ns is not None
+    assert ns.hook_stage == 'post-checkout'
+    assert ns.color is True
+    assert ns.source == 'a'
+    assert ns.origin == 'b'
+    assert ns.checkout_type == 'c'
+
+
 @pytest.fixture
 def push_example(tempdir_factory):
     src = git_dir(tempdir_factory)

--- a/tests/commands/run_test.py
+++ b/tests/commands/run_test.py
@@ -18,6 +18,7 @@ from pre_commit.commands.run import Classifier
 from pre_commit.commands.run import filter_by_include_exclude
 from pre_commit.commands.run import run
 from pre_commit.util import cmd_output
+from pre_commit.util import EnvironT
 from pre_commit.util import make_executable
 from testing.auto_namedtuple import auto_namedtuple
 from testing.fixtures import add_config_to_repo
@@ -464,6 +465,15 @@ def test_all_push_options_ok(cap_out, store, repo_with_passing_hook):
     ret, printed = _do_run(cap_out, store, repo_with_passing_hook, args)
     assert ret == 0
     assert b'Specify both --origin and --source.' not in printed
+
+
+def test_checkout_type(cap_out, store, repo_with_passing_hook):
+    args = run_opts(origin='', source='', checkout_type='1')
+    environ: EnvironT = {}
+    ret, printed = _do_run(
+        cap_out, store, repo_with_passing_hook, args, environ,
+    )
+    assert environ['PRE_COMMIT_CHECKOUT_TYPE'] == '1'
 
 
 def test_has_unmerged_paths(in_merge_conflict):

--- a/tests/repository_test.py
+++ b/tests/repository_test.py
@@ -871,7 +871,7 @@ def test_manifest_hooks(tempdir_factory, store):
         require_serial=False,
         stages=(
             'commit', 'merge-commit', 'prepare-commit-msg', 'commit-msg',
-            'manual', 'push',
+            'manual', 'post-checkout', 'push',
         ),
         types=['file'],
         verbose=False,


### PR DESCRIPTION
This adds support for the `post-checkout` hook.

Fixes: https://github.com/pre-commit/pre-commit/issues/1120
Documentation PR: https://github.com/pre-commit/pre-commit.github.io/pull/307

One thing I would still like to do, if possible, would be to force hooks like this to always have `always_run` be set since that is somewhat implied by the nature of the hook (since it doesn't operate on files).