### PR TITLE
Add PYTHON_SETUP_DEPENDENCIES, which adds dependencies to install in each virtualenv

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
     -   id: name-tests-test
     -   id: requirements-txt-fixer
     -   id: double-quote-string-fixer
--   repo: https://gitlab.com/pycqa/flake8
+-   repo: https://gitlab.com/pycqa/flake8.git
     rev: 3.8.4
     hooks:
     -   id: flake8

--- a/pre_commit/languages/python.py
+++ b/pre_commit/languages/python.py
@@ -197,10 +197,17 @@ def install_environment(
     if python is not None:
         venv_cmd.extend(('-p', python))
     install_cmd = ('python', '-mpip', 'install', '.', *additional_dependencies)
+    setup_dependencies_env = os.environ.get('PYTHON_SETUP_DEPENDENCIES')
+    if setup_dependencies_env:
+        setup_dependencies = setup_dependencies_env.split(':')
+    else:
+        setup_dependencies = []
 
     with clean_path_on_failure(envdir):
         cmd_output_b(*venv_cmd, cwd='/')
         with in_env(prefix, version):
+            for dep in setup_dependencies:
+                cmd_output_b('python', '-mpip', 'install', dep)
             helpers.run_setup_cmd(prefix, install_cmd)
 
 


### PR DESCRIPTION
My use case is that I'm in an environment where I need to use a socks proxy for all traffic. I actually use [tails](https://tails.boum.org), which restricts all outgoing traffic through tor.

virtualenvs *almost* work in this environment: `pip` respects the `https_proxy` environment variable and has a `--proxy` argument; but `pip` does not have built-in socks support and requires the `pysocks` package. So creating a new virtualenv creates a chicken-and-egg problem: how do you install `pysocks` if `pip` requires `pysocks` to work?

I can't find a well-supported solution to this problem. The best answer I can find is to download a `pysocks` wheel with a web browser and `pip install` the wheel file.

This PR is a hacky way to apply this solution in `pre-commit`. Setting up a python environment now respects a `PYTHON_SETUP_DEPENDENCIES` environment variable, which is a `:`-separated list of things to `pip install`, before `pip install`'ing the normal things for the environment.

So for my use case, I download `pysocks` and do
```bash
export PYTHON_SETUP_DEPENDENCIES=/tmp/PySocks-1.7.1-py3-none-any.whl
```
then `pre-commit` works like normal.

I expect there are better solutions to this problem, but I thought a PR is a good way to get the ball rolling.