### PR TITLE
Improve path canonicalization

### DIFF
--- a/pre_commit/main.py
+++ b/pre_commit/main.py
@@ -159,8 +159,11 @@ def _add_run_options(parser: argparse.ArgumentParser) -> None:
 def _canon_subpath(path: str, toplevel: str) -> str:
     tail = ''
     while len(path):
-        if os.path.samefile(path, toplevel):
-            return os.path.join(toplevel, tail)
+        try:
+            if os.path.samefile(path, toplevel):
+                return os.path.join(toplevel, tail)
+        except FileNotFoundError:
+            pass
         path, base = os.path.split(path)
         tail = os.path.join(base, tail)
     return tail

--- a/pre_commit/main.py
+++ b/pre_commit/main.py
@@ -187,8 +187,10 @@ def _adjust_args_and_chdir(args: argparse.Namespace) -> None:
 
     args.config = os.path.relpath(args.config)
     if args.command in {'run', 'try-repo'}:
-        args.files = [_canon_relpath(filename, toplevel)
-                      for filename in args.files]
+        args.files = [
+            _canon_relpath(filename, toplevel)
+            for filename in args.files
+        ]
     if args.command == 'try-repo' and os.path.exists(args.repo):
         args.repo = os.path.relpath(args.repo)
 


### PR DESCRIPTION
Followup from #2073.

I apologize for the first PR, it was a bit dry, but I now have a bit more time to dedicate to the issue. This still doesn't include a test case (I need some help there), but I'd like to know if handling such a scenario is something we'd like to handle and thus follow up.

The issue:

The git toplevel is a path with all symlinks leading to the repository
root resolved. When transforming the supplied files to paths relative to
the repository's root we _also_ need to resolve all symlinks up to the
repository's root in order to correctly handle different symlinked paths
that eventually lead to the same repository.

Such paths are currently accepted by git, but are not matched correctly
in pre-commit, as they incorrectly show as out-of-tree.

To relativize paths correctly, iteratively try to replace the trailing
components of the absolute path until the repository root is matched.
The root prefix is then substituted for the real path, yelding a path
with the subtree path untouched. This allows to correctly supply a
symlink to git itself.

For paths which are not directly given as an argument to git, using
os.path.realpath() instead is sufficient.

This allows pre-commit to see the subtree path in the same way as
currently accepted by git. This means that symlinks anywhere in the repository tree as passed through as-is.

Technically, using os.path.realpath() for the dirname of each path would be sufficient: as discussed originally in #2073, git only accepts a symlink as the last path component and refuses others. However, since we would resolve the symlinks components within the repository itself _for_ git, we would also lead to git accepting such paths as a result, which might create some unexpected results with automated tooling (the source of the problem in the first place).

I have an updated version of the test script as provided in the first PR, which is probably not ideal. I'm working on a slow metered connection, and after trying to run pytest I had to stop due to the traffic generated. Any help in doing this selectively would be very appreciated.