### PR TITLE
Use temp env file to install add_deps for conda

### DIFF
--- a/pre_commit/languages/conda.py
+++ b/pre_commit/languages/conda.py
@@ -80,7 +80,8 @@ def install_environment(
                 tmp_env_file.name, cwd=prefix.prefix_dir,
             )
         finally:
-            os.remove(tmp_env_file.name)
+            if os.path.exists(tmp_env_file.name):
+                os.remove(tmp_env_file.name)
 
 
 def run_hook(

--- a/pre_commit/languages/conda.py
+++ b/pre_commit/languages/conda.py
@@ -67,6 +67,7 @@ def install_environment(
         with open(env_yaml_path) as env_file:
             env_yaml = yaml_load(env_file)
         env_yaml['dependencies'] += additional_dependencies
+        tmp_env_file = None
         try:
             with NamedTemporaryFile(
                 suffix='.yml',
@@ -80,7 +81,7 @@ def install_environment(
                 tmp_env_file.name, cwd=prefix.prefix_dir,
             )
         finally:
-            if os.path.exists(tmp_env_file.name):
+            if tmp_env_file and os.path.exists(tmp_env_file.name):
                 os.remove(tmp_env_file.name)
 
 


### PR DESCRIPTION
Regards #1738 

It's possible to install `conda-forge` dependencies though using `additional_dependencies: [-c, conda-forge, ...]`, but it's not documented, triggers two lengthy solves and looks hacky (`-c` is not a conda package). 

I've changed the code to create a temporary env.yml instead and use that to install the environment.
I've talked about it with @xhochy (who authored the original code) and we agreed that this approach is cleaner, plus it's faster too.
