### PR TITLE
Remove Python 2-specific universal wheel specification

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -49,9 +49,6 @@ pre_commit.resources =
     empty_template_*
     hook-tmpl
 
-[bdist_wheel]
-universal = True
-
 [coverage:run]
 plugins = covdefaults
 omit = pre_commit/resources/*


### PR DESCRIPTION
This will mark the wheels as python 3+ only.
We already have the `python_requires = >=3.7` config.
But we still create wheels that are marked as python 2 compatible.
[PyPi pre-commit files](https://pypi.org/project/pre-commit/#files): `pre_commit-2.17.0-py2.py3-none-any.whl `

As far as I understand, there is no need for this `universal` option anymore, since the project is Python 3+ only.
The python 3 build machinery should detect automatically that the python package doesn't have C extensions:
[Packaging and distributing projects: Wheels](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#wheels)

This was hinted to me, by @johnthagen for one of my projects.