### PR TITLE
Ignore BOM for autoupdate migration

### DIFF
--- a/pre_commit/commands/migrate_config.py
+++ b/pre_commit/commands/migrate_config.py
@@ -39,14 +39,14 @@ def _migrate_sha_to_rev(contents: str) -> str:
 
 
 def migrate_config(config_file: str, quiet: bool = False) -> int:
-    with open(config_file) as f:
+    with open(config_file, encoding='utf-8-sig') as f:
         orig_contents = contents = f.read()
 
     contents = _migrate_map(contents)
     contents = _migrate_sha_to_rev(contents)
 
     if contents != orig_contents:
-        with open(config_file, 'w') as f:
+        with open(config_file, 'w', encoding='utf-8') as f:
             f.write(contents)
 
         print('Configuration has been migrated.')


### PR DESCRIPTION
PowerShell (v5.1 and before) output is in UTF-16 and also contains BOM (Byte-Order Mark)
pyyaml just support UTF-8 so this makes a problem when `pre-commit sample-config > .pre-commit-config.yaml` runs.

I changed default encoding of migrate_config to 'utf-8-sig' to handle this issue.

https://stackoverflow.com/questions/68487529/how-to-ensure-python-prints-utf-8-and-not-utf-16-le-when-piped-in-powershell
https://docs.python.org/3/library/codecs.html#module-encodings.utf_8_sig