### PR TITLE
Add PRE_COMMIT_ALL_FILES environment variable

### DIFF
--- a/pre_commit/commands/run.py
+++ b/pre_commit/commands/run.py
@@ -387,6 +387,9 @@ def run(
 
     if args.rewrite_command:
         environ['PRE_COMMIT_REWRITE_COMMAND'] = args.rewrite_command
+    
+    if args.all_files:
+        environ['PRE_COMMIT_ALL_FILES'] = '1' if args.all_files else ''
 
     # Set pre_commit flag
     environ['PRE_COMMIT'] = '1'

--- a/pre_commit/commands/run.py
+++ b/pre_commit/commands/run.py
@@ -387,7 +387,7 @@ def run(
 
     if args.rewrite_command:
         environ['PRE_COMMIT_REWRITE_COMMAND'] = args.rewrite_command
-    
+
     if args.all_files:
         environ['PRE_COMMIT_ALL_FILES'] = '1' if args.all_files else ''
 

--- a/tests/commands/run_test.py
+++ b/tests/commands/run_test.py
@@ -524,6 +524,15 @@ def test_checkout_type(cap_out, store, repo_with_passing_hook):
     assert environ['PRE_COMMIT_CHECKOUT_TYPE'] == '1'
 
 
+def test_all_files(cap_out, store, repo_with_passing_hook):
+    args = run_opts(all_files=True)
+    environ: MutableMapping[str, str] = {}
+    ret, printed = _do_run(
+        cap_out, store, repo_with_passing_hook, args, environ,
+    )
+    assert environ['PRE_COMMIT_ALL_FILES'] == '1'
+
+
 def test_has_unmerged_paths(in_merge_conflict):
     assert _has_unmerged_paths() is True
     cmd_output('git', 'add', '.')


### PR DESCRIPTION
Add a `PRE_COMMIT_ALL_FILES` environment variable to allow hooks to determine if pre-commit was called with `--all-files`. This can be useful if different behavior is desired when running pre-commit over all files vs only staged files.

While moving hooks from husky to pre-commit, we ran into a small hiccup. Our UI team was using [`pretty-quick`](https://github.com/azz/pretty-quick) through `husky`. Instead of using pre-commit's prettier hook, we've decided to use a local hook that calls `yarn pretty-quick --staged` directly to avoid conflicting versions of `prettier` between `pre-commit` and our `package.json`.

What has become apparent is `pre-commit run -a` won't do the _right_ thing now because [`--staged`](https://github.com/azz/pretty-quick#--staged-only-git) only works on staged files. When `pre-commit` is run with `--all-files` we'd like to drop `--staged` or use `prettier` instead.

By adding the `PRE_COMMIT_ALL_FILES`, hooks now have additional insight into how `pre-commit` was called. 