### PR TITLE
Don't use --user when running docker on windows

### DIFF
--- a/pre_commit/languages/docker.py
+++ b/pre_commit/languages/docker.py
@@ -76,18 +76,18 @@ def install_environment(
         os.mkdir(directory)
 
 
-def get_docker_user() -> str:  # pragma: win32 no cover
+def get_docker_user() -> Tuple[str, ...]:  # pragma: win32 no cover
     try:
-        return f'{os.getuid()}:{os.getgid()}'
+        return ('-u', f'{os.getuid()}:{os.getgid()}')
     except AttributeError:
-        return '1000:1000'
+        return ()
 
 
 def docker_cmd() -> Tuple[str, ...]:  # pragma: win32 no cover
     return (
         'docker', 'run',
         '--rm',
-        '-u', get_docker_user(),
+        *get_docker_user(),
         # https://docs.docker.com/engine/reference/commandline/run/#mount-volumes-from-container-volumes-from
         # The `Z` option tells Docker to label the content with a private
         # unshared label. Only the current container can use a private volume.

--- a/tests/languages/docker_test.py
+++ b/tests/languages/docker_test.py
@@ -20,4 +20,4 @@ def test_docker_fallback_user():
         getuid=invalid_attribute,
         getgid=invalid_attribute,
     ):
-        assert docker.get_docker_user() == '1000:1000'
+        assert docker.get_docker_user() == ()


### PR DESCRIPTION
Previous PR https://github.com/pre-commit/pre-commit/pull/1094 hard code the docker user to `1000:1000` on Windows platform. This is a fragile assumption since not all docker image would have user 1000 configured inside of the container.

Instead, we don't use docker user on Windows to allow it to use the default user defined on the image.