### PR TITLE
Add 'install-hooks' to COMMANDS_NO_GIT

### DIFF
--- a/pre_commit/main.py
+++ b/pre_commit/main.py
@@ -37,7 +37,7 @@ os.environ.pop('__PYVENV_LAUNCHER__', None)
 
 
 COMMANDS_NO_GIT = {
-    'clean', 'gc', 'init-templatedir', 'install-hooks', 'sample-config'
+    'clean', 'gc', 'init-templatedir', 'install-hooks', 'sample-config',
 }
 
 


### PR DESCRIPTION
The `install-hooks` command seems like it does not require a git directory. If that's correct, could it be added to `COMMANDS_NO_GIT`?

My use-case: to build a warmed-up pre-commit image with hook environments ready go. To be used in a CI environment, where the same image can be used for running pre-commit hooks on various different repos (that share the same pre-commit hooks) by mounting the repo into the container. This saves having to add a `git init` in the image :) 