### PR TITLE
Support Golang major versions

### DIFF
--- a/pre_commit/languages/golang.py
+++ b/pre_commit/languages/golang.py
@@ -57,7 +57,7 @@ def guess_go_dir(remote_url: str) -> str:
         return 'unknown_src_dir'
 
 
-def find_go_mod_dir(repo_src_dir):
+def find_go_mod_dir(repo_src_dir: str) -> str:
     # First the root
     if os.path.exists(os.path.join(repo_src_dir, 'go.mod')):
         return repo_src_dir
@@ -66,7 +66,7 @@ def find_go_mod_dir(repo_src_dir):
         if each.is_dir() and re.fullmatch('v[0-9]+', each.name) \
                 and os.path.exists(os.path.join(each.path, 'go.mod')):
             return each.path
-    raise FatalError("could not find a go.mod file in this git repository")
+    raise FatalError('could not find a go.mod file in this git repository')
 
 
 def install_environment(


### PR DESCRIPTION
Golang has a special treatment of major versions. If you go from v1.x.x to v2.x.x you are supposed to put all your code in a v2 directory in the root of the repository. This break pre-commit because pre-commit tries to do a `go install ./...` in the root, this fails because now the `go.mod` file is missing. See this repository for example: https://github.com/nicksnyder/go-i18n.

This patch checks if there is a go.mod in the root of the project, if it is not it will scan all subdirectories matching the v[0-9]+ pattern until it finds one containing a go.mod file. This will be the _cwd_ for the install command.

For reference:
https://go.dev/doc/modules/major-version