### PR TITLE
Add a `files_contain` option to hook configuration

### DIFF
--- a/pre_commit/clientlib.py
+++ b/pre_commit/clientlib.py
@@ -60,6 +60,7 @@ MANIFEST_HOOK_DICT = cfgv.Map(
     cfgv.Optional('alias', cfgv.check_string, ''),
 
     cfgv.Optional('files', check_string_regex, ''),
+    cfgv.Optional('files_contain', cfgv.check_string, ''),
     cfgv.Optional('exclude', check_string_regex, '^$'),
     cfgv.Optional('types', cfgv.check_array(check_type_tag), ['file']),
     cfgv.Optional('types_or', cfgv.check_array(check_type_tag), []),

--- a/pre_commit/hook.py
+++ b/pre_commit/hook.py
@@ -20,6 +20,7 @@ class Hook(NamedTuple):
     language: str
     alias: str
     files: str
+    files_contain: str
     exclude: str
     types: Sequence[str]
     types_or: Sequence[str]

--- a/pre_commit/meta_hooks/check_useless_excludes.py
+++ b/pre_commit/meta_hooks/check_useless_excludes.py
@@ -53,7 +53,9 @@ def check_useless_excludes(config_file: str) -> int:
             types = hook['types']
             types_or = hook['types_or']
             exclude_types = hook['exclude_types']
+            files_contain = hook['files_contain']
             names = classifier.by_types(names, types, types_or, exclude_types)
+            names = classifier.files_contain(names, files_contain)
             include, exclude = hook['files'], hook['exclude']
             if not exclude_matches_any(names, include, exclude):
                 print(

--- a/tests/commands/run_test.py
+++ b/tests/commands/run_test.py
@@ -1028,6 +1028,18 @@ def test_classifier_empty_types_or(tmpdir):
         assert for_file == ['bar']
 
 
+def test_classifier_files_contain(tmpdir):
+    tmpdir.join('ignored').ensure().write('We\nIgnore\nThis\nFile\n')
+    tmpdir.join('matched').ensure().write('We\nMatch\nThis\nFile\n')
+    with tmpdir.as_cwd():
+        classifier = Classifier(('ignored', 'matched'))
+        files_contain = classifier.files_contain(
+            classifier.filenames,
+            contains='Match',
+        )
+        assert files_contain == ['matched']
+
+
 @pytest.fixture
 def some_filenames():
     return (

--- a/tests/repository_test.py
+++ b/tests/repository_test.py
@@ -986,6 +986,7 @@ def test_manifest_hooks(tempdir_factory, store):
         exclude='^$',
         exclude_types=[],
         files='',
+        files_contain='',
         id='bash_hook',
         language='script',
         language_version='default',


### PR DESCRIPTION
We have a large existing codebase we're slowly trying to roll out some pre-commit checks for. We're currently using the old traditional hand rolled shell scripts to do this, but we'd love to be able to use `pre-commit` for this instead.

This PR adds a hook selector called `files_contain`, which is applied after all the existing selectors. Only files that contain the given string are passed to the hook.

Using a simple pre-defined string instead of a regular expression allows us to still have reasonable performance when using this option.