### PR TITLE
Allow symlinked system binaries inside the home dir

### DIFF
--- a/pre_commit/languages/helpers.py
+++ b/pre_commit/languages/helpers.py
@@ -30,9 +30,10 @@ def exe_exists(exe: str) -> bool:
     if found is None:  # exe exists
         return False
 
+    realpath = os.path.realpath(found)
     homedir = os.path.expanduser('~')
     try:
-        common: Optional[str] = os.path.commonpath((found, homedir))
+        common: Optional[str] = os.path.commonpath((realpath, homedir))
     except ValueError:  # on windows, different drives raises ValueError
         common = None
 


### PR DESCRIPTION
In case a user has system binaries symlinked to a directory in the home directory, this is no longer ruled out in `exe_exists` to be used by default.

Following from the discussion in #1668 I think this could be a minor improvement.