### PR TITLE
Migrate from dependency toml because it has not yet reached v1.0

### DIFF
--- a/pre_commit/languages/rust.py
+++ b/pre_commit/languages/rust.py
@@ -5,7 +5,11 @@ import os.path
 from typing import Generator
 from typing import Sequence
 
-import toml
+try:
+    from tomllib import load as toml_load
+except ModuleNotFoundError:  # Python < 3.11
+    from tomli import load as toml_load
+from tomli_w import dump as toml_dump
 
 import pre_commit.constants as C
 from pre_commit.envcontext import envcontext
@@ -42,13 +46,13 @@ def _add_dependencies(
         additional_dependencies: set[str],
 ) -> None:
     with open(cargo_toml_path, 'r+') as f:
-        cargo_toml = toml.load(f)
+        cargo_toml = toml_load(f)
         cargo_toml.setdefault('dependencies', {})
         for dep in additional_dependencies:
             name, _, spec = dep.partition(':')
             cargo_toml['dependencies'][name] = spec or '*'
         f.seek(0)
-        toml.dump(cargo_toml, f)
+        toml_dump(cargo_toml, f)
         f.truncate()
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,8 @@ install_requires =
     identify>=1.0.0
     nodeenv>=0.11.1
     pyyaml>=5.1
-    toml
+    tomli;python_version<"3.11"
+    tomli-w
     virtualenv>=20.10.0
     importlib-metadata;python_version<"3.8"
 python_requires = >=3.7


### PR DESCRIPTION
https://pypi.org/project/toml -- Currently v0.10.2 is still zero-ver and does not align with the recommendations at https://docs.python.org/3.11/library/tomllib.html

This pull request recommends the adoption of:
* https://pypi.org/project/tomli -- Currently v2.0.1
* https://pypi.org/project/tomli-w -- Currently v1.0.0