### PR TITLE
Fix zipapp build on mac

### DIFF
--- a/pre_commit/clientlib.py
+++ b/pre_commit/clientlib.py
@@ -81,6 +81,7 @@ MANIFEST_HOOK_DICT = cfgv.Map(
     cfgv.Optional('require_serial', cfgv.check_bool, False),
     cfgv.Optional('stages', cfgv.check_array(cfgv.check_one_of(C.STAGES)), []),
     cfgv.Optional('verbose', cfgv.check_bool, False),
+    cfgv.Optional('commit_changes', cfgv.check_bool, False),
 )
 MANIFEST_SCHEMA = cfgv.Array(MANIFEST_HOOK_DICT)
 

--- a/pre_commit/git.py
+++ b/pre_commit/git.py
@@ -215,6 +215,11 @@ def commit(repo: str = '.') -> None:
     cmd_output_b(*cmd, cwd=repo, env=env)
 
 
+def update_changes(repo: str = '.') -> None:
+    cmd = ('git', 'add', '--update')
+    cmd_output_b(*cmd, cwd=repo)
+
+
 def git_path(name: str, repo: str = '.') -> str:
     _, out, _ = cmd_output('git', 'rev-parse', '--git-path', name, cwd=repo)
     return os.path.join(repo, out.strip())

--- a/pre_commit/hook.py
+++ b/pre_commit/hook.py
@@ -36,6 +36,7 @@ class Hook(NamedTuple):
     require_serial: bool
     stages: Sequence[str]
     verbose: bool
+    commit_changes: bool
 
     @property
     def cmd(self) -> tuple[str, ...]:

--- a/pre_commit/staged_files_only.py
+++ b/pre_commit/staged_files_only.py
@@ -82,8 +82,34 @@ def _unstaged_changes_cleared(patch_dir: str) -> Generator[None, None, None]:
                 # We failed to apply the patch, presumably due to fixes made
                 # by hooks.
                 # Roll back the changes made by hooks.
-                cmd_output_b(*_CHECKOUT_CMD, env=no_checkout_env)
+                cmd_output_b(
+                    'git',
+                    'restore',
+                    '--source',
+                    tree,
+                    '--worktree',
+                    '.',
+                    env=no_checkout_env,
+                )
                 _git_apply(patch_filename)
+
+                # Save the current satte of the index which may include
+                # partially staged files, a new commit, etc.
+                new_tree = cmd_output('git', 'write-tree')[1].strip()
+                # Restore worktree to the patch base (which updates the index
+                # as a side-effect).
+                cmd_output_b(
+                    'git',
+                    'checkout',
+                    tree,
+                    '--',
+                    '.',
+                    env=no_checkout_env,
+                )
+                # Apply patch.
+                _git_apply(patch_filename)
+                # Restore new saved index.
+                cmd_output_b('git', 'read-tree', new_tree, env=no_checkout_env)
 
             logger.info(f'Restored changes from {patch_filename}.')
     else:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = pre_commit
-version = 2.20.0
+version = 2.20.0.post1.dev1
 description = A framework for managing and maintaining multi-language pre-commit hooks.
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/testing/zipapp/make
+++ b/testing/zipapp/make
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import argparse
 import base64
+import configparser
 import hashlib
 import importlib.resources
 import io
@@ -60,7 +61,7 @@ def _write_cache_key(version: str, wheeldir: str, dest: str) -> None:
 
 def main() -> int:
     parser = argparse.ArgumentParser()
-    parser.add_argument('version')
+    parser.add_argument('--version', required=False)
     args = parser.parse_args()
 
     with tempfile.TemporaryDirectory() as tmpdir:
@@ -70,10 +71,25 @@ def main() -> int:
         _msg('building podman image...')
         _exit_if_retv('podman', 'build', '-q', '-t', IMG, HERE)
 
+        if args.version:
+            wheel_spec = f'pre_commit=={args.version}'
+            volume_options_for_current_dir = ()
+            version = args.version
+        else:
+            wheel_spec = 'pre_commit'
+            cwd = os.getcwd()
+            volume_options_for_current_dir = (  # type: ignore
+                '--volume', f'{cwd}:{cwd}:ro',
+            )
+            config = configparser.ConfigParser()
+            config.read(f'{cwd}/setup.cfg')
+            version = config['metadata']['version']
+
         _msg('populating wheels...')
         _exit_if_retv(
-            'podman', 'run', '--rm', '--volume', f'{wheeldir}:/wheels:rw', IMG,
-            'pip', 'wheel', f'pre_commit=={args.version}', 'setuptools',
+            'podman', 'run', '--rm', '--volume', f'{wheeldir}:/wheels:rw',
+            *volume_options_for_current_dir, IMG,
+            'pip', 'wheel', wheel_spec, 'setuptools',
             '--wheel-dir', '/wheels',
         )
 
@@ -94,9 +110,9 @@ def main() -> int:
         shutil.copy(file_lock_py, file_lock_py_dest)
 
         _msg('writing CACHE_KEY...')
-        _write_cache_key(args.version, wheeldir, tmpdir)
+        _write_cache_key(version, wheeldir, tmpdir)
 
-        filename = f'pre-commit-{args.version}.pyz'
+        filename = f'pre-commit-{version}.pyz'
         _msg(f'writing {filename}...')
         shebang = '/usr/bin/env python3'
         zipapp.create_archive(tmpdir, filename, interpreter=shebang)


### PR DESCRIPTION
Changes:

- when version number is not provided, build a zipapp for the checked-out version according to setup.cfg
- fix errors when building under podman on mac

To build:
1. Ensure volumes are mapped to the podman VM:
```
podman machine init -v ${TMPDIR}:${TMPDIR} -v ${HOME}:${HOME}
podman machine start
```

2. Ensure dependencies are installed:
```
mamba install coreutils
pip install -r requirements-dev.txt
```

3. Build zipapp:
```
python3 testing/zipapp/make
```