### PR TITLE
chore: drop universal wheel

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -50,9 +50,6 @@ exclude =
     tests*
     testing*
 
-[bdist_wheel]
-universal = True
-
 [coverage:run]
 plugins = covdefaults
 omit = pre_commit/resources/*


### PR DESCRIPTION
Pre-commit does not support Python 2 anymore (`python_requires = >=3.6.1`), so it does not need universal wheels activated, which produce `py3.py2` in the wheel name instead of `py3`.

You can see the "Universal" naming here: https://pypi.org/project/pre-commit/#files 