### PR TITLE
Use tomllib/tomli/tomli-w instead of toml

### DIFF
--- a/pre_commit/languages/rust.py
+++ b/pre_commit/languages/rust.py
@@ -11,7 +11,11 @@ import urllib.request
 from typing import Generator
 from typing import Sequence
 
-import toml
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib
+import tomli_w
 
 import pre_commit.constants as C
 from pre_commit import parse_shebang
@@ -85,14 +89,14 @@ def _add_dependencies(
         cargo_toml_path: str,
         additional_dependencies: set[str],
 ) -> None:
-    with open(cargo_toml_path, 'r+') as f:
-        cargo_toml = toml.load(f)
+    with open(cargo_toml_path, 'rb+') as f:
+        cargo_toml = tomllib.load(f)
         cargo_toml.setdefault('dependencies', {})
         for dep in additional_dependencies:
             name, _, spec = dep.partition(':')
             cargo_toml['dependencies'][name] = spec or '*'
         f.seek(0)
-        toml.dump(cargo_toml, f)
+        tomli_w.dump(cargo_toml, f)
         f.truncate()
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,7 @@ url = https://github.com/pre-commit/pre-commit
 author = Anthony Sottile
 author_email = asottile@umich.edu
 license = MIT
-license_file = LICENSE
+license_files = LICENSE
 classifiers =
     License :: OSI Approved :: MIT License
     Programming Language :: Python :: 3

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,8 @@ install_requires =
     identify>=1.0.0
     nodeenv>=0.11.1
     pyyaml>=5.1
-    toml
+    tomli-w
+    tomli;python_version<"3.11"
     virtualenv>=20.10.0
     importlib-metadata;python_version<"3.8"
 python_requires = >=3.7


### PR DESCRIPTION
`toml` has issue parsing newer toml files, and most of python ecosystem moved to `tomllib` (builtin in python 3.11) with `tomli` for backward support, with `tomli-w` used for writing. Upstream of `toml` is also less active.