### PR TITLE
Distinct exit codes for the various error cases

### DIFF
--- a/pre_commit/error_handler.py
+++ b/pre_commit/error_handler.py
@@ -15,7 +15,12 @@ class FatalError(RuntimeError):
     pass
 
 
-def _log_and_exit(msg: str, exc: BaseException, formatted: str) -> None:
+def _log_and_exit(
+    msg: str,
+    code: int = 0,
+    exc: BaseException,
+    formatted: str,
+) -> None:
     error_msg = f'{msg}: {type(exc).__name__}: '.encode() + force_bytes(exc)
     output.write_line_b(error_msg)
     log_path = os.path.join(Store().directory, 'pre-commit.log')
@@ -47,7 +52,7 @@ def _log_and_exit(msg: str, exc: BaseException, formatted: str) -> None:
         _log_line('```')
         _log_line(formatted)
         _log_line('```')
-    raise SystemExit(1)
+    raise SystemExit(code)
 
 
 @contextlib.contextmanager
@@ -56,9 +61,9 @@ def error_handler() -> Generator[None, None, None]:
         yield
     except (Exception, KeyboardInterrupt) as e:
         if isinstance(e, FatalError):
-            msg = 'An error has occurred'
+            msg, code = 'An error has occurred', 1
         elif isinstance(e, KeyboardInterrupt):
-            msg = 'Interrupted (^C)'
+            msg, code = 'Interrupted (^C)', 130
         else:
-            msg = 'An unexpected error has occurred'
-        _log_and_exit(msg, e, traceback.format_exc())
+            msg, code = 'An unexpected error has occurred', 3
+        _log_and_exit(msg, code, e, traceback.format_exc())

--- a/pre_commit/error_handler.py
+++ b/pre_commit/error_handler.py
@@ -17,7 +17,7 @@ class FatalError(RuntimeError):
 
 def _log_and_exit(
     msg: str,
-    code: int = 0,
+    code: int,
     exc: BaseException,
     formatted: str,
 ) -> None:

--- a/tests/error_handler_test.py
+++ b/tests/error_handler_test.py
@@ -32,10 +32,10 @@ def test_error_handler_fatal_error(mocked_log_and_exit):
 
     mocked_log_and_exit.assert_called_once_with(
         'An error has occurred',
+        1,
         exc,
         # Tested below
         mock.ANY,
-        1,
     )
 
     pattern = re_assert.Matches(
@@ -57,10 +57,10 @@ def test_error_handler_uncaught_error(mocked_log_and_exit):
 
     mocked_log_and_exit.assert_called_once_with(
         'An unexpected error has occurred',
+        3,
         exc,
         # Tested below
         mock.ANY,
-        3,
     )
     pattern = re_assert.Matches(
         r'Traceback \(most recent call last\):\n'
@@ -81,10 +81,10 @@ def test_error_handler_keyboardinterrupt(mocked_log_and_exit):
 
     mocked_log_and_exit.assert_called_once_with(
         'Interrupted (^C)',
+        130,
         exc,
         # Tested below
         mock.ANY,
-        130,
     )
     pattern = re_assert.Matches(
         r'Traceback \(most recent call last\):\n'

--- a/tests/error_handler_test.py
+++ b/tests/error_handler_test.py
@@ -98,7 +98,7 @@ def test_error_handler_keyboardinterrupt(mocked_log_and_exit):
 def test_log_and_exit(cap_out, mock_store_dir):
     with pytest.raises(SystemExit):
         error_handler._log_and_exit(
-            'msg', error_handler.FatalError('hai'), "I'm a stacktrace",
+            'msg', 1, error_handler.FatalError('hai'), "I'm a stacktrace",
         )
 
     printed = cap_out.get()

--- a/tests/error_handler_test.py
+++ b/tests/error_handler_test.py
@@ -32,6 +32,7 @@ def test_error_handler_fatal_error(mocked_log_and_exit):
         exc,
         # Tested below
         mock.ANY,
+        1,
     )
 
     assert re.match(
@@ -56,6 +57,7 @@ def test_error_handler_uncaught_error(mocked_log_and_exit):
         exc,
         # Tested below
         mock.ANY,
+        3,
     )
     assert re.match(
         r'Traceback \(most recent call last\):\n'
@@ -79,6 +81,7 @@ def test_error_handler_keyboardinterrupt(mocked_log_and_exit):
         exc,
         # Tested below
         mock.ANY,
+        130,
     )
     assert re.match(
         r'Traceback \(most recent call last\):\n'

--- a/tests/error_handler_test.py
+++ b/tests/error_handler_test.py
@@ -107,7 +107,7 @@ def test_log_and_exit(cap_out, mock_store_dir):
 
     with pytest.raises(SystemExit):
         error_handler._log_and_exit(
-            'msg', 1, error_handler.FatalError('hai'), "I'm a stacktrace",
+            'msg', 1, error_handler.FatalError('hai'), tb,
         )
 
     printed = cap_out.get()


### PR DESCRIPTION
This PR attempts to follow the Linux/Bash convention for exit codes. See more at [Exit Codes With Special Meanings](https://tldp.org/LDP/abs/html/exitcodes.html) (You might need to use the Google we cache, because the resources seems down right now).

Basically we will have the following:
- `1` for standard error
- `130` for interrupted process by user
- `3` for any unexpected error