### PR TITLE
support gitconfig from env

### DIFF
--- a/pre_commit/git.py
+++ b/pre_commit/git.py
@@ -41,9 +41,10 @@ def no_git_env(
     return {
         k: v for k, v in _env.items()
         if not k.startswith('GIT_') or
+        k.startswith(('GIT_CONFIG_KEY_', 'GIT_CONFIG_VALUE_')) or
         k in {
             'GIT_EXEC_PATH', 'GIT_SSH', 'GIT_SSH_COMMAND', 'GIT_SSL_CAINFO',
-            'GIT_SSL_NO_VERIFY',
+            'GIT_SSL_NO_VERIFY', 'GIT_CONFIG_COUNT',
         }
     }
 

--- a/tests/git_test.py
+++ b/tests/git_test.py
@@ -227,6 +227,11 @@ def test_no_git_env():
         'GIT_SSH': '/usr/bin/ssh',
         'GIT_SSH_COMMAND': 'ssh -o',
         'GIT_DIR': '/none/shall/pass',
+        'GIT_CONFIG_KEY_0': 'user.name',
+        'GIT_CONFIG_VALUE_0': 'anthony',
+        'GIT_CONFIG_KEY_1': 'user.email',
+        'GIT_CONFIG_VALUE_1': 'asottile@example.com',
+        'GIT_CONFIG_COUNT': '2',
     }
     no_git_env = git.no_git_env(env)
     assert no_git_env == {
@@ -234,6 +239,11 @@ def test_no_git_env():
         'GIT_EXEC_PATH': '/some/git/exec/path',
         'GIT_SSH': '/usr/bin/ssh',
         'GIT_SSH_COMMAND': 'ssh -o',
+        'GIT_CONFIG_KEY_0': 'user.name',
+        'GIT_CONFIG_VALUE_0': 'anthony',
+        'GIT_CONFIG_KEY_1': 'user.email',
+        'GIT_CONFIG_VALUE_1': 'asottile@example.com',
+        'GIT_CONFIG_COUNT': '2',
     }
 
 


### PR DESCRIPTION
Add exceptions to the git env so externally configured gitconfig
values set via `GIT_CONFIG_KEY_<n>`, `GIT_CONFIG_VALUE_<n>` and
`GIT_CONFIG_COUNT` get passed through. This is e.g. useful when using
the env to inject insteadOf configurations to force use of proxy servers
in a CI environment.