### PR TITLE
Expose hook stage to hook scripts as env var

### DIFF
--- a/pre_commit/commands/run.py
+++ b/pre_commit/commands/run.py
@@ -391,6 +391,9 @@ def run(
     if args.rewrite_command:
         environ['PRE_COMMIT_REWRITE_COMMAND'] = args.rewrite_command
 
+    if args.hook_stage:
+        environ['PRE_COMMIT_HOOK_STAGE'] = args.hook_stage
+
     # Set pre_commit flag
     environ['PRE_COMMIT'] = '1'
 


### PR DESCRIPTION
This change makes it possible for one hook script to run in several stages and change its behavior based on context.

My primary use case is to write a single hook for Git LFS that runs during the `push`, `post-checkout`, `post-commit`, and `post-merge` stages.