### PR TITLE
Add support for Go 1.16

### DIFF
--- a/pre_commit/resources/empty_template_go.mod
+++ b/pre_commit/resources/empty_template_go.mod
@@ -1,0 +1,1 @@
+module pre-commit-dummy-empty-module

--- a/testing/resources/golang_hooks_repo/go.mod
+++ b/testing/resources/golang_hooks_repo/go.mod
@@ -1,0 +1,1 @@
+module golang-hello-world


### PR DESCRIPTION
Go 1.16 changes the way modules are handled. It now expects Go projects to have non-empty `go.mod` files.

This change is compatible with Go 1.15.

Fixes #1815

---

The golang tests pass under all combinations of `Go [1.15|1.16]` + `GO111MODULE=[""|"on"|"auto"]`.

I could also install and run the following hook successfully with both Go 1.15 and Go 1.16:

```
- repo: local
    hooks:
      - id: shfmt
        name: Format shell files with shfmt
        language: golang
        additional_dependencies: ["mvdan.cc/sh/v3/cmd/shfmt@v3.2.1"]
        types: [shell]
        entry: shfmt -w
```

These changes work for my use cases, and they seem sensible to me, but I'm not all that familiar with Go modules, so perhaps this has some implications I don't know about.
