### PR TITLE
Make `language: r` work when there is already a renv in the working directory and `RENV_PROJECT` is set

### DIFF
--- a/pre_commit/languages/r.py
+++ b/pre_commit/languages/r.py
@@ -54,6 +54,12 @@ def _prefix_if_non_local_file_entry(
             path = prefix.path(entry[1])
         return (path,)
 
+def _rscript_exec():
+    """
+    When invoked in a sub-process of R, use full path
+    """
+    return os.path.join(os.getenv('R_HOME', ""), 'Rscript')
+
 
 def _entry_validate(entry: Sequence[str]) -> None:
     """
@@ -95,8 +101,9 @@ def install_environment(
         os.makedirs(env_dir, exist_ok=True)
         shutil.copy(prefix.path('renv.lock'), env_dir)
         shutil.copytree(prefix.path('renv'), os.path.join(env_dir, 'renv'))
+        
         cmd_output_b(
-            'Rscript', '--vanilla', '-e',
+            _rscript_exec(), '--vanilla', '-e',
             f"""\
             prefix_dir <- {prefix.prefix_dir!r}
             options(
@@ -130,7 +137,7 @@ def install_environment(
         if additional_dependencies:
             with in_env(prefix, version):
                 cmd_output_b(
-                    'Rscript', *RSCRIPT_OPTS, '-e',
+                    _rscript_exec(), *RSCRIPT_OPTS, '-e',
                     'renv::install(commandArgs(trailingOnly = TRUE))',
                     *additional_dependencies,
                     cwd=env_dir,

--- a/pre_commit/languages/r.py
+++ b/pre_commit/languages/r.py
@@ -58,9 +58,6 @@ def _prefix_if_non_local_file_entry(
 
 
 def _rscript_exec() -> str:
-    """
-    When invoked in a sub-process of R, use full path
-    """
     return os.path.join(os.getenv('R_HOME', ''), 'Rscript')
 
 

--- a/pre_commit/languages/r.py
+++ b/pre_commit/languages/r.py
@@ -8,6 +8,7 @@ from typing import Tuple
 
 from pre_commit.envcontext import envcontext
 from pre_commit.envcontext import PatchesT
+from pre_commit.envcontext import UNSET
 from pre_commit.hook import Hook
 from pre_commit.languages import helpers
 from pre_commit.prefix import Prefix
@@ -23,6 +24,7 @@ healthy = helpers.basic_healthy
 def get_env_patch(venv: str) -> PatchesT:
     return (
         ('R_PROFILE_USER', os.path.join(venv, 'activate.R')),
+        ('RENV_PROJECT', UNSET),
     )
 
 
@@ -54,11 +56,12 @@ def _prefix_if_non_local_file_entry(
             path = prefix.path(entry[1])
         return (path,)
 
-def _rscript_exec():
+
+def _rscript_exec() -> str:
     """
     When invoked in a sub-process of R, use full path
     """
-    return os.path.join(os.getenv('R_HOME', ""), 'Rscript')
+    return os.path.join(os.getenv('R_HOME', ''), 'Rscript')
 
 
 def _entry_validate(entry: Sequence[str]) -> None:
@@ -101,7 +104,7 @@ def install_environment(
         os.makedirs(env_dir, exist_ok=True)
         shutil.copy(prefix.path('renv.lock'), env_dir)
         shutil.copytree(prefix.path('renv'), os.path.join(env_dir, 'renv'))
-        
+
         cmd_output_b(
             _rscript_exec(), '--vanilla', '-e',
             f"""\


### PR DESCRIPTION
Hooks with `language: r` fail [under certain circumstances](https://github.com/lorenzwalthert/precommit/issues/342) if there is a virtual R environment present in the repo where a user want's to use hooks. This is because the env variable `RENV_PROJECT` is set in the terminal by some editors, e.g. RStudio to the virtual R environment of the user, but when pre-commit installs hooks (from that IDE terminal), it should not use that environment (obviously). Hence, we should unset that env variable before installing hooks. See https://github.com/rstudio/renv/issues/900 for an in-depth discussion.

In addition, the command line executable `Rscript` should not be used when called from R itself for some [version incompatibility](https://stat.ethz.ch/pipermail/r-devel/2018-February/075507.html), but instead in that case, the full path should be specified. Hence, if `$R_HOME` is set, we should construct the full path to the executable with it, instead of relying on the `$PATH`.
