### PR TITLE
Improve MSYS2 Compatibility

### DIFF
--- a/pre_commit/git.py
+++ b/pre_commit/git.py
@@ -182,7 +182,9 @@ def check_for_cygwin_mismatch() -> None:
     if sys.platform in ('cygwin', 'win32'):  # pragma: no cover (windows)
         is_cygwin_python = sys.platform == 'cygwin'
         toplevel = cmd_output('git', 'rev-parse', '--show-toplevel')[1]
-        is_cygwin_git = toplevel.startswith('/')
+        git_exec_path = cmd_output('git', '--exec-path')[1].strip()
+        is_msys2_git = git_exec_path == '/usr/lib/git-core'
+        is_cygwin_git = toplevel.startswith('/') and not is_msys2_git
 
         if is_cygwin_python ^ is_cygwin_git:
             exe_type = {True: '(cygwin)', False: '(windows)'}

--- a/pre_commit/main.py
+++ b/pre_commit/main.py
@@ -26,6 +26,7 @@ from pre_commit.error_handler import error_handler
 from pre_commit.error_handler import FatalError
 from pre_commit.logging_handler import logging_handler
 from pre_commit.store import Store
+from pre_commit.util import cmd_output
 from pre_commit.util import CalledProcessError
 
 
@@ -159,6 +160,9 @@ def _adjust_args_and_chdir(args: argparse.Namespace) -> None:
                 'git toplevel unexpectedly empty! make sure you are not '
                 'inside the `.git` directory of your repository.',
             )
+        elif os.name == 'nt' and toplevel.startswith('/'):
+            full_win_path = cmd_output("cygpath", "-w", toplevel)[1].strip()
+            os.chdir(full_win_path)
         else:
             os.chdir(toplevel)
 


### PR DESCRIPTION
This PR closes part of #1605 

It makes two updates:
1. Update pre-commit to make use of the cygpath command to convert the path to the standard Windows path format after it gets the top-level path from git.
2. Remove cygwin warnings about incompatible Python+git versions if in the MSYS2 environment