### PR TITLE
pre_commit: prefer pythonX over pythonX.Y

### DIFF
--- a/pre_commit/commands/install_uninstall.py
+++ b/pre_commit/commands/install_uninstall.py
@@ -59,8 +59,8 @@ def shebang() -> str:
         py, _ = os.path.splitext(SYS_EXE)
     else:
         exe_choices = [
-            f'python{sys.version_info[0]}.{sys.version_info[1]}',
             f'python{sys.version_info[0]}',
+            f'python{sys.version_info[0]}.{sys.version_info[1]}',
         ]
         # avoid searching for bare `python` as it's likely to be python 2
         if SYS_EXE != 'python':


### PR DESCRIPTION
This patch prevent reinstallation of pre-commit hooks or any script generated
by shebang function to just update the script shebang, since the scripts are
not heavily dependent on a specific Python 3 version:

    /usr/bin/env: ‘python3.9’: No such file or directory

Signed-off-by: Luís Ferreira <contact@lsferreira.net>

---

Since e622f793c3de2276d6975358c7e35e9b890fbdfd is a thing, shebang is unused, perhaps change this to delete it completely?