### PR TITLE
allow GIT_ASKPASS as a pass through env var 

### DIFF
--- a/pre_commit/git.py
+++ b/pre_commit/git.py
@@ -43,6 +43,7 @@ def no_git_env(_env: Mapping[str, str] | None = None) -> dict[str, str]:
             'GIT_SSL_NO_VERIFY', 'GIT_CONFIG_COUNT',
             'GIT_HTTP_PROXY_AUTHMETHOD',
             'GIT_ALLOW_PROTOCOL',
+            'GIT_ASKPASS',
         }
     }
 


### PR DESCRIPTION
documented via man gitcredentials,  it is used to provide a script/input for git to fetch creds in a no-tty usecase. used among other things by jenkins to pass credentials down to git for authentication.

https://github.com/jenkinsci/git-plugin/blob/1e3488a730a169778ba0863dd4edbb1dc29154a1/README.adoc#git-bindings https://github.com/jenkinsci/git-plugin/blob/9429e7d05df3dbb4060ac6ab4da6538bb0eb50ba/src/main/java/jenkins/plugins/git/GitUsernamePasswordBinding.java#L130