### PR TITLE
Add dummy go.mod for local "empty" installs

### DIFF
--- a/pre_commit/store.py
+++ b/pre_commit/store.py
@@ -182,9 +182,9 @@ class Store:
         return self._new_repo(repo, ref, deps, clone_strategy)
 
     LOCAL_RESOURCES = (
-        'Cargo.toml', 'main.go', 'main.rs', '.npmignore', 'package.json',
-        'pre_commit_dummy_package.gemspec', 'setup.py', 'environment.yml',
-        'Makefile.PL',
+        'Cargo.toml', 'main.go', 'go.mod', 'main.rs', '.npmignore',
+        'package.json', 'pre_commit_dummy_package.gemspec', 'setup.py',
+        'environment.yml', 'Makefile.PL',
     )
 
     def make_local(self, deps: Sequence[str]) -> str:


### PR DESCRIPTION
Empty local golang installs seem to fail when trying to use go modules in additional_dependencies. Test config:
```yaml
repos:
  - repo: local
    hooks:
      - id: shfmt
        name: shfmt
        language: golang
        additional_dependencies: [mvdan.cc/sh/v3/cmd/shfmt]
        entry: shfmt
        args: [-w]
        types: [shell]
      - id: misspell
        name: misspell
        language: golang
        additional_dependencies: [github.com/client9/misspell/cmd/misspell]
        entry: misspell
        args: [-error]
        types: [text]
```

misspell is there just to represent something that's not a go module, and to see this change didn't break it (it didn't).

With pre-commit 2.3.0 shfmt setup fails for me with golang 1.12, 1.13, and 1.14 with:
```
An unexpected error has occurred: CalledProcessError: command: ('/usr/bin/go', 'get', 'mvdan.cc/sh/v3/cmd/shfmt')
return code: 1
expected return code: 0
stdout: (none)
stderr:
    package mvdan.cc/sh/v3/cmd/shfmt: cannot find package "mvdan.cc/sh/v3/cmd/shfmt" in any of:
    	/usr/lib/go-1.14/src/mvdan.cc/sh/v3/cmd/shfmt (from $GOROOT)
    	/home/scop/.cache/pre-commit/repoetpe3oez/golangenv-default/src/mvdan.cc/sh/v3/cmd/shfmt (from $GOPATH)
```

After this change, it works out of the box for me with go 1.13 and 1.14. For 1.12 this isn't enough, it would additionally need `GO111MODULE=on` in the environment, after that it'd work too. I left it out of this PR because I'm not quite sure if it would cause problems with some "conventional" installs pointed to upstream repos that provide a hook config. For this particular test it would not cause any problems with 1.13 or 1.14 though.