### PR TITLE
util: also run chmod on EPERM

### DIFF
--- a/pre_commit/util.py
+++ b/pre_commit/util.py
@@ -255,7 +255,7 @@ def rmtree(path: str) -> None:
         excvalue = exc[1]
         if (
                 func in (os.rmdir, os.remove, os.unlink) and
-                excvalue.errno == errno.EACCES
+                excvalue.errno in (errno.EACCES, errno.EPERM)
         ):
             for p in (path, os.path.dirname(path)):
                 os.chmod(p, os.stat(p).st_mode | stat.S_IWUSR)

--- a/pre_commit/util.py
+++ b/pre_commit/util.py
@@ -255,7 +255,7 @@ def rmtree(path: str) -> None:
         excvalue = exc[1]
         if (
                 func in (os.rmdir, os.remove, os.unlink) and
-                excvalue.errno in (errno.EACCES, errno.EPERM)
+                excvalue.errno in {errno.EACCES, errno.EPERM}
         ):
             for p in (path, os.path.dirname(path)):
                 os.chmod(p, os.stat(p).st_mode | stat.S_IWUSR)


### PR DESCRIPTION
Writing a test for this one is tricky, because I was seeing the issue
only when the directory being removed is a docker volume, so instead of
getting EACCES we get EPERM.

This is easy to reproduce though. The existing test fails when the
directory being used for the files is a docker volume:

```
% docker run \
	-v $(mktemp -d):/tmp \
	-v ${PWD}:/src \
	-w /src \
	python:3 \
	bash -c 'pip install -e . && pip install -r requirements-dev.txt && python -m pytest tests/util_test.py'
```