### PR TITLE
Fix test failure of test_installed_from_venv when running with pytest-runner

### DIFF
--- a/tests/commands/install_uninstall_test.py
+++ b/tests/commands/install_uninstall_test.py
@@ -530,6 +530,8 @@ def test_installed_from_venv(tempdir_factory, store):
                 'GIT_COMMITTER_NAME': os.environ['GIT_COMMITTER_NAME'],
                 'GIT_AUTHOR_EMAIL': os.environ['GIT_AUTHOR_EMAIL'],
                 'GIT_COMMITTER_EMAIL': os.environ['GIT_COMMITTER_EMAIL'],
+                # Pass PYTHONPATH to support running tests using pytest-runner
+                'PYTHONPATH': os.environ.get('PYTHONPATH', ''),
             },
         )
         assert ret == 0


### PR DESCRIPTION
Passing PYTHONPATH here fixes the module not found error when running with pytest-runner without pre-commit installed first.