### PR TITLE
install_uninstall: prefer shebang with only major version

### DIFF
--- a/pre_commit/commands/install_uninstall.py
+++ b/pre_commit/commands/install_uninstall.py
@@ -58,8 +58,8 @@ def shebang() -> str:
         py, _ = os.path.splitext(SYS_EXE)
     else:
         exe_choices = [
-            f'python{sys.version_info[0]}.{sys.version_info[1]}',
             f'python{sys.version_info[0]}',
+            f'python{sys.version_info[0]}.{sys.version_info[1]}',
         ]
         # avoid searching for bare `python` as it's likely to be python 2
         if SYS_EXE != 'python':


### PR DESCRIPTION
Having a major.minor version of python in the shebangs, has the unwanted
side effect of requiring an uninstallation and then reinstallation
all the pre-commit hooks, once the system updates the python
installation to a newer minor version, since it will not find the
version which the shebangs specifies.

To make matters worse the uninstallation of the hooks has to be manual
since the script will not be able to run for the aforementioned reason.

This change makes the python symlink with just the major version as the
preferred choice over the major.minor version specified shebang.

Signed-off-by: Antonio Gutierrez <chibby0ne@gmail.com>