### PR TITLE
Remove period from 'Stashing unstaged files to {patch_filename}.'

### DIFF
--- a/pre_commit/staged_files_only.py
+++ b/pre_commit/staged_files_only.py
@@ -58,7 +58,7 @@ def _unstaged_changes_cleared(patch_dir: str) -> Generator[None, None, None]:
         patch_filename = f'patch{int(time.time())}-{os.getpid()}'
         patch_filename = os.path.join(patch_dir, patch_filename)
         logger.warning('Unstaged files detected.')
-        logger.info(f'Stashing unstaged files to {patch_filename}.')
+        logger.info(f'Stashing unstaged files to {patch_filename}')
         # Save the current unstaged changes as a patch
         os.makedirs(patch_dir, exist_ok=True)
         with open(patch_filename, 'wb') as patch_file:


### PR DESCRIPTION
This extra period makes it ever so slightly more difficult to copy the path in the rare circumstance where I actually care about the path.