### PR TITLE
docs: fix simple typo, targetting -> targeting

### DIFF
--- a/tests/error_handler_test.py
+++ b/tests/error_handler_test.py
@@ -187,7 +187,7 @@ def test_error_handler_no_tty(tempdir_factory):
 @xfailif_windows  # pragma: win32 no cover
 def test_error_handler_read_only_filesystem(mock_store_dir, cap_out, capsys):
     # a better scenario would be if even the Store crash would be handled
-    # but realistically we're only targetting systems where the Store has
+    # but realistically we're only targeting systems where the Store has
     # already been set up
     Store()
 


### PR DESCRIPTION
There is a small typo in tests/error_handler_test.py.

Should read `targeting` rather than `targetting`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md