### PR TITLE
Adding argument: --summary-json-output-file

### DIFF
--- a/pre_commit/main.py
+++ b/pre_commit/main.py
@@ -154,6 +154,10 @@ def _add_run_options(parser: argparse.ArgumentParser) -> None:
             'the rewrite'
         ),
     )
+    parser.add_argument(
+        '--summary-json-output-file',
+        help='Write summary information to a json file.'
+    )
 
 
 def _adjust_args_and_chdir(args: argparse.Namespace) -> None:


### PR DESCRIPTION
This PR adds the `--summary-json-output-file` option to the `pre-commit run` set of arguments. Providing a filename to this argument will output the summary data in JSON format.

Example usage:
```
pre-commit run -a --summary-json-output-file /tmp/foo.json
```

Example output:
```
{
  "isort": "Passed",
  "black": "Passed",
  "Check for case conflicts": "Passed",
  "Fix End of Files": "Passed",
  "Mixed line ending": "Passed",
  "Trim Trailing Whitespace": "Passed",
  "Flake8": "Passed",
  "Pretty format JSON": "Passed",
  "Check for merge conflicts": "Passed",
  "check blanket noqa": "Passed",
  "check for not-real mock methods": "Passed",
  "use logger.warning(": "Passed",
  "bandit": "Passed",
  "update-schema": "Failed"
}

```