### PR TITLE
Allow local config only hooks

### DIFF
--- a/pre_commit/clientlib.py
+++ b/pre_commit/clientlib.py
@@ -5,8 +5,10 @@ import shlex
 import sys
 from typing import Any
 from typing import Dict
+from typing import Mapping
 from typing import Optional
 from typing import Sequence
+from typing import TypeVar
 
 import cfgv
 from identify.identify import ALL_TAGS
@@ -87,6 +89,18 @@ load_manifest = functools.partial(
     load_strategy=yaml_load,
     exc_tp=InvalidManifestError,
 )
+
+
+HOOK_CONFIG_T = TypeVar('HOOK_CONFIG_T', bound=Mapping[str, Any])
+
+
+def validate_manifest(data: HOOK_CONFIG_T) -> HOOK_CONFIG_T:
+    return cfgv.validate(data, MANIFEST_SCHEMA)
+
+
+def apply_manifest_defaults(data: Sequence[HOOK_CONFIG_T]) \
+        -> Sequence[HOOK_CONFIG_T]:
+    return cfgv.apply_defaults(data, MANIFEST_SCHEMA)
 
 
 def validate_manifest_main(argv: Optional[Sequence[str]] = None) -> int:


### PR DESCRIPTION
Some authors of very useful tools are reluctant to add and host .pre-commit-hooks.yml to their repos for various reasons.

As we can already override everything in local configs anyway, we could actually operate solely on local configs. This way, no .pre-commit-hooks.yaml is needed in a target repo. I think making this possible would be very valuable.

This is more or less a PoC in its current state; I haven't dug deeper to look for dragons, and docs and some polishing are required (the access to cfgv might be  bit icky the way it is now, and we print the "Proceeding with local configs" info all the time when it could do so only on install/update), but in its current form I can for example Just Use shfmt with this:
```yaml
  - repo: https://github.com/mvdan/sh
    rev: v3.1.0
    hooks:
      - id: shfmt
        name: shfmt
        language: golang
        entry: shfmt
        args: [-w]
        types: [shell]
```
...and perlcritic with:
```yaml
  - repo: https://github.com/Perl-Critic/Perl-Critic
    rev: v1.138
    hooks:
      - id: perlcritic
        name: perlcritic
        language: perl
        entry: perlcritic
        args: [--quiet, --verbose, "5"]
        types: [perl]
```
...in my .pre-commit-config.yaml even though the target repos have no .pre-commit-hooks.yaml at all.