### PR TITLE
Switch pty use to fix solaris

### DIFF
--- a/pre_commit/util.py
+++ b/pre_commit/util.py
@@ -168,10 +168,10 @@ if os.name != 'nt':  # pragma: win32 no cover
             self.r, self.w = openpty()
 
             # tty flags normally change \n to \r\n
-            attrs = termios.tcgetattr(self.r)
+            attrs = termios.tcgetattr(self.w)
             assert isinstance(attrs[1], int)
             attrs[1] &= ~(termios.ONLCR | termios.OPOST)
-            termios.tcsetattr(self.r, termios.TCSANOW, attrs)
+            termios.tcsetattr(self.w, termios.TCSANOW, attrs)
 
             return self
 


### PR DESCRIPTION
Use the child instead of parent fd when manipulating pty for color.

Fixes https://github.com/pre-commit/pre-commit/issues/2389