### PR TITLE
Don't crash on un-stringable exceptions

### DIFF
--- a/tests/error_handler_test.py
+++ b/tests/error_handler_test.py
@@ -6,6 +6,7 @@ from unittest import mock
 import pytest
 
 from pre_commit import error_handler
+from pre_commit.util import CalledProcessError
 from testing.util import cmd_output_mocked_pre_commit_home
 
 
@@ -133,6 +134,22 @@ def test_error_handler_non_ascii_exception(mock_store_dir):
     with pytest.raises(SystemExit):
         with error_handler.error_handler():
             raise ValueError('☃')
+
+
+def test_error_handler_non_utf8_exception(mock_store_dir):
+    with pytest.raises(SystemExit):
+        with error_handler.error_handler():
+            raise CalledProcessError(1, ('exe',), 0, b'error: \xa0\xe1', b'')
+
+
+def test_error_handler_non_stringable_exception(mock_store_dir):
+    class C(Exception):
+        def __str__(self):
+            raise RuntimeError('not today!')
+
+    with pytest.raises(SystemExit):
+        with error_handler.error_handler():
+            raise C()
 
 
 def test_error_handler_no_tty(tempdir_factory):


### PR DESCRIPTION
Resolves #1358

I was able to reproduce and then fix the crash -- also fixed arbitrary errors in `__str__` though I think those are nearly impossible

(the output below was retrieved by intentionally breaking `virtualenv.py` to print some garbage and then crash)

```console
$ pre-commit run flake8 --all-files
[INFO] Initializing environment for https://gitlab.com/pycqa/flake8:astpretty==1,flake8-typing-imports==1.6.0.
[INFO] Installing environment for https://gitlab.com/pycqa/flake8.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
An unexpected error has occurred: CalledProcessError: command: ('/home/asottile/workspace/pre-commit/venv/bin/python3', '-mvirtualenv', '/home/asottile/.cache/pre-commit/repo0gp5o4dq/py_env-python3', '-p', '/home/asottile/workspace/pre-commit/venv/bin/python3')
return code: 1
expected return code: 0
stdout:
    ��
stderr: (none)
Check the log at /home/asottile/.cache/pre-commit/pre-commit.log
```