### PR TITLE
To comply with shellcheck

### DIFF
--- a/pre_commit/resources/hook-tmpl
+++ b/pre_commit/resources/hook-tmpl
@@ -15,6 +15,6 @@ if [ -x "$INSTALL_PYTHON" ]; then
 elif command -v pre-commit > /dev/null; then
     exec pre-commit "${ARGS[@]}"
 else
-    echo '`pre-commit` not found.  Did you forget to activate your virtualenv?' 1>&2
+    echo "'pre-commit' not found.  Did you forget to activate your virtualenv?" 1>&2
     exit 1
 fi

--- a/tests/commands/install_uninstall_test.py
+++ b/tests/commands/install_uninstall_test.py
@@ -257,8 +257,8 @@ def test_environment_not_sourced(tempdir_factory, store):
         )
         assert ret == 1
         assert out == (
-            '`pre-commit` not found.  '
-            'Did you forget to activate your virtualenv?\n'
+            "'pre-commit' not found.  "
+            "Did you forget to activate your virtualenv?\n"
         )
 
 

--- a/tests/commands/install_uninstall_test.py
+++ b/tests/commands/install_uninstall_test.py
@@ -258,7 +258,7 @@ def test_environment_not_sourced(tempdir_factory, store):
         assert ret == 1
         assert out == (
             "'pre-commit' not found.  "
-            "Did you forget to activate your virtualenv?\n"
+            'Did you forget to activate your virtualenv?\n'
         )
 
 


### PR DESCRIPTION
The `pre-commit` script fails bash linter shellcheck.