### PR TITLE
Rust as 1st class language

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,9 +65,9 @@ to implement.  The current implemented languages are at varying levels:
 - 0th class - pre-commit does not require any dependencies for these languages
   as they're not actually languages (current examples: fail, pygrep)
 - 1st class - pre-commit will bootstrap a full interpreter requiring nothing to
-  be installed globally (current examples: node, ruby)
+  be installed globally (current examples: node, ruby, rust)
 - 2nd class - pre-commit requires the user to install the language globally but
-  will install tools in an isolated fashion (current examples: python, go, rust,
+  will install tools in an isolated fashion (current examples: python, go,
   swift, docker).
 - 3rd class - pre-commit requires the user to install both the tool and the
   language globally (current examples: script, system)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,6 +17,8 @@ jobs:
   parameters:
     toxenvs: [py37]
     os: windows
+    additional_variables:
+      TEMP: C:\Temp
     pre_test:
     - task: UseRubyVersion@0
     - powershell: Write-Host "##vso[task.prependpath]$env:CONDA\Scripts"

--- a/tests/languages/rust_test.py
+++ b/tests/languages/rust_test.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+
+import pre_commit.constants as C
+from pre_commit import parse_shebang
+from pre_commit.languages import rust
+from pre_commit.prefix import Prefix
+from pre_commit.util import cmd_output
+
+ACTUAL_GET_DEFAULT_VERSION = rust.get_default_version.__wrapped__
+
+
+@pytest.fixture
+def cmd_output_b_mck():
+    with mock.patch.object(rust, 'cmd_output_b') as mck:
+        yield mck
+
+
+def test_sets_system_when_rust_is_available(cmd_output_b_mck):
+    cmd_output_b_mck.return_value = (0, b'', b'')
+    assert ACTUAL_GET_DEFAULT_VERSION() == 'system'
+
+
+def test_uses_default_when_rust_is_not_available(cmd_output_b_mck):
+    cmd_output_b_mck.return_value = (127, b'', b'error: not found')
+    assert ACTUAL_GET_DEFAULT_VERSION() == C.DEFAULT
+
+
+@pytest.mark.parametrize('language_version', (C.DEFAULT, '1.56.0'))
+def test_installs_with_bootstrapped_rustup(tmpdir, language_version):
+    tmpdir.join('src', 'main.rs').ensure().write(
+        'fn main() {\n'
+        '    println!("Hello, world!");\n'
+        '}\n',
+    )
+    tmpdir.join('Cargo.toml').ensure().write(
+        '[package]\n'
+        'name = "hello_world"\n'
+        'version = "0.1.0"\n'
+        'edition = "2021"\n',
+    )
+    prefix = Prefix(str(tmpdir))
+
+    find_executable_exes = []
+
+    original_find_executable = parse_shebang.find_executable
+
+    def mocked_find_executable(exe: str) -> str | None:
+        """
+        Return `None` the first time `find_executable` is called to ensure
+        that the bootstrapping code is executed, then just let the function
+        work as normal.
+
+        Also log the arguments to ensure that everything works as expected.
+        """
+        find_executable_exes.append(exe)
+        if len(find_executable_exes) == 1:
+            return None
+        return original_find_executable(exe)
+
+    with mock.patch.object(parse_shebang, 'find_executable') as find_exe_mck:
+        find_exe_mck.side_effect = mocked_find_executable
+        rust.install_environment(prefix, language_version, ())
+        assert find_executable_exes == ['rustup', 'rustup', 'cargo']
+
+    with rust.in_env(prefix, language_version):
+        assert cmd_output('hello_world')[1] == 'Hello, world!\n'

--- a/tests/repository_test.py
+++ b/tests/repository_test.py
@@ -471,7 +471,7 @@ def test_additional_rust_cli_dependencies_installed(
     hook = _get_hook(config, store, 'rust-hook')
     binaries = os.listdir(
         hook.prefix.path(
-            helpers.environment_dir(rust.ENVIRONMENT_DIR, C.DEFAULT), 'bin',
+            helpers.environment_dir(rust.ENVIRONMENT_DIR, 'system'), 'bin',
         ),
     )
     # normalize for windows
@@ -490,7 +490,7 @@ def test_additional_rust_lib_dependencies_installed(
     hook = _get_hook(config, store, 'rust-hook')
     binaries = os.listdir(
         hook.prefix.path(
-            helpers.environment_dir(rust.ENVIRONMENT_DIR, C.DEFAULT), 'bin',
+            helpers.environment_dir(rust.ENVIRONMENT_DIR, 'system'), 'bin',
         ),
     )
     # normalize for windows


### PR DESCRIPTION
This adds support for pinning a specific rust version and bootstrapping rust with rustup/rustup-init.

I tried to follow the desired behavior described here: https://github.com/pre-commit/pre-commit/pull/1863#issuecomment-817185697