### PR TITLE
Force version of importlib-resources

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ install_requires =
     toml
     virtualenv>=20.0.8
     importlib-metadata;python_version<"3.8"
-    importlib-resources;python_version<"3.7"
+    importlib-resources==1.5.0;python_version<"3.7"
 python_requires = >=3.6.1
 
 [options.entry_points]


### PR DESCRIPTION
As virtualenv needs a version of importlib older than 2.0.0, the importlib-resources version has been forced to 1.5.0.
