### PR TITLE
Improve performance by ignoring submodules

### DIFF
--- a/pre_commit/commands/run.py
+++ b/pre_commit/commands/run.py
@@ -258,7 +258,9 @@ def _all_filenames(args: argparse.Namespace) -> Collection[str]:
 
 
 def _get_diff() -> bytes:
-    _, out, _ = cmd_output_b('git', 'diff', '--no-ext-diff', retcode=None)
+    _, out, _ = cmd_output_b(
+        'git', 'diff', '--no-ext-diff', '--ignore-submodules', retcode=None,
+    )
     return out
 
 

--- a/pre_commit/git.py
+++ b/pre_commit/git.py
@@ -130,7 +130,9 @@ def get_staged_files(cwd: Optional[str] = None) -> List[str]:
 
 
 def intent_to_add_files() -> List[str]:
-    _, stdout, _ = cmd_output('git', 'status', '--porcelain', '-z')
+    _, stdout, _ = cmd_output(
+        'git', 'status', '--ignore-submodules', '--porcelain', '-z',
+    )
     parts = list(reversed(zsplit(stdout)))
     intent_to_add = []
     while parts:


### PR DESCRIPTION
When git status runs in a repo with submodules, it'll recursively run
git status in every submodule as well by default (sequentially).
git status is substantially slower on Windows than on Linux. git diff
behaves similarly to git status in terms of running recursively within
all submodules. In repos with hundreds of submodules, this quickly adds
up when git status/diff are called multiple times. Pre-commit runs
git status once at the beginning of an operation and then runs git diff
before and after each hook. These calls quickly add up and make
pre-commit unusable in large repos with lots of submodules.

This commit drastically improves performance in repos with lots of
submodules and fixes #1701 by telling git status and git diff to ignore
submodules. This change is not expected to have any negative effect on
existing hooks because each submodule should manage its own hooks
instead of relying on superproject hooks to manipulate their contents.