### PR TITLE
Add shell completions by shtab

### DIFF
--- a/pre_commit/_shtab.py
+++ b/pre_commit/_shtab.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from argparse import ArgumentParser
+from typing import Any
+
+FILE = None
+DIRECTORY = DIR = None
+
+
+def add_argument_to(
+    parser: ArgumentParser, *args: list[Any], **kwargs: dict[Any, Any],
+) -> ArgumentParser:
+    from argparse import Action
+
+    Action.complete = None  # type: ignore
+    return parser

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,6 +39,10 @@ console_scripts =
     pre-commit-validate-config = pre_commit.clientlib:validate_config_main
     pre-commit-validate-manifest = pre_commit.clientlib:validate_manifest_main
 
+[options.extras_require]
+completion =
+    shtab
+
 [options.package_data]
 pre_commit.resources =
     *.tar.gz


### PR DESCRIPTION
Maybe fix #1119. Just offer a few commonplace remarks by way of introduction in the
hope that others may come up with valuable opinions.

> complete for installed hooks

Not fixed.

> don't really want to add a dependency for this

Introduce an extras_require. Even if shtab is not installed, it still can work.

```sh
pre-commit --print-completion bash | sudo tee /usr/share/bash-completion/completions/pre-commit
pre-commit --print-completion zsh | sudo tee /usr/share/zsh/site-functions/_pre-commit
pre-commit --print-completion tcsh | sudo tee /etc/profile.d/pre-commit.completion.csh
```
