### PR TITLE
Add a coursier_launch integration

### DIFF
--- a/pre_commit/languages/all.py
+++ b/pre_commit/languages/all.py
@@ -7,6 +7,7 @@ from typing import Tuple
 from pre_commit.hook import Hook
 from pre_commit.languages import conda
 from pre_commit.languages import coursier
+from pre_commit.languages import coursier_launch
 from pre_commit.languages import docker
 from pre_commit.languages import docker_image
 from pre_commit.languages import dotnet
@@ -43,9 +44,10 @@ languages = {
     # BEGIN GENERATED (testing/gen-languages-all)
     'conda': Language(name='conda', ENVIRONMENT_DIR=conda.ENVIRONMENT_DIR, get_default_version=conda.get_default_version, healthy=conda.healthy, install_environment=conda.install_environment, run_hook=conda.run_hook),  # noqa: E501
     'coursier': Language(name='coursier', ENVIRONMENT_DIR=coursier.ENVIRONMENT_DIR, get_default_version=coursier.get_default_version, healthy=coursier.healthy, install_environment=coursier.install_environment, run_hook=coursier.run_hook),  # noqa: E501
+    'coursier_launch': Language(name='coursier_launch', ENVIRONMENT_DIR=coursier_launch.ENVIRONMENT_DIR, get_default_version=coursier_launch.get_default_version, healthy=coursier_launch.healthy, install_environment=coursier_launch.install_environment, run_hook=coursier_launch.run_hook),  # noqa: E501
     'docker': Language(name='docker', ENVIRONMENT_DIR=docker.ENVIRONMENT_DIR, get_default_version=docker.get_default_version, healthy=docker.healthy, install_environment=docker.install_environment, run_hook=docker.run_hook),  # noqa: E501
-    'docker_image': Language(name='docker_image', ENVIRONMENT_DIR=docker_image.ENVIRONMENT_DIR, get_default_version=docker_image.get_default_version, healthy=docker_image.healthy, install_environment=docker_image.install_environment, run_hook=docker_image.run_hook),  # noqa: E501
     'dotnet': Language(name='dotnet', ENVIRONMENT_DIR=dotnet.ENVIRONMENT_DIR, get_default_version=dotnet.get_default_version, healthy=dotnet.healthy, install_environment=dotnet.install_environment, run_hook=dotnet.run_hook),  # noqa: E501
+    'docker_image': Language(name='docker_image', ENVIRONMENT_DIR=docker_image.ENVIRONMENT_DIR, get_default_version=docker_image.get_default_version, healthy=docker_image.healthy, install_environment=docker_image.install_environment, run_hook=docker_image.run_hook),  # noqa: E501
     'fail': Language(name='fail', ENVIRONMENT_DIR=fail.ENVIRONMENT_DIR, get_default_version=fail.get_default_version, healthy=fail.healthy, install_environment=fail.install_environment, run_hook=fail.run_hook),  # noqa: E501
     'golang': Language(name='golang', ENVIRONMENT_DIR=golang.ENVIRONMENT_DIR, get_default_version=golang.get_default_version, healthy=golang.healthy, install_environment=golang.install_environment, run_hook=golang.run_hook),  # noqa: E501
     'node': Language(name='node', ENVIRONMENT_DIR=node.ENVIRONMENT_DIR, get_default_version=node.get_default_version, healthy=node.healthy, install_environment=node.install_environment, run_hook=node.run_hook),  # noqa: E501

--- a/pre_commit/languages/coursier_launch.py
+++ b/pre_commit/languages/coursier_launch.py
@@ -1,0 +1,21 @@
+from typing import Sequence
+from typing import Tuple
+
+from pre_commit.hook import Hook
+from pre_commit.languages import helpers
+
+ENVIRONMENT_DIR = None
+get_default_version = helpers.basic_get_default_version
+healthy = helpers.basic_healthy
+install_environment = helpers.no_install
+
+
+def run_hook(
+        hook: Hook,
+        file_args: Sequence[str],
+        color: bool,
+) -> Tuple[int, bytes]:   # pragma: win32 no cover
+    hook_cmd = hook.cmd
+    forwarded_cmd = hook_cmd if '--' in hook_cmd else hook_cmd + ('--',)
+    cmd = ('cs', 'launch') + forwarded_cmd
+    return helpers.run_xargs(hook, cmd, file_args, color=color)

--- a/testing/gen-languages-all
+++ b/testing/gen-languages-all
@@ -2,9 +2,9 @@
 import sys
 
 LANGUAGES = [
-    'conda', 'coursier', 'docker', 'dotnet', 'docker_image', 'fail', 'golang',
-    'node', 'perl', 'pygrep', 'python', 'ruby', 'rust', 'script', 'swift',
-    'system',
+    'conda', 'coursier', 'coursier_launch', 'docker', 'dotnet', 'docker_image',
+    'fail', 'golang', 'node', 'perl', 'pygrep', 'python', 'ruby', 'rust',
+    'script', 'swift', 'system',
 ]
 FIELDS = [
     'ENVIRONMENT_DIR', 'get_default_version', 'healthy', 'install_environment',

--- a/testing/resources/coursier_launch_hooks_repo/.pre-commit-hooks.yaml
+++ b/testing/resources/coursier_launch_hooks_repo/.pre-commit-hooks.yaml
@@ -1,0 +1,5 @@
+-   id: echo-java
+    name: echo-java
+    description: echo from java
+    entry: echo-java
+    language: coursier_launch

--- a/tests/repository_test.py
+++ b/tests/repository_test.py
@@ -205,6 +205,15 @@ def test_run_a_coursier_hook(tempdir_factory, store):
     )
 
 
+@skipif_cant_run_coursier  # pragma: win32 no cover
+def test_run_a_coursier_launch_hook(tempdir_factory, store, hook_id):
+    _test_hook_repo(
+        tempdir_factory, store, 'coursier_hooks_repo',
+        'echo-java',
+        ['Hello World from coursier'], b'Hello World from coursier\n',
+    )
+
+
 @skipif_cant_run_docker  # pragma: win32 no cover
 def test_run_a_docker_hook(tempdir_factory, store):
     _test_hook_repo(


### PR DESCRIPTION
This is a follow up to the repository based coursier integration. The
standard coursier integration is to this integration what the docker
integration is to the docker_image integration.

This is meant to target either maven coordinates or coursier apps
directly without depending on a hook repository containing app
descriptors and hook configs making this integration highly suitable
for local hooks.

An example of hook local targets are bellow
```yaml
- repo: local
  hooks:
    - id: scalafmt
      name: scalafmt
      entry: scalafmt # coursier app target
      language: coursier_launch
      files: (\.scala|\.sbt|\.sc)$
    - id: scalafix
      name: scalafix
      entry: ch.epfl.scala:::scalafix-cli:latest.release # maven coordinates target
      language: coursier_launch
      files: (\.scala|\.sbt|\.sc)$
    - id: echo-java
      name: echo-java
      entry: echo-java
      language: coursier_launch
      args: ["--", "hello from java"] # forward arguments to the app
```