### PR TITLE
Pick a tag if multiple tags exist on a SHA.

### DIFF
--- a/pre_commit/commands/autoupdate.py
+++ b/pre_commit/commands/autoupdate.py
@@ -59,6 +59,9 @@ class RevInfo(NamedTuple):
             except CalledProcessError:
                 cmd = (*git_cmd, 'rev-parse', 'FETCH_HEAD')
                 rev = cmd_output(*cmd, cwd=tmp)[1].strip()
+            else:
+                if tags_only:
+                    rev = git.get_best_candidate_tag(rev, tmp)
 
             frozen = None
             if freeze:

--- a/pre_commit/git.py
+++ b/pre_commit/git.py
@@ -229,3 +229,18 @@ def check_for_cygwin_mismatch() -> None:
                 f' - python {exe_type[is_cygwin_python]}\n'
                 f' - git {exe_type[is_cygwin_git]}\n',
             )
+
+
+def get_best_candidate_tag(rev: str, git_repo: str) -> str:
+    """Get the best tag candidate.
+
+    Multiple tags can exist on a SHA. Sometimes a moving tag is attached
+    to a version tag. Try to pick the tag that looks like a version.
+    """
+    tags = cmd_output(
+        'git', *NO_FS_MONITOR, 'tag', '--points-at', rev, cwd=git_repo,
+    )[1].splitlines()
+    for tag in tags:
+        if '.' in tag:
+            return tag
+    return rev

--- a/tests/commands/autoupdate_test.py
+++ b/tests/commands/autoupdate_test.py
@@ -103,6 +103,24 @@ def test_rev_info_update_tags_only_does_not_pick_tip(tagged):
     assert new_info.rev == 'v1.2.3'
 
 
+def test_rev_info_update_tags_prefers_version_tag(tagged, out_of_date):
+    cmd_output('git', 'tag', 'latest', cwd=out_of_date.path)
+    config = make_config_from_repo(tagged.path, rev=tagged.original_rev)
+    info = RevInfo.from_config(config)
+    new_info = info.update(tags_only=True, freeze=False)
+    assert new_info.rev == 'v1.2.3'
+
+
+def test_rev_info_update_tags_non_version_tag(out_of_date):
+    cmd_output('git', 'tag', 'latest', cwd=out_of_date.path)
+    config = make_config_from_repo(
+        out_of_date.path, rev=out_of_date.original_rev,
+    )
+    info = RevInfo.from_config(config)
+    new_info = info.update(tags_only=True, freeze=False)
+    assert new_info.rev == 'latest'
+
+
 def test_rev_info_update_freeze_tag(tagged):
     git_commit(cwd=tagged.path)
     config = make_config_from_repo(tagged.path, rev=tagged.original_rev)


### PR DESCRIPTION
This PR uses `git tag --points-at` to check if multiple tags exist for a given tag. If so, it tries to pick the "best" one that looks like a version tag.

Fixes #2311