### PR TITLE
surround filenames containing whitespace with quotes

### DIFF
--- a/pre_commit/commands/run.py
+++ b/pre_commit/commands/run.py
@@ -109,6 +109,12 @@ class Classifier:
             hook.types_or,
             hook.exclude_types,
         )
+
+        # surround filenames containing whitespace with quotes
+        for f in names:
+            if re.search(r"\s", f):
+                f = '"' + f + '"'
+
         return tuple(names)
 
     @classmethod

--- a/pre_commit/commands/run.py
+++ b/pre_commit/commands/run.py
@@ -112,7 +112,7 @@ class Classifier:
 
         # surround filenames containing whitespace with quotes
         for f in names:
-            if re.search(r"\s", f):
+            if re.search(r'\s', f):
                 f = '"' + f + '"'
 
         return tuple(names)


### PR DESCRIPTION
Filenames containing spaces are currently appended "as-is" to the command-line arguments for hooks, resulting in situations like this:

* Files:
1. `source.cpp`
2. `other file.cpp`

* Command line:
```
my_hook.sh source.cpp other file.cpp
```

This makes it impossible to differentiate filenames from within the hook. Simply adding quotes around filenames fixes the issue