### PR TITLE
fix reference to github.com/golang/example

### DIFF
--- a/tests/repository_test.py
+++ b/tests/repository_test.py
@@ -569,7 +569,7 @@ def test_additional_golang_dependencies_installed(
     path = make_repo(tempdir_factory, 'golang_hooks_repo')
     config = make_config_from_repo(path)
     # A small go package
-    deps = ['github.com/golang/example/hello']
+    deps = ['golang.org/x/example/hello']
     config['hooks'][0]['additional_dependencies'] = deps
     hook = _get_hook(config, store, 'golang-hook')
     binaries = os.listdir(
@@ -590,7 +590,7 @@ def test_local_golang_additional_dependencies(store):
             'name': 'hello',
             'entry': 'hello',
             'language': 'golang',
-            'additional_dependencies': ['github.com/golang/example/hello'],
+            'additional_dependencies': ['golang.org/x/example/hello'],
         }],
     }
     hook = _get_hook(config, store, 'hello')


### PR DESCRIPTION
this was broken recently when that moved to go modules: https://github.com/golang/example/commit/bcf50bfd7dcd8020c90965747d857ae42802e0c5#commitcomment-46255173