### PR TITLE
add initial dotnet support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /.tox
 /dist
 /venv*
+.vscode/

--- a/pre_commit/languages/all.py
+++ b/pre_commit/languages/all.py
@@ -8,6 +8,7 @@ from pre_commit.hook import Hook
 from pre_commit.languages import conda
 from pre_commit.languages import docker
 from pre_commit.languages import docker_image
+from pre_commit.languages import dotnet
 from pre_commit.languages import fail
 from pre_commit.languages import golang
 from pre_commit.languages import node
@@ -42,6 +43,7 @@ languages = {
     'conda': Language(name='conda', ENVIRONMENT_DIR=conda.ENVIRONMENT_DIR, get_default_version=conda.get_default_version, healthy=conda.healthy, install_environment=conda.install_environment, run_hook=conda.run_hook),  # noqa: E501
     'docker': Language(name='docker', ENVIRONMENT_DIR=docker.ENVIRONMENT_DIR, get_default_version=docker.get_default_version, healthy=docker.healthy, install_environment=docker.install_environment, run_hook=docker.run_hook),  # noqa: E501
     'docker_image': Language(name='docker_image', ENVIRONMENT_DIR=docker_image.ENVIRONMENT_DIR, get_default_version=docker_image.get_default_version, healthy=docker_image.healthy, install_environment=docker_image.install_environment, run_hook=docker_image.run_hook),  # noqa: E501
+    'dotnet': Language(name='dotnet', ENVIRONMENT_DIR=dotnet.ENVIRONMENT_DIR, get_default_version=dotnet.get_default_version, healthy=dotnet.healthy, install_environment=dotnet.install_environment, run_hook=dotnet.run_hook),  # noqa: E501
     'fail': Language(name='fail', ENVIRONMENT_DIR=fail.ENVIRONMENT_DIR, get_default_version=fail.get_default_version, healthy=fail.healthy, install_environment=fail.install_environment, run_hook=fail.run_hook),  # noqa: E501
     'golang': Language(name='golang', ENVIRONMENT_DIR=golang.ENVIRONMENT_DIR, get_default_version=golang.get_default_version, healthy=golang.healthy, install_environment=golang.install_environment, run_hook=golang.run_hook),  # noqa: E501
     'node': Language(name='node', ENVIRONMENT_DIR=node.ENVIRONMENT_DIR, get_default_version=node.get_default_version, healthy=node.healthy, install_environment=node.install_environment, run_hook=node.run_hook),  # noqa: E501

--- a/pre_commit/languages/dotnet.py
+++ b/pre_commit/languages/dotnet.py
@@ -1,0 +1,90 @@
+import contextlib
+import os.path
+from typing import Generator
+from typing import Sequence
+from typing import Tuple
+
+import pre_commit.constants as C
+from pre_commit.envcontext import envcontext
+from pre_commit.envcontext import PatchesT
+from pre_commit.envcontext import Var
+from pre_commit.hook import Hook
+from pre_commit.languages import helpers
+from pre_commit.prefix import Prefix
+from pre_commit.util import clean_path_on_failure
+from pre_commit.util import rmtree
+
+ENVIRONMENT_DIR = 'dotnetenv'
+BIN_DIR = 'bin'
+
+get_default_version = helpers.basic_get_default_version
+healthy = helpers.basic_healthy
+
+
+def get_env_patch(venv: str) -> PatchesT:
+    return (
+        ('PATH', (os.path.join(venv, BIN_DIR), os.pathsep, Var('PATH'))),
+    )
+
+
+@contextlib.contextmanager
+def in_env(prefix: Prefix) -> Generator[None, None, None]:
+    directory = helpers.environment_dir(ENVIRONMENT_DIR, C.DEFAULT)
+    envdir = prefix.path(directory)
+    with envcontext(get_env_patch(envdir)):
+        yield
+
+
+def install_environment(
+        prefix: Prefix,
+        version: str,
+        additional_dependencies: Sequence[str],
+) -> None:
+    helpers.assert_version_default('dotnet', version)
+    helpers.assert_no_additional_deps('dotnet', additional_dependencies)
+
+    envdir = prefix.path(helpers.environment_dir(ENVIRONMENT_DIR, version))
+    with clean_path_on_failure(envdir):
+        build_dir = 'pre-commit-build'
+
+        # Build & pack nupkg file
+        helpers.run_setup_cmd(
+            prefix,
+            (
+                'dotnet', 'pack',
+                '--configuration', 'Release',
+                '--output', build_dir,
+            ),
+        )
+
+        # Determine tool from the packaged file <tool_name>.<version>.nupkg
+        build_outputs = os.listdir(os.path.join(prefix.prefix_dir, build_dir))
+        if len(build_outputs) != 1:
+            raise NotImplementedError(
+                f"Can't handle multiple build outputs. Got {build_outputs}",
+            )
+        tool_name = build_outputs[0].split('.')[0]
+
+        # Install to bin dir
+        helpers.run_setup_cmd(
+            prefix,
+            (
+                'dotnet', 'tool', 'install',
+                '--tool-path', os.path.join(envdir, BIN_DIR),
+                '--add-source', build_dir,
+                tool_name,
+            ),
+        )
+
+        # Cleanup build output
+        for d in ('bin', 'obj', build_dir):
+            rmtree(prefix.path(d))
+
+
+def run_hook(
+        hook: Hook,
+        file_args: Sequence[str],
+        color: bool,
+) -> Tuple[int, bytes]:
+    with in_env(hook.prefix):
+        return helpers.run_xargs(hook, hook.cmd, file_args, color=color)

--- a/testing/gen-languages-all
+++ b/testing/gen-languages-all
@@ -2,8 +2,9 @@
 import sys
 
 LANGUAGES = [
-    'conda', 'docker', 'docker_image', 'fail', 'golang', 'node', 'perl',
-    'pygrep', 'python', 'ruby', 'rust', 'script', 'swift', 'system',
+    'conda', 'docker', 'dotnet', 'docker_image', 'fail', 'golang',
+    'node', 'perl', 'pygrep', 'python', 'ruby', 'rust', 'script', 'swift',
+    'system',
 ]
 FIELDS = [
     'ENVIRONMENT_DIR', 'get_default_version', 'healthy', 'install_environment',

--- a/testing/resources/dotnet_hooks_csproj_repo/.gitignore
+++ b/testing/resources/dotnet_hooks_csproj_repo/.gitignore
@@ -1,0 +1,3 @@
+bin/
+obj/
+nupkg/

--- a/testing/resources/dotnet_hooks_csproj_repo/.pre-commit-hooks.yaml
+++ b/testing/resources/dotnet_hooks_csproj_repo/.pre-commit-hooks.yaml
@@ -1,0 +1,5 @@
+-   id: dotnet example hook
+    name: dotnet example hook
+    entry: testeroni
+    language: dotnet
+    files: ''

--- a/testing/resources/dotnet_hooks_csproj_repo/Program.cs
+++ b/testing/resources/dotnet_hooks_csproj_repo/Program.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace dotnet_hooks_repo
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            Console.WriteLine("Hello from dotnet!");
+        }
+    }
+}

--- a/testing/resources/dotnet_hooks_csproj_repo/dotnet_hooks_csproj_repo.csproj
+++ b/testing/resources/dotnet_hooks_csproj_repo/dotnet_hooks_csproj_repo.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <PackAsTool>true</PackAsTool>
+    <ToolCommandName>testeroni</ToolCommandName>
+    <PackageOutputPath>./nupkg</PackageOutputPath>
+  </PropertyGroup>
+</Project>

--- a/testing/resources/dotnet_hooks_sln_repo/.gitignore
+++ b/testing/resources/dotnet_hooks_sln_repo/.gitignore
@@ -1,0 +1,3 @@
+bin/
+obj/
+nupkg/

--- a/testing/resources/dotnet_hooks_sln_repo/.pre-commit-hooks.yaml
+++ b/testing/resources/dotnet_hooks_sln_repo/.pre-commit-hooks.yaml
@@ -1,0 +1,5 @@
+-   id: dotnet example hook
+    name: dotnet example hook
+    entry: testeroni
+    language: dotnet
+    files: ''

--- a/testing/resources/dotnet_hooks_sln_repo/Program.cs
+++ b/testing/resources/dotnet_hooks_sln_repo/Program.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace dotnet_hooks_sln_repo
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            Console.WriteLine("Hello from dotnet!");
+        }
+    }
+}

--- a/testing/resources/dotnet_hooks_sln_repo/dotnet_hooks_sln_repo.csproj
+++ b/testing/resources/dotnet_hooks_sln_repo/dotnet_hooks_sln_repo.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <PackAsTool>true</PackAsTool>
+    <ToolCommandName>testeroni</ToolCommandName>
+    <PackageOutputPath>./nupkg</PackageOutputPath>
+  </PropertyGroup>
+</Project>

--- a/testing/resources/dotnet_hooks_sln_repo/dotnet_hooks_sln_repo.sln
+++ b/testing/resources/dotnet_hooks_sln_repo/dotnet_hooks_sln_repo.sln
@@ -1,0 +1,34 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26124.0
+MinimumVisualStudioVersion = 15.0.26124.0
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "dotnet_hooks_sln_repo", "dotnet_hooks_sln_repo.csproj", "{6568CFDB-6F6F-45A9-932C-8C7DAABC8E56}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{6568CFDB-6F6F-45A9-932C-8C7DAABC8E56}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6568CFDB-6F6F-45A9-932C-8C7DAABC8E56}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6568CFDB-6F6F-45A9-932C-8C7DAABC8E56}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{6568CFDB-6F6F-45A9-932C-8C7DAABC8E56}.Debug|x64.Build.0 = Debug|Any CPU
+		{6568CFDB-6F6F-45A9-932C-8C7DAABC8E56}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{6568CFDB-6F6F-45A9-932C-8C7DAABC8E56}.Debug|x86.Build.0 = Debug|Any CPU
+		{6568CFDB-6F6F-45A9-932C-8C7DAABC8E56}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6568CFDB-6F6F-45A9-932C-8C7DAABC8E56}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6568CFDB-6F6F-45A9-932C-8C7DAABC8E56}.Release|x64.ActiveCfg = Release|Any CPU
+		{6568CFDB-6F6F-45A9-932C-8C7DAABC8E56}.Release|x64.Build.0 = Release|Any CPU
+		{6568CFDB-6F6F-45A9-932C-8C7DAABC8E56}.Release|x86.ActiveCfg = Release|Any CPU
+		{6568CFDB-6F6F-45A9-932C-8C7DAABC8E56}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/tests/repository_test.py
+++ b/tests/repository_test.py
@@ -917,3 +917,17 @@ def test_local_perl_additional_dependencies(store):
     ret, out = _hook_run(hook, (), color=False)
     assert ret == 0
     assert _norm_out(out).startswith(b'This is perltidy, v20200110')
+
+
+@pytest.mark.parametrize(
+    'repo',
+    (
+        'dotnet_hooks_csproj_repo',
+        'dotnet_hooks_sln_repo',
+    ),
+)
+def test_dotnet_hook(tempdir_factory, store, repo):
+    _test_hook_repo(
+        tempdir_factory, store, repo,
+        'dotnet example hook', [], b'Hello from dotnet!\n',
+    )

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist = py36,py37,py38,pypy3,pre-commit
 
 [testenv]
 deps = -rrequirements-dev.txt
-passenv = HOME LOCALAPPDATA RUSTUP_HOME
+passenv = APPDATA HOME LOCALAPPDATA PROGRAMFILES RUSTUP_HOME
 commands =
     coverage erase
     coverage run -m pytest {posargs:tests}


### PR DESCRIPTION
Hello hello.

This PR adds [2nd class](https://github.com/pre-commit/pre-commit/blob/master/CONTRIBUTING.md#adding-support-for-a-new-hook-language) support for dotnet [tools](https://docs.microsoft.com/en-us/dotnet/core/tools/global-tools-how-to-create) by using `dotnet pack` and `dotnet tool install`.

I've also tested a "real world" hook:

<details>

```console
$ cd /tmp
$ rm -rf ./foo
$ dotnet new console --name foo
The template "Console Application" was created successfully.

Processing post-creation actions...
Running 'dotnet restore' on foo/foo.csproj...
  Determining projects to restore...
  Restored /tmp/foo/foo.csproj (in 190 ms).

Restore succeeded.

$ cd foo
$ git init
Initialized empty Git repository in /tmp/foo/.git/
$ sed -i 's/Console/    Console/g' Program.cs
$ pre-commit try-repo https://github.com/rkm/format --ref af89478 --files=foo.csproj
[INFO] Initializing environment for https://github.com/rkm/format.
===============================================================================
Using config:
===============================================================================
repos:
-   repo: https://github.com/rkm/format
    rev: af89478
    hooks:
    -   id: dotnet-format
===============================================================================
[INFO] Installing environment for https://github.com/rkm/format.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
dotnet format............................................................Failed
- hook id: dotnet-format
- files were modified by this hook

  Formatting code files in workspace '/tmp/foo/foo.csproj'.
  Warnings were encountered while loading the workspace. Set the verbosity option to the 'diagnostic' level to log warnings.
  Formatted code file '/tmp/foo/Program.cs'.
  Format complete in 3530ms.
```
</details>

One of the issues I found was that nuget doesn't play nicely when some env vars are not set. In particular the Windows build was failing until I added the tox.ini changes below. If you don't want to carry that addition, then I can probably investigate a workaround using `get_env_patch`.

Looking forward to your review!