### PR TITLE
Remove virtualenv dependency.

### DIFF
--- a/pre_commit/languages/python.py
+++ b/pre_commit/languages/python.py
@@ -202,7 +202,7 @@ def py_interface(
 
 def make_venv(envdir: str, python: str) -> None:
     env = dict(os.environ, VIRTUALENV_NO_DOWNLOAD='1')
-    cmd = (sys.executable, '-mvirtualenv', envdir, '-p', python)
+    cmd = (sys.executable, '-mvenv', envdir)
     cmd_output_b(*cmd, env=env, cwd='/')
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,6 @@ install_requires =
     nodeenv>=0.11.1
     pyyaml>=5.1
     toml
-    virtualenv>=15.2
     importlib-metadata;python_version<"3.8"
     importlib-resources;python_version<"3.7"
 python_requires = >=3.6.1


### PR DESCRIPTION
Hi there, 
First of all, thank you for all your hard work building and maintaining this package. It's already been a tremendous help to my workflow. 

I might be missing something, but from my understanding of the code, it seems like all the virtualenv functionalities being used by pre-commit are already taken care of by venv. Venv has been a core Python module [since v3.3](https://docs.python.org/3/library/venv.html), which means it's safe to assume in this project  (whose minimum version is 3.6 and  Python 2 is no longer supported).


With all that in mind, is there a specific reason for keeping the virtualenv dependency around around? If not, can it be removed?

### Advantages 

- Smaller package size (potentially?)

- One less dependency to be managed, which is great for those of us using less package managers like Nix. 


### Disadvantages 

- None that occur to me immediately (happy to hear otherwise!) 


## Testing 

To test, I ran the test suite on Mac OS X (10.14.6) and Windows 10. 

```bash
pre-commit run --all-files --show-diff-on-failure
```

### Mac OS 

- Success 

<img width="1246" alt="Screen Shot 2020-03-31 at 10 42 30 PM" src="https://user-images.githubusercontent.com/14322653/78105016-0c37c100-73a5-11ea-8de4-cb86c0d6217a.png">

### Windows 10

- All hooks pass except MyPy. 

- However
  - The files that are failing are unchanged in this commit 
  - This MyPy check seems to fail in master as well (proof in screenshot)

<img width="1076" alt="Screen Shot 2020-03-31 at 10 17 27 PM" src="https://user-images.githubusercontent.com/14322653/78105052-22de1800-73a5-11ea-8a90-9ed03c028966.png">


<img width="972" alt="Screen Shot 2020-03-31 at 11 10 10 PM" src="https://user-images.githubusercontent.com/14322653/78105023-0e018480-73a5-11ea-99a4-de4020dc769c.png">
