### PR TITLE
Fix ruby hooks when --format-executable is in gemrc

### DIFF
--- a/pre_commit/languages/ruby.py
+++ b/pre_commit/languages/ruby.py
@@ -134,7 +134,8 @@ def install_environment(
             helpers.run_setup_cmd(
                 prefix,
                 (
-                    'gem', 'install', '--no-document',
+                    'gem', 'install',
+                    '--no-document', '--no-format-executable',
                     *prefix.star('.gem'), *additional_dependencies,
                 ),
             )


### PR DESCRIPTION
I used this gemrc to break things (default on opensuse):

```yaml
---
:benchmark: false
:install: --format-executable --no-user-install
install: --format-executable --no-user-install
:backtrace: true
:update_sources: true
:format_executable: true
:verbose: true
:update: --format-executable --no-user-install
update: --format-executable --no-user-install
:bulk_threshold: 1000
:sources:
- https://rubygems.org
```