### PR TITLE
added recursive repository support for golang

### DIFF
--- a/pre_commit/languages/golang.py
+++ b/pre_commit/languages/golang.py
@@ -69,7 +69,8 @@ def install_environment(
         repo_src_dir = os.path.join(directory, 'src', guess_go_dir(remote))
 
         # Clone into the goenv we'll create
-        helpers.run_setup_cmd(prefix, ('git', 'clone', '.', repo_src_dir))
+        cmd = ('git', 'clone', '--recursive', '.', repo_src_dir)
+        helpers.run_setup_cmd(prefix, cmd)
 
         if sys.platform == 'cygwin':  # pragma: no cover
             _, gopath, _ = cmd_output('cygpath', '-w', directory)


### PR DESCRIPTION
resolves #1788 

note that i also added `depth=1` to reduce cache size and installation time. not sure if the whole command call should be replaced with `_shallow_clone`, depends on whether you want to keep all command calls within the helper module or not.