### PR TITLE
Fix shellcheck warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@
 
 A framework for managing and maintaining multi-language pre-commit hooks.
 
-For more information see: https://pre-commit.com/
+For more information see: <https://pre-commit.com/>

--- a/pre_commit/resources/hook-tmpl
+++ b/pre_commit/resources/hook-tmpl
@@ -15,6 +15,6 @@ if [ -x "$INSTALL_PYTHON" ]; then
 elif command -v pre-commit > /dev/null; then
     exec pre-commit "${ARGS[@]}"
 else
-    echo '`pre-commit` not found.  Did you forget to activate your virtualenv?' 1>&2
+    echo "\`pre-commit\` not found.  Did you forget to activate your virtualenv?" 1>&2
     exit 1
 fi

--- a/testing/resources/modified_file_returns_zero_repo/bin/hook.sh
+++ b/testing/resources/modified_file_returns_zero_repo/bin/hook.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-for f in $@; do
+for f in "$@"; do
     # Non UTF-8 bytes
     echo -e '\x01\x97' > "$f"
     echo "Modified: $f!"

--- a/testing/resources/modified_file_returns_zero_repo/bin/hook3.sh
+++ b/testing/resources/modified_file_returns_zero_repo/bin/hook3.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-for f in $@; do
+for f in "$@"; do
     # Non UTF-8 bytes
     echo -e '\x01\x97' > "$f"
 done


### PR DESCRIPTION
Found some shellcheck warnings

* https://github.com/koalaman/shellcheck/wiki/SC2068
* https://github.com/koalaman/shellcheck/wiki/SC2016

and no shellcheck but when I'm at it...

* https://github.com/DavidAnson/markdownlint/blob/v0.25.1/doc/Rules.md#md034---bare-url-used