### PR TITLE
forbid overriding `entry` for meta hooks

### DIFF
--- a/pre_commit/clientlib.py
+++ b/pre_commit/clientlib.py
@@ -251,12 +251,21 @@ _meta = (
     ),
 )
 
+
+class NotAllowed(cfgv.OptionalNoDefault):
+    def check(self, dct: Dict[str, Any]) -> None:
+        if self.key in dct:
+            raise cfgv.ValidationError(f'{self.key!r} cannot be overridden')
+
+
 META_HOOK_DICT = cfgv.Map(
     'Hook', 'id',
     cfgv.Required('id', cfgv.check_string),
     cfgv.Required('id', cfgv.check_one_of(tuple(k for k, _ in _meta))),
     # language must be system
     cfgv.Optional('language', cfgv.check_one_of({'system'}), 'system'),
+    # entry cannot be overridden
+    NotAllowed('entry', cfgv.check_any),
     *(
         # default to the hook definition for the meta hooks
         cfgv.ConditionalOptional(key, cfgv.check_any, value, 'id', hook_id)

--- a/tests/clientlib_test.py
+++ b/tests/clientlib_test.py
@@ -423,6 +423,13 @@ def test_migrate_to_sha_ok():
         {'repo': 'meta', 'hooks': [{'id': 'identity', 'language': 'python'}]},
         # name override must be string
         {'repo': 'meta', 'hooks': [{'id': 'identity', 'name': False}]},
+        pytest.param(
+            {
+                'repo': 'meta',
+                'hooks': [{'id': 'identity', 'entry': 'echo hi'}],
+            },
+            id='cannot override entry for meta hooks',
+        ),
     ),
 )
 def test_meta_hook_invalid(config_repo):


### PR DESCRIPTION
would have avoided some confusion in #2180