### PR TITLE
remove warnings checks

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,24 +21,6 @@ from testing.util import cwd
 from testing.util import git_commit
 
 
-@pytest.fixture(autouse=True)
-def no_warnings(recwarn):
-    yield
-    warnings = []
-    for warning in recwarn:  # pragma: no cover
-        message = str(warning.message)
-        # ImportWarning: Not importing directory '...' missing __init__(.py)
-        if not (
-            isinstance(warning.message, ImportWarning) and
-            message.startswith('Not importing directory ') and
-            ' missing __init__' in message
-        ):
-            warnings.append(
-                f'{warning.filename}:{warning.lineno} {message}',
-            )
-    assert not warnings
-
-
 @pytest.fixture
 def tempdir_factory(tmpdir):
     class TmpdirFactory:


### PR DESCRIPTION
this wasn't all that useful -- and most of it was for checking python 2 things