### PR TITLE
Pass explicit mirror list including BackPAN to cpan

### DIFF
--- a/pre_commit/languages/perl.py
+++ b/pre_commit/languages/perl.py
@@ -54,7 +54,11 @@ def install_environment(
     with clean_path_on_failure(_envdir(prefix, version)):
         with in_env(prefix, version):
             helpers.run_setup_cmd(
-                prefix, ('cpan', '-T', '.', *additional_dependencies),
+                prefix, (
+                    'cpan', '-T',
+                    '-M', 'https://www.cpan.org,https://backpan.perl.org',
+                    '.', *additional_dependencies,
+                ),
             )
 
 


### PR DESCRIPTION
Gives out of the box ability to use dependencies that have been archived to BackPAN.

Refs https://github.com/pre-commit/pre-commit/pull/2134