### PR TITLE
force default branch name for tests

### DIFF
--- a/testing/fixtures.py
+++ b/testing/fixtures.py
@@ -38,7 +38,7 @@ def copy_tree_to_path(src_dir, dest_dir):
 
 def git_dir(tempdir_factory):
     path = tempdir_factory.get()
-    cmd_output('git', 'init', path)
+    cmd_output('git', '-c', 'init.defaultBranch=master', 'init', path)
     return path
 
 


### PR DESCRIPTION
Fixes https://github.com/pre-commit/pre-commit/issues/2391

More modern git versions have the ability to set the default branch name, and recent documentation warns against expecting the branch name to be stable. As such, added an explicit set to  `master` (as that was the minimal change and is backwards compatible with older versions of git.

Call is made in a try/except block checking for errors and stepping back to the previous version without initial-branch