### PR TITLE
pre-push: fix stdin line splitting when <local ref> has whitespace

### DIFF
--- a/pre_commit/commands/hook_impl.py
+++ b/pre_commit/commands/hook_impl.py
@@ -114,7 +114,8 @@ def _pre_push_ns(
     remote_url = args[1]
 
     for line in stdin.decode().splitlines():
-        local_branch, local_sha, remote_branch, remote_sha = line.split()
+        parts = line.rsplit(maxsplit=3)
+        local_branch, local_sha, remote_branch, remote_sha = parts
         if local_sha == Z40:
             continue
         elif remote_sha != Z40 and _rev_exists(remote_sha):

--- a/tests/commands/hook_impl_test.py
+++ b/tests/commands/hook_impl_test.py
@@ -242,6 +242,18 @@ def test_run_ns_pre_push_new_branch_existing_rev(push_example):
     assert ns is None
 
 
+def test_run_ns_pre_push_ref_with_whitespace(push_example):
+    src, src_head, clone, _ = push_example
+
+    with cwd(clone):
+        args = ('origin', src)
+        line = f'HEAD^{{/ }} {src_head} refs/heads/b2 {hook_impl.Z40}\n'
+        stdin = line.encode()
+        ns = hook_impl._run_ns('pre-push', False, args, stdin)
+
+    assert ns is None
+
+
 def test_pushing_orphan_branch(push_example):
     src, src_head, clone, _ = push_example
 


### PR DESCRIPTION
From the `pre-push.sample` file:

> Information about the commits which are being pushed is supplied as
> lines to the standard input in the form:
>
>   `<local ref> <local sha1> <remote ref> <remote sha1>`

When `<local ref>` is not simply a branch name, but a more general
ref (see git-rev-parse(1)), it could contain whitespace, and that
breaks the split() call that expected only 3 spaces in the line.

Changed to use `rsplit(maxsplit=3)` since only the <local ref> is
likely to have embedded whitespace.

Added a new test case for the same.

Fixes #2344 