### PR TITLE
Add ability to specify rust language version

### DIFF
--- a/pre_commit/languages/rust.py
+++ b/pre_commit/languages/rust.py
@@ -18,23 +18,59 @@ from pre_commit.util import clean_path_on_failure
 from pre_commit.util import cmd_output_b
 
 ENVIRONMENT_DIR = 'rustenv'
+RUNTIME_DIR = 'rustup'
 get_default_version = helpers.basic_get_default_version
-healthy = helpers.basic_healthy
 
 
-def get_env_patch(target_dir: str) -> PatchesT:
-    return (
-        ('PATH', (os.path.join(target_dir, 'bin'), os.pathsep, Var('PATH'))),
+def _envdir(prefix: Prefix, version: str) -> str:
+    directory = helpers.environment_dir(ENVIRONMENT_DIR, version)
+    return prefix.path(directory)
+
+
+def _version_flag(version: str) -> Sequence[str]:
+    return [] if version == C.DEFAULT else [f'+{version}']
+
+
+def _resolve_version(prefix: Prefix, version: str) -> str:
+    if version != C.DEFAULT:
+        return version
+
+    if prefix.exists('rust-toolchain'):
+        with open(prefix.path('rust-toolchain')) as f:
+            return f.readline().strip()
+
+    return version
+
+
+def get_env_patch(prefix: Prefix, version: str) -> PatchesT:
+    env_path = _envdir(prefix, version)
+    patch = (
+        ('CARGO_HOME', env_path),
+        ('PATH', (os.path.join(env_path, 'bin'), os.pathsep, Var('PATH'))),
     )
+
+    if version != C.DEFAULT:
+        return (*patch, ('RUSTUP_HOME', prefix.path(RUNTIME_DIR)))
+
+    return patch
 
 
 @contextlib.contextmanager
-def in_env(prefix: Prefix) -> Generator[None, None, None]:
-    target_dir = prefix.path(
-        helpers.environment_dir(ENVIRONMENT_DIR, C.DEFAULT),
-    )
-    with envcontext(get_env_patch(target_dir)):
+def in_env(prefix: Prefix, version: str) -> Generator[None, None, None]:
+    with envcontext(get_env_patch(prefix, version)):
         yield
+
+
+def healthy(prefix: Prefix, version: str) -> bool:
+    language_version = _resolve_version(prefix, version)
+    with in_env(prefix, language_version):
+        version_flag = _version_flag(language_version)
+        retcode, _, _ = cmd_output_b(
+            'rustc', *version_flag, '--version',
+            retcode=None,
+            cwd=prefix.prefix_dir,
+        )
+        return retcode == 0
 
 
 def _add_dependencies(
@@ -57,11 +93,6 @@ def install_environment(
         version: str,
         additional_dependencies: Sequence[str],
 ) -> None:
-    helpers.assert_version_default('rust', version)
-    directory = prefix.path(
-        helpers.environment_dir(ENVIRONMENT_DIR, C.DEFAULT),
-    )
-
     # There are two cases where we might want to specify more dependencies:
     # as dependencies for the library being built, and as binary packages
     # to be `cargo install`'d.
@@ -80,19 +111,29 @@ def install_environment(
     if len(lib_deps) > 0:
         _add_dependencies(prefix.path('Cargo.toml'), lib_deps)
 
-    with clean_path_on_failure(directory):
+    language_version = _resolve_version(prefix, version)
+    directory = _envdir(prefix, language_version)
+    with clean_path_on_failure(directory), in_env(prefix, language_version):
+        if language_version != C.DEFAULT:
+            cmd_output_b(
+                'rustup', 'toolchain', 'install',
+                '--no-self-update', '--profile', 'minimal', language_version,
+                cwd=prefix.prefix_dir,
+            )
+
         packages_to_install: Set[Tuple[str, ...]] = {('--path', '.')}
         for cli_dep in cli_deps:
             cli_dep = cli_dep[len('cli:'):]
-            package, _, version = cli_dep.partition(':')
-            if version != '':
-                packages_to_install.add((package, '--version', version))
+            package, _, dep_version = cli_dep.partition(':')
+            if dep_version != '':
+                packages_to_install.add((package, '--version', dep_version))
             else:
                 packages_to_install.add((package,))
 
+        version_flag = _version_flag(language_version)
         for args in packages_to_install:
             cmd_output_b(
-                'cargo', 'install', '--bins', '--root', directory, *args,
+                'cargo', *version_flag, 'install', '--bins', *args,
                 cwd=prefix.prefix_dir,
             )
 
@@ -102,5 +143,6 @@ def run_hook(
         file_args: Sequence[str],
         color: bool,
 ) -> Tuple[int, bytes]:
-    with in_env(hook.prefix):
+    language_version = _resolve_version(hook.prefix, hook.language_version)
+    with in_env(hook.prefix, language_version):
         return helpers.run_xargs(hook, hook.cmd, file_args, color=color)


### PR DESCRIPTION
**This PR is probably a breaking change**
Previously, using hooks written in rust only required a system installation of Rust and `cargo`, now it instead requires a system installation of `rustup`. `rustup` is the preferred method of installing rust so most users are probably using it already, but some installation methods will install Rust and `cargo` alone.

#### A quick background on rustup
When `rustc`, `cargo`, et al. are installed via `rustup`, the binary that is invoked is actually `rustup` itself. It then does the job of figuring out which toolchain to use and invokes the correct matching binary. It has some interesting behavior when making this decision:
- If a toolchain is explicitly selected on the cli (e.g. `cargo +stable install...`) it will use the specified toolchain or error if it is not installed.
- If a toolchain is selected via an override (there are a few different methods, but the relevant one here is the presence of a `rust-toolchain` file in the hook repo), it will use the specified toolchain or **download it if it is not installed**.
- If no toolchain is selected explicitly or via an override, it will use the default toolchain if one exists, or error out.

This means that, as it is currently implemented, using pre-commit with rust hooks that specify overrides cause these override toolchains to be installed into the system installation, where they accumulate and live forever. This is actually what I was trying to fix originally in this PR, full support for specifying the language version turned out to be a beneficial side-effect.

#### Design
For backwards compatibility, `C.DEFAULT` is still the default version for the rust language, and it implies the use of the system default toolchain.

All public entrypoints into the rust language api start by resolving the actual toolchain version to be used, maintaining the precedence of pre-commit config > override file > default/system. If we actually resolve a version that is not `C.DEFAULT`, we set the env var `RUSTUP_HOME` to point at what is essentially our virtual environment. By resolving the version up front ourselves, we can always be explicit about which toolchain we are using and remove the ambiguity caused by `rustup` trying to resolve overrides.

`rustup` expects to be in charge of it's own data, so this PR has all the toolchains installed side-by-side into a top-level `rustup` directory within a prefix. Each individual hook is still installed into the appropriate `rustenv-{version}` directory. This data is all self contained within a prefix so all the downloaded toolchains can be properly discarded via `pre-commit clean` or `pre-commit gc`.

#### TODO
- [ ] Tests