### PR TITLE
Enforce binary installs also for dependencies in R

### DIFF
--- a/pre_commit/languages/r.py
+++ b/pre_commit/languages/r.py
@@ -158,7 +158,7 @@ def _inline_r_setup(code: str) -> str:
     only be configured via R options once R has started. These are set here.
     """
     with_option = f"""\
-    options(install.packages.compile.from.source = "never")
+    options(install.packages.compile.from.source = "never", pkgType = "binary")
     {code}
     """
     return with_option


### PR DESCRIPTION
Should solve problems detected in #2459.