### PR TITLE
implement default_install_hook_types

### DIFF
--- a/pre_commit/clientlib.py
+++ b/pre_commit/clientlib.py
@@ -336,6 +336,11 @@ CONFIG_SCHEMA = cfgv.Map(
     'Config', None,
 
     cfgv.RequiredRecurse('repos', cfgv.Array(CONFIG_REPO_DICT)),
+    cfgv.Optional(
+        'default_install_hook_types',
+        cfgv.check_array(cfgv.check_one_of(C.HOOK_TYPES)),
+        ['pre-commit'],
+    ),
     cfgv.OptionalRecurse(
         'default_language_version', DEFAULT_LANGUAGE_VERSION, {},
     ),
@@ -355,6 +360,7 @@ CONFIG_SCHEMA = cfgv.Map(
     cfgv.WarnAdditionalKeys(
         (
             'repos',
+            'default_install_hook_types',
             'default_language_version',
             'default_stages',
             'files',

--- a/pre_commit/commands/init_templatedir.py
+++ b/pre_commit/commands/init_templatedir.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import logging
 import os.path
-from typing import Sequence
 
 from pre_commit.commands.install_uninstall import install
 from pre_commit.store import Store
@@ -16,7 +15,7 @@ def init_templatedir(
         config_file: str,
         store: Store,
         directory: str,
-        hook_types: Sequence[str],
+        hook_types: list[str] | None,
         skip_on_missing_config: bool = True,
 ) -> int:
     install(

--- a/pre_commit/commands/install_uninstall.py
+++ b/pre_commit/commands/install_uninstall.py
@@ -5,10 +5,10 @@ import os.path
 import shlex
 import shutil
 import sys
-from typing import Sequence
 
 from pre_commit import git
 from pre_commit import output
+from pre_commit.clientlib import InvalidConfigError
 from pre_commit.clientlib import load_config
 from pre_commit.repository import all_hooks
 from pre_commit.repository import install_hook_envs
@@ -30,6 +30,18 @@ PRIOR_HASHES = (
 CURRENT_HASH = b'138fd403232d2ddd5efb44317e38bf03'
 TEMPLATE_START = '# start templated\n'
 TEMPLATE_END = '# end templated\n'
+
+
+def _hook_types(cfg_filename: str, hook_types: list[str] | None) -> list[str]:
+    if hook_types is not None:
+        return hook_types
+    else:
+        try:
+            cfg = load_config(cfg_filename)
+        except InvalidConfigError:
+            return ['pre-commit']
+        else:
+            return cfg['default_install_hook_types']
 
 
 def _hook_paths(
@@ -103,7 +115,7 @@ def _install_hook_script(
 def install(
         config_file: str,
         store: Store,
-        hook_types: Sequence[str],
+        hook_types: list[str] | None,
         overwrite: bool = False,
         hooks: bool = False,
         skip_on_missing_config: bool = False,
@@ -116,7 +128,7 @@ def install(
         )
         return 1
 
-    for hook_type in hook_types:
+    for hook_type in _hook_types(config_file, hook_types):
         _install_hook_script(
             config_file, hook_type,
             overwrite=overwrite,
@@ -150,7 +162,7 @@ def _uninstall_hook_script(hook_type: str) -> None:
         output.write_line(f'Restored previous hooks to {hook_path}')
 
 
-def uninstall(hook_types: Sequence[str]) -> int:
-    for hook_type in hook_types:
+def uninstall(config_file: str, hook_types: list[str] | None) -> int:
+    for hook_type in _hook_types(config_file, hook_types):
         _uninstall_hook_script(hook_type)
     return 0

--- a/pre_commit/constants.py
+++ b/pre_commit/constants.py
@@ -24,4 +24,10 @@ STAGES = (
     'post-rewrite',
 )
 
+HOOK_TYPES = (
+    'pre-commit', 'pre-merge-commit', 'pre-push', 'prepare-commit-msg',
+    'commit-msg', 'post-commit', 'post-checkout', 'post-merge',
+    'post-rewrite',
+)
+
 DEFAULT = 'default'

--- a/pre_commit/main.py
+++ b/pre_commit/main.py
@@ -4,7 +4,6 @@ import argparse
 import logging
 import os
 import sys
-from typing import Any
 from typing import Sequence
 
 import pre_commit.constants as C
@@ -46,34 +45,10 @@ def _add_config_option(parser: argparse.ArgumentParser) -> None:
     )
 
 
-class AppendReplaceDefault(argparse.Action):
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        super().__init__(*args, **kwargs)
-        self.appended = False
-
-    def __call__(
-            self,
-            parser: argparse.ArgumentParser,
-            namespace: argparse.Namespace,
-            values: str | Sequence[str] | None,
-            option_string: str | None = None,
-    ) -> None:
-        if not self.appended:
-            setattr(namespace, self.dest, [])
-            self.appended = True
-        getattr(namespace, self.dest).append(values)
-
-
 def _add_hook_type_option(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
-        '-t', '--hook-type', choices=(
-            'pre-commit', 'pre-merge-commit', 'pre-push', 'prepare-commit-msg',
-            'commit-msg', 'post-commit', 'post-checkout', 'post-merge',
-            'post-rewrite',
-        ),
-        action=AppendReplaceDefault,
-        default=['pre-commit'],
-        dest='hook_types',
+        '-t', '--hook-type',
+        choices=C.HOOK_TYPES, action='append', dest='hook_types',
     )
 
 
@@ -399,7 +374,10 @@ def main(argv: Sequence[str] | None = None) -> int:
         elif args.command == 'try-repo':
             return try_repo(args)
         elif args.command == 'uninstall':
-            return uninstall(hook_types=args.hook_types)
+            return uninstall(
+                config_file=args.config,
+                hook_types=args.hook_types,
+            )
         else:
             raise NotImplementedError(
                 f'Command {args.command} not implemented.',

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -14,20 +14,6 @@ from testing.auto_namedtuple import auto_namedtuple
 from testing.util import cwd
 
 
-@pytest.mark.parametrize(
-    ('argv', 'expected'),
-    (
-        ((), ['f']),
-        (('--f', 'x'), ['x']),
-        (('--f', 'x', '--f', 'y'), ['x', 'y']),
-    ),
-)
-def test_append_replace_default(argv, expected):
-    parser = argparse.ArgumentParser()
-    parser.add_argument('--f', action=main.AppendReplaceDefault, default=['f'])
-    assert parser.parse_args(argv).f == expected
-
-
 def _args(**kwargs):
     kwargs.setdefault('command', 'help')
     kwargs.setdefault('config', C.CONFIG_FILE)
@@ -172,7 +158,7 @@ def test_init_templatedir(mock_store_dir):
 
     assert patch.call_count == 1
     assert 'tdir' in patch.call_args[0]
-    assert patch.call_args[1]['hook_types'] == ['pre-commit']
+    assert patch.call_args[1]['hook_types'] is None
     assert patch.call_args[1]['skip_on_missing_config'] is True
 
 


### PR DESCRIPTION
this implements a configurable fallback for the default value of `pre-commit install`

(this feature is kinda broken by design, but maybe this will stop people asking for it)