### PR TITLE
Use more common package definition for R

### DIFF
--- a/pre_commit/languages/r.py
+++ b/pre_commit/languages/r.py
@@ -107,11 +107,13 @@ def install_environment(
               'renv::activate("', file.path(getwd()), '"); '
             )
             writeLines(activate_statement, 'activate.R')
-            is_package <- tryCatch({{
-                content_desc <- read.dcf(file.path(prefix_dir, 'DESCRIPTION'))
-                suppressWarnings(unname(content_desc[,'Type']) == "Package")
-                }},
-                error = function(...) FALSE
+            is_package <- tryCatch(
+              {{
+                  path_desc <- file.path(prefix_dir, 'DESCRIPTION')
+                  suppressWarnings(desc <- read.dcf(path_desc))
+                  "Package" %in% colnames(desc)
+              }},
+              error = function(...) FALSE
             )
             if (is_package) {{
                 renv::install(prefix_dir)


### PR DESCRIPTION
This changes the criteria for determining if a hook repo is an R package: I suggest to check for `Package:` in `DESCRIPTION` (like {devtools}) to determine if a repo is an R package, we previously checked on the less commonly used `Type: Package` field. The definition matters because non-package repos are not installed.

I’ll send a PR to update the docs if it goes through. 