### PR TITLE
Fix typo in "resources/hook-tmpl"

### DIFF
--- a/pre_commit/resources/hook-tmpl
+++ b/pre_commit/resources/hook-tmpl
@@ -11,7 +11,7 @@ HERE="$(cd "$(dirname "$0")" && pwd)"
 ARGS+=(--hook-dir "$HERE" -- "$@")
 
 if [ -x "$INSTALL_PYTHON" ]; then
-    exec "$INSTALL_PYTHON" -mpre_commit "${ARGS[@]}"
+    exec "$INSTALL_PYTHON" -m pre_commit "${ARGS[@]}"
 elif command -v pre-commit > /dev/null; then
     exec pre-commit "${ARGS[@]}"
 else


### PR DESCRIPTION
Pretty much self-explanatory here ... I've looked into the installed hook scripts & found out that there was a typo in missing space.

While python doesn't, for some reason, seem to have a problem with it, I think we can agree that it's just cleaner this way.