### PR TITLE
Use 'go install' instead of 'go get'

### DIFF
--- a/pre_commit/languages/golang.py
+++ b/pre_commit/languages/golang.py
@@ -79,9 +79,11 @@ def install_environment(
             gopath = directory
         env = dict(os.environ, GOPATH=gopath)
         env.pop('GOBIN', None)
-        cmd_output_b('go', 'get', './...', cwd=repo_src_dir, env=env)
+        cmd_output_b('go', 'install', './...', cwd=repo_src_dir, env=env)
         for dependency in additional_dependencies:
-            cmd_output_b('go', 'get', dependency, cwd=repo_src_dir, env=env)
+            cmd_output_b(
+                'go', 'install', dependency, cwd=repo_src_dir, env=env,
+            )
         # Same some disk space, we don't need these after installation
         rmtree(prefix.path(directory, 'src'))
         pkgdir = prefix.path(directory, 'pkg')


### PR DESCRIPTION
`go install` is the recommended way to install modules starting from go 1.16.
In go 1.18 `go get` cannot be used anymore to install packages [1]. go 1.18 is
not released yet.

[1] https://tip.golang.org/doc/go1.18#go-command