### PR TITLE
Remove `.` from `Installing environment for` log

### DIFF
--- a/pre_commit/repository.py
+++ b/pre_commit/repository.py
@@ -63,7 +63,7 @@ def _hook_installed(hook: Hook) -> bool:
 
 
 def _hook_install(hook: Hook) -> None:
-    logger.info(f'Installing environment for {hook.src}.')
+    logger.info(f'Installing environment for {hook.src}')
     logger.info('Once installed this environment will be reused.')
     logger.info('This may take a few minutes...')
 


### PR DESCRIPTION
This is a minor thing, but a bit frustrating.
Some services / terminals like xterm, hyper, and github actions detect links:
<img width="641" alt="Снимок экрана 2022-08-15 в 12 14 15" src="https://user-images.githubusercontent.com/4660275/184609193-43f222c5-32de-444f-a42f-610a600d94ca.png">

But, when clicked, they lead to a url with `.` in it, and it does not exist:
<img width="727" alt="Снимок экрана 2022-08-15 в 12 14 26" src="https://user-images.githubusercontent.com/4660275/184609285-ce3c5c57-df66-4b41-87a0-f2c9702fbba8.png">
