### PR TITLE
Use os.path.realpath() for path canonicalization

### DIFF
--- a/pre_commit/main.py
+++ b/pre_commit/main.py
@@ -159,11 +159,11 @@ def _add_run_options(parser: argparse.ArgumentParser) -> None:
 def _adjust_args_and_chdir(args: argparse.Namespace) -> None:
     # `--config` was specified relative to the non-root working directory
     if os.path.exists(args.config):
-        args.config = os.path.abspath(args.config)
+        args.config = os.path.realpath(args.config)
     if args.command in {'run', 'try-repo'}:
-        args.files = [os.path.abspath(filename) for filename in args.files]
+        args.files = [os.path.realpath(filename) for filename in args.files]
     if args.command == 'try-repo' and os.path.exists(args.repo):
-        args.repo = os.path.abspath(args.repo)
+        args.repo = os.path.realpath(args.repo)
 
     toplevel = git.get_root()
     os.chdir(toplevel)


### PR DESCRIPTION
os.getcwd() returns the real path of the current working directory. In
a directory which has been symlinked this does not necessarily match the
same prefix of the current directory.

When os.getcwd() is cd-ed to relativize path names a few lines below
this results in paths which are relative to symlinked tree, not to the
real tree. This makes path rule matches fail.

Use os.path.realpath() when making paths absolute, so that relative
paths refer to the same tree as os.getcwd()

This was the underlying issue of #2072 