### PR TITLE
Support custom core.hooksPath

### DIFF
--- a/pre_commit/commands/install_uninstall.py
+++ b/pre_commit/commands/install_uninstall.py
@@ -146,7 +146,8 @@ def install(
         if not follow_hooks_path:
             logger.error(
                 'Cowardly refusing to install hooks with `core.hooksPath` set.'
-                '\nhint: `git config --unset-all core.hooksPath`',
+                '\nhint: `git config --unset-all core.hooksPath`, '
+                'or use the `--follow-custom-hooks-path` flag',
             )
             return 1
 

--- a/pre_commit/git.py
+++ b/pre_commit/git.py
@@ -6,6 +6,7 @@ from typing import List
 from typing import MutableMapping
 from typing import Optional
 from typing import Set
+from typing import Tuple
 
 from pre_commit.errors import FatalError
 from pre_commit.util import CalledProcessError
@@ -176,9 +177,9 @@ def has_diff(*args: str, repo: str = '.') -> bool:
     return cmd_output_b(*cmd, cwd=repo, retcode=None)[0] == 1
 
 
-def has_core_hookpaths_set() -> bool:
+def has_core_hookpaths_set() -> Tuple[bool, str]:
     _, out, _ = cmd_output_b('git', 'config', 'core.hooksPath', retcode=None)
-    return bool(out.strip())
+    return bool(out.strip()), out.strip().decode()
 
 
 def init_repo(path: str, remote: str) -> None:

--- a/pre_commit/main.py
+++ b/pre_commit/main.py
@@ -267,6 +267,14 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         ),
     )
 
+    install_parser.add_argument(
+        '--follow-custom-hooks-path', action='store_true', default=False,
+        help=(
+            'Whether to follow a custom core.hooksPath when attempting '
+            'to install the pre-comit hook.'
+        ),
+    )
+
     install_hooks_parser = subparsers.add_parser(
         'install-hooks',
         help=(
@@ -373,6 +381,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
                 overwrite=args.overwrite,
                 hooks=args.install_hooks,
                 skip_on_missing_config=args.allow_missing_config,
+                follow_hooks_path=args.follow_custom_hooks_path,
             )
         elif args.command == 'init-templatedir':
             return init_templatedir(

--- a/pre_commit/main.py
+++ b/pre_commit/main.py
@@ -271,7 +271,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         '--follow-custom-hooks-path', action='store_true', default=False,
         help=(
             'Whether to follow a custom core.hooksPath when attempting '
-            'to install the pre-comit hook.'
+            'to install the pre-commit hook.'
         ),
     )
 


### PR DESCRIPTION
I get that `pre-commit` should treat repos with a set `core.hooksPath` with caution, but it could simply follow that custom directory and install the hooks there, right?
IMO people with a custom hooks directory should have access to `pre-commit`, instead of having to reset their path...

I implemented a `--follow-custom-hooks-path` flag for `pre-commit install` that follows the custom hooks path, whilst maintaining the original behavior of `pre-commit install` (force installing, renaming previously defined hook to `pre-commit.legacy` etc).
I also slightly adjusted the error message when running `pre-commit install` with a set `core.hooksPath`.

(This is my first open-source contribution, hopefully it's not too bad :)