### PR TITLE
use Rscript path relative to $R_HOME/bin/...

### DIFF
--- a/pre_commit/languages/r.py
+++ b/pre_commit/languages/r.py
@@ -59,7 +59,11 @@ def _prefix_if_non_local_file_entry(
 
 
 def _rscript_exec() -> str:
-    return os.path.join(os.getenv('R_HOME', ''), 'Rscript')
+    r_home = os.environ.get('R_HOME')
+    if r_home is None:
+        return 'Rscript'
+    else:
+        return os.path.join(r_home, 'bin', 'Rscript')
 
 
 def _entry_validate(entry: Sequence[str]) -> None:

--- a/tests/languages/r_test.py
+++ b/tests/languages/r_test.py
@@ -4,6 +4,7 @@ import os.path
 
 import pytest
 
+from pre_commit import envcontext
 from pre_commit.languages import r
 from testing.fixtures import make_config_from_repo
 from testing.fixtures import make_repo
@@ -129,3 +130,14 @@ def test_r_parsing_file_local(tempdir_factory, store):
         config=config,
         expect_path_prefix=False,
     )
+
+
+def test_rscript_exec_relative_to_r_home():
+    expected = os.path.join('r_home_dir', 'bin', 'Rscript')
+    with envcontext.envcontext((('R_HOME', 'r_home_dir'),)):
+        assert r._rscript_exec() == expected
+
+
+def test_path_rscript_exec_no_r_home_set():
+    with envcontext.envcontext((('R_HOME', envcontext.UNSET),)):
+        assert r._rscript_exec() == 'Rscript'


### PR DESCRIPTION
I'm not familiar enough with developing pre-commit to know how to test out my branch in the same environment where I experienced the bug, but I would be happy to do so with a little more guidance.

I believe this fixes the Rscript path issue I noticed using the built-in Terminal from RStudio Server on Ubuntu.