### PR TITLE
Use exclusion syntax for git diff filtering

### DIFF
--- a/pre_commit/git.py
+++ b/pre_commit/git.py
@@ -127,8 +127,7 @@ def get_staged_files(cwd: Optional[str] = None) -> List[str]:
     return zsplit(
         cmd_output(
             'git', 'diff', '--staged', '--name-only', '--no-ext-diff', '-z',
-            # Everything except for D
-            '--diff-filter=ACMRTUXB',
+            '--diff-filter=d',
             cwd=cwd,
         )[1],
     )


### PR DESCRIPTION
Since git 1.8.5 [1], '--diff-filter' can take lowercase args to mean
"show everything but these classes". Use this to exclude deleted files
rather than specify every other class.

[1] https://git.kernel.org/pub/scm/git/git.git/tree/Documentation/RelNotes/1.8.5.txt#n186