### PR TITLE
Force gem installation into `GEM_HOME`

### DIFF
--- a/pre_commit/languages/ruby.py
+++ b/pre_commit/languages/ruby.py
@@ -138,6 +138,7 @@ def install_environment(
                 (
                     'gem', 'install',
                     '--no-document', '--no-format-executable',
+                    '--no-user-install',
                     *prefix.star('.gem'), *additional_dependencies,
                 ),
             )

--- a/tests/repository_test.py
+++ b/tests/repository_test.py
@@ -332,6 +332,13 @@ def test_run_a_ruby_hook(tempdir_factory, store):
     )
 
 
+def test_run_a_ruby_hook_with_user_install_set(tempdir_factory, store, tmpdir):
+    gemrc = tmpdir.join('gemrc')
+    gemrc.write('gem: --user-install\n')
+    with envcontext((('GEMRC', str(gemrc)),)):
+        test_run_a_ruby_hook(tempdir_factory, store)
+
+
 @xfailif_windows  # pragma: win32 no cover
 def test_run_versioned_ruby_hook(tempdir_factory, store):
     _test_hook_repo(


### PR DESCRIPTION
When `--user-install` is set in the gemrc config file, `gem` ignores
`GEM_HOME`. `--no-user-install` prevents this behaviour.

Resolves #2383