### PR TITLE
Use reversed colors for better legibility

### DIFF
--- a/pre_commit/color.py
+++ b/pre_commit/color.py
@@ -56,10 +56,10 @@ if sys.platform == 'win32':  # pragma: no cover (windows)
 else:  # pragma: win32 no cover
     terminal_supports_color = True
 
-RED = '\033[41m'
-GREEN = '\033[42m'
-YELLOW = '\033[43;30m'
-TURQUOISE = '\033[46;30m'
+RED = '\033[31;7m'
+GREEN = '\033[32;7m'
+YELLOW = '\033[33;7m'
+TURQUOISE = '\033[36;7m'
 SUBTLE = '\033[2m'
 NORMAL = '\033[m'
 


### PR DESCRIPTION
# Problem

The current set of colors have the following problems.

- The green and red texts are hard to read because the grey color of the theme text is not readable against those backgrounds.
- The yellow and turquoise texts look weird on light backgrounds due to the use of dark text.

These issues have been raised before: #1897, #969

## Screenshots

**Dark theme:**
<img width="777" alt="Screenshot 2022-08-23 at 11 22 36 AM" src="https://user-images.githubusercontent.com/16580576/186080471-4e4c2c36-1e93-4ad9-8712-7decc0589df4.png">

**Light theme:**
<img width="777" alt="Screenshot 2022-08-23 at 11 22 56 AM" src="https://user-images.githubusercontent.com/16580576/186080511-0f473509-3b8a-4eb7-86b0-19c60cfba843.png">

# Solution

This PR changes the ANSI codes to use the colors on the foreground (using ANSI codes 3x) and then reverses them with the background (using ANSI code 7). This makes sure that text is always readable and looks harmonious with the background.

## Screenshots

**Dark theme:**
<img width="777" alt="Screenshot 2022-08-23 at 11 26 58 AM" src="https://user-images.githubusercontent.com/16580576/186081106-671c50e0-2914-4103-984e-9dd695e971ec.png">

**Light theme:**
<img width="777" alt="Screenshot 2022-08-23 at 11 27 41 AM" src="https://user-images.githubusercontent.com/16580576/186081190-3507b415-b349-45d2-bb39-e71b1962899f.png">

The new colors are legible in both modes.