### PR TITLE
Make the unstagged changes patch filename easier to understand

### DIFF
--- a/pre_commit/git.py
+++ b/pre_commit/git.py
@@ -42,6 +42,10 @@ def no_git_env(_env: Optional[EnvironT] = None) -> Dict[str, str]:
     }
 
 
+def get_basename() -> str:
+    return cmd_output('basename', get_root())[1].strip()
+
+
 def get_root() -> str:
     return cmd_output('git', 'rev-parse', '--show-toplevel')[1].strip()
 

--- a/pre_commit/staged_files_only.py
+++ b/pre_commit/staged_files_only.py
@@ -47,7 +47,8 @@ def _unstaged_changes_cleared(patch_dir: str) -> Generator[None, None, None]:
         retcode=None,
     )
     if retcode and diff_stdout_binary.strip():
-        patch_filename = f'patch{int(time.time())}'
+        strftime = time.strftime('%Y-%m-%d-%H-%M-%S', time.gmtime())
+        patch_filename = f'patch-{git.get_basename()}-{strftime}'
         patch_filename = os.path.join(patch_dir, patch_filename)
         logger.warning('Unstaged files detected.')
         logger.info(f'Stashing unstaged files to {patch_filename}.')


### PR DESCRIPTION
By having the basename of the repository directory and a
human readable time in the filename.

Instead of having something like this:
```
[WARNING] Unstaged files detected.
[INFO] Stashing unstaged files to /home/asottile/.cache/pre-commit/patch1591945458.
```

We'll now have something like this:
```
[WARNING] Unstaged files detected.
[INFO] Stashing unstaged files to /home/pierre/.cache/pre-commit/patch-myproject-2020-06-12-11-37-48.
```