### PR TITLE
Add PRE_COMIMT_ARGV environment variable

### DIFF
--- a/pre_commit/main.py
+++ b/pre_commit/main.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import logging
 import os
+import re
 import sys
 from typing import Sequence
 
@@ -345,6 +346,8 @@ def main(argv: Sequence[str] | None = None) -> int:
     if len(argv) == 0:
         argv = ['run']
     args = parser.parse_args(argv)
+
+    os.environ['PRE_COMMIT_ARGV'] = ' '.join([re.escape(x) for x in argv])
 
     if args.command == 'help' and args.help_cmd:
         parser.parse_args([args.help_cmd, '--help'])


### PR DESCRIPTION
This pull request adds an environment variable called `PRE_COMMIT_ARGV` cointaining the actual `pre-commit` arguments (escaped).

The main reason to add this environment variable is so the arguments can be used on inner `pre-commit` executions. This use case is for requests like [this](https://github.com/pre-commit/pre-commit/issues/2337) and [this](https://github.com/pre-commit/pre-commit/issues/2335). Having this env var allows you to have something like:

### main repository

 `.pre_commit_config.yaml`:
```yaml
repos:
- repo: git@github.com:mycompany/pre-commit.git
  rev: v0.1
  hooks:
    - id: custom_hooks
```

### `mycompany/pre-commit` repository
`.pre-commit-hooks.yaml`:
```yaml
- id: required
  name: Custom checks
  description: Custom checks
  entry: pre_commit_hooks/custom_hooks.sh
  language: script
  verbose: true
  pass_filenames: false
```

`pre_commit_hooks/custom_hooks.sh`:
```bash
#!/usr/bin/env bash

CUSTOM_HOOKS_DIR="$(dirname "$(readlink -f "$0")")"

eval pre-commit $PRE_COMMIT_ARGV -c "$CUSTOM_HOOKS_DIR/pre-commit-config.yaml"
```

`pre_commit_hooks/pre-commit-config.yaml`:
```yaml
repos:
- repo: https://github.com/antonbabenko/pre-commit-terraform
  rev: v1.64.0
  hooks:
    - id: terraform_fmt
    - id: terraform_tflint
```
