### PR TITLE
Permit installing to core.hooksPath if within repo

### DIFF
--- a/pre_commit/git.py
+++ b/pre_commit/git.py
@@ -173,9 +173,13 @@ def has_diff(*args: str, repo: str = '.') -> bool:
     return cmd_output_b(*cmd, cwd=repo, retcode=None)[0] == 1
 
 
-def has_core_hookpaths_set() -> bool:
+def get_core_hookspath() -> str:
     _, out, _ = cmd_output_b('git', 'config', 'core.hooksPath', retcode=None)
-    return bool(out.strip())
+    return out.strip().decode()
+
+
+def has_core_hookpaths_set() -> bool:
+    return bool(get_core_hookspath())
 
 
 def init_repo(path: str, remote: str) -> None:

--- a/tests/commands/install_uninstall_test.py
+++ b/tests/commands/install_uninstall_test.py
@@ -105,9 +105,18 @@ def test_install_multiple_hooks_at_once(in_git_dir, store):
     assert not in_git_dir.join('.git/hooks/pre-push').exists()
 
 
-def test_install_refuses_core_hookspath(in_git_dir, store):
-    cmd_output('git', 'config', '--local', 'core.hooksPath', 'hooks')
+def test_install_refuses_core_hookspath_outside_repo(in_git_dir, store):
+    cmd_output('git', 'config', '--local', 'core.hooksPath', '../hooks')
     assert install(C.CONFIG_FILE, store, hook_types=['pre-commit'])
+    cmd_output('git', 'config', '--local', 'core.hooksPath', '/tmp/hooks')
+    assert install(C.CONFIG_FILE, store, hook_types=['pre-commit'])
+
+
+def test_install_core_hookspath_inside_repo(in_git_dir, store):
+    hook = in_git_dir.join('.hooks').ensure_dir().join('pre-commit')
+    cmd_output('git', 'config', '--local', 'core.hooksPath', '.hooks')
+    install(C.CONFIG_FILE, store, hook_types=['pre-commit'])
+    assert hook.exists()
 
 
 def test_install_hooks_dead_symlink(in_git_dir, store):


### PR DESCRIPTION
 ### Summary

There's [several
threads](https://github.com/pre-commit/pre-commit/issues?q=is%3Aissue+core+hooksPath+is%3Aclosed)
around using pre-commit with global git hooks directories, but I didn't
see anything around setting `core.hooksPath` to a directory within the
repo, as the `husky` tool does.

This patch adds support for installing/uninstalling pre-commit when
`core.hooksPath` references a path within the git repo.

 ### Testing

- add a couple of simple tests
- a repo with core.hooksPath set within the repo, install/uninstall does
  the right thing
- a repo with core.hooksPath set to `../hooks`, install/uninstall fails
- a repo with core.hooksPath unset, install/uninstall works as before