### PR TITLE
Update pre-commit version in sample config

### DIFF
--- a/pre_commit/commands/sample_config.py
+++ b/pre_commit/commands/sample_config.py
@@ -7,7 +7,7 @@ SAMPLE_CONFIG = '''\
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.4.0
+    rev: v3.2.0
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer

--- a/tests/commands/sample_config_test.py
+++ b/tests/commands/sample_config_test.py
@@ -10,7 +10,7 @@ def test_sample_config(capsys):
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.4.0
+    rev: v3.2.0
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer


### PR DESCRIPTION
This is a minor change. The sample config doesn't even have the latest major version in it.

[This](https://stackoverflow.com/a/12704727) provides the solution to what is proposed in the `TODO`.
The output from
```bash
git -c 'versionsort.suffix=-' ls-remote --exit-code --refs --sort='version:refname' --tags git://github.com/pre-commit/pre-commit-hooks '*.*.*' | tail --lines=1 | cut --delimiter='/' --fields=3
```
can be directly inserted inplace of the defined rev.

Alternatively one could borrow parts from the autoupdate command. The logic there seems to init a repository and then parses the output from git commands using functions from the util module. The above may or may not be overkill. I have not looked into the details of the different approaches yet. Seems doable though!

If that change is desired, I would be happy to update the PR accordingly.