### PR TITLE
Add hook tags

### DIFF
--- a/pre_commit/clientlib.py
+++ b/pre_commit/clientlib.py
@@ -80,6 +80,7 @@ MANIFEST_HOOK_DICT = cfgv.Map(
     cfgv.Optional('minimum_pre_commit_version', cfgv.check_string, '0'),
     cfgv.Optional('require_serial', cfgv.check_bool, False),
     cfgv.Optional('stages', cfgv.check_array(cfgv.check_one_of(C.STAGES)), []),
+    cfgv.Optional('tags', cfgv.check_array(cfgv.check_string), []),
     cfgv.Optional('verbose', cfgv.check_bool, False),
 )
 MANIFEST_SCHEMA = cfgv.Array(MANIFEST_HOOK_DICT)

--- a/pre_commit/commands/hook_impl.py
+++ b/pre_commit/commands/hook_impl.py
@@ -100,6 +100,7 @@ def _ns(
         rewrite_command=rewrite_command,
         files=(),
         hook=None,
+        tags=(),
         verbose=False,
         show_diff_on_failure=False,
     )

--- a/pre_commit/commands/run.py
+++ b/pre_commit/commands/run.py
@@ -11,6 +11,7 @@ import time
 import unicodedata
 from typing import Any
 from typing import Collection
+from typing import Iterable
 from typing import MutableMapping
 from typing import Sequence
 
@@ -323,25 +324,28 @@ def _has_unstaged_config(config_file: str) -> bool:
     # be explicit, other git errors don't mean it has an unstaged config.
     return retcode == 1
 
+
 def _hook_should_run(args: argparse.Namespace, hook: Hook) -> bool:
     if args.hook_stage not in hook.stages:
         return False
 
     if args.tags:
         return len(set(hook.tags) & set(args.tags)) > 0
-    
+
     return (
-        not args.hook
-        or hook.id == args.hook
-        or hook.alias == args.hook
+        not args.hook or
+        hook.id == args.hook or
+        hook.alias == args.hook
     )
 
-def _hook_is_skipped(skips: Sequence[str], hook: Hook) -> bool:
+
+def _hook_is_skipped(skips: Iterable[str], hook: Hook) -> bool:
     return (
-        hook.id in skips
-        or hook.alias in skips
-        or len(set(hook.tags) & set(skips)) > 0
+        hook.id in skips or
+        hook.alias in skips or
+        len(set(hook.tags) & set(skips)) > 0
     )
+
 
 def run(
         config_file: str,
@@ -438,7 +442,8 @@ def run(
             return 1
         if args.tags and not hooks:
             output.write_line(
-                f'No hooks with tags matching `{args.tags}` in stage `{args.hook_stage}`'
+                f'No hooks with tags matching `{args.tags}` '
+                f'in stage `{args.hook_stage}`',
             )
             return 1
 

--- a/pre_commit/hook.py
+++ b/pre_commit/hook.py
@@ -35,6 +35,7 @@ class Hook(NamedTuple):
     minimum_pre_commit_version: str
     require_serial: bool
     stages: Sequence[str]
+    tags: Sequence[str]
     verbose: bool
 
     @property

--- a/pre_commit/main.py
+++ b/pre_commit/main.py
@@ -57,7 +57,9 @@ def _add_hook_type_option(parser: argparse.ArgumentParser) -> None:
 
 
 def _add_run_options(parser: argparse.ArgumentParser) -> None:
-    parser.add_argument('hook', nargs='?', help='A single hook-id to run')
+    hooks_mutex_group = parser.add_mutually_exclusive_group(required=False)
+    hooks_mutex_group.add_argument('hook', nargs='?', help='A single hook-id to run')
+    hooks_mutex_group.add_argument('--tags', nargs='+', default=[], help='Tag groups to run')
     parser.add_argument('--verbose', '-v', action='store_true', default=False)
     mutex_group = parser.add_mutually_exclusive_group(required=False)
     mutex_group.add_argument(

--- a/pre_commit/main.py
+++ b/pre_commit/main.py
@@ -58,8 +58,12 @@ def _add_hook_type_option(parser: argparse.ArgumentParser) -> None:
 
 def _add_run_options(parser: argparse.ArgumentParser) -> None:
     hooks_mutex_group = parser.add_mutually_exclusive_group(required=False)
-    hooks_mutex_group.add_argument('hook', nargs='?', help='A single hook-id to run')
-    hooks_mutex_group.add_argument('--tags', nargs='+', default=[], help='Tag groups to run')
+    hooks_mutex_group.add_argument(
+        'hook', nargs='?', help='A single hook-id to run',
+    )
+    hooks_mutex_group.add_argument(
+        '--tags', nargs='+', default=[], help='Tag groups to run',
+    )
     parser.add_argument('--verbose', '-v', action='store_true', default=False)
     mutex_group = parser.add_mutually_exclusive_group(required=False)
     mutex_group.add_argument(

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = pre_commit
-version = 2.20.0
+version = 2.21.0
 description = A framework for managing and maintaining multi-language pre-commit hooks.
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/testing/resources/script_hooks_repo/.pre-commit-hooks.yaml
+++ b/testing/resources/script_hooks_repo/.pre-commit-hooks.yaml
@@ -4,4 +4,4 @@
     language: script
     files: ''
     tags:
-    -   foo 
+    -   foo

--- a/testing/resources/script_hooks_repo/.pre-commit-hooks.yaml
+++ b/testing/resources/script_hooks_repo/.pre-commit-hooks.yaml
@@ -3,3 +3,5 @@
     entry: bin/hook.sh
     language: script
     files: ''
+    tags:
+    -   foo 

--- a/testing/util.py
+++ b/testing/util.py
@@ -67,6 +67,7 @@ def run_opts(
         color=False,
         verbose=False,
         hook=None,
+        tags=(),
         remote_branch='',
         local_branch='',
         from_ref='',
@@ -84,12 +85,14 @@ def run_opts(
 ):
     # These are mutually exclusive
     assert not (all_files and files)
+    assert not (hook and tags)
     return auto_namedtuple(
         all_files=all_files,
         files=files,
         color=color,
         verbose=verbose,
         hook=hook,
+        tags=tags,
         remote_branch=remote_branch,
         local_branch=local_branch,
         from_ref=from_ref,

--- a/tests/commands/run_test.py
+++ b/tests/commands/run_test.py
@@ -144,14 +144,21 @@ def _do_run(cap_out, store, repo, args, environ={}, config_file=C.CONFIG_FILE):
 
 def _test_run(
     cap_out, store, repo, opts, expected_outputs, expected_ret, stage,
-    config_file=C.CONFIG_FILE, environ_override=None
+    config_file=C.CONFIG_FILE, environ_override=None,
 ):
     if stage:
         stage_a_file()
     if environ_override is None:
         environ_override = {}
     args = run_opts(**opts)
-    ret, printed = _do_run(cap_out, store, repo, args, config_file=config_file, environ=environ_override)
+    ret, printed = _do_run(
+        cap_out,
+        store,
+        repo,
+        args,
+        config_file=config_file,
+        environ=environ_override,
+    )
 
     assert ret == expected_ret, (ret, expected_ret, printed)
     for expected_output_part in expected_outputs:
@@ -369,13 +376,19 @@ def test_show_diff_on_failure(
         ),
         (
             {'tags': ['bar', 'baz']},
-            (b'No hooks with tags matching `[\'bar\', \'baz\']` in stage `commit`',),
+            (
+                b'No hooks with tags matching `[\'bar\', \'baz\']`',
+                b'in stage `commit`',
+            ),
             1,
             True,
         ),
         (
             {'tags': ['bar', 'baz'], 'hook_stage': 'push'},
-            (b'No hooks with tags matching `[\'bar\', \'baz\']` in stage `push`',),
+            (
+                b'No hooks with tags matching `[\'bar\', \'baz\']`',
+                b'in stage `push`',
+            ),
             1,
             True,
         ),
@@ -633,6 +646,7 @@ def test_skip_aliased_hook(cap_out, store, aliased_repo):
     for msg in (b'Bash hook', b'Skipped'):
         assert printed.count(msg) == 1
 
+
 def test_skip_tag(cap_out, store, repo_with_passing_hook):
     _test_run(
         cap_out,
@@ -642,7 +656,7 @@ def test_skip_tag(cap_out, store, repo_with_passing_hook):
         (b'Bash hook', b'Skipped'),
         0,
         True,
-        environ_override={'SKIP': 'foo'}
+        environ_override={'SKIP': 'foo'},
     )
 
 

--- a/tests/commands/run_test.py
+++ b/tests/commands/run_test.py
@@ -144,12 +144,14 @@ def _do_run(cap_out, store, repo, args, environ={}, config_file=C.CONFIG_FILE):
 
 def _test_run(
     cap_out, store, repo, opts, expected_outputs, expected_ret, stage,
-    config_file=C.CONFIG_FILE,
+    config_file=C.CONFIG_FILE, environ_override=None
 ):
     if stage:
         stage_a_file()
+    if environ_override is None:
+        environ_override = {}
     args = run_opts(**opts)
-    ret, printed = _do_run(cap_out, store, repo, args, config_file=config_file)
+    ret, printed = _do_run(cap_out, store, repo, args, config_file=config_file, environ=environ_override)
 
     assert ret == expected_ret, (ret, expected_ret, printed)
     for expected_output_part in expected_outputs:
@@ -352,6 +354,7 @@ def test_show_diff_on_failure(
         ({}, (b'Bash hook', b'Passed'), 0, True),
         ({'verbose': True}, (b'foo.py\nHello World',), 0, True),
         ({'hook': 'bash_hook'}, (b'Bash hook', b'Passed'), 0, True),
+        ({'tags': ['foo']}, (b'Bash hook', b'Passed'), 0, True),
         (
             {'hook': 'nope'},
             (b'No hook with id `nope` in stage `commit`',),
@@ -361,6 +364,18 @@ def test_show_diff_on_failure(
         (
             {'hook': 'nope', 'hook_stage': 'push'},
             (b'No hook with id `nope` in stage `push`',),
+            1,
+            True,
+        ),
+        (
+            {'tags': ['bar', 'baz']},
+            (b'No hooks with tags matching `[\'bar\', \'baz\']` in stage `commit`',),
+            1,
+            True,
+        ),
+        (
+            {'tags': ['bar', 'baz'], 'hook_stage': 'push'},
+            (b'No hooks with tags matching `[\'bar\', \'baz\']` in stage `push`',),
             1,
             True,
         ),
@@ -617,6 +632,18 @@ def test_skip_aliased_hook(cap_out, store, aliased_repo):
     # Only the aliased hook runs and is skipped
     for msg in (b'Bash hook', b'Skipped'):
         assert printed.count(msg) == 1
+
+def test_skip_tag(cap_out, store, repo_with_passing_hook):
+    _test_run(
+        cap_out,
+        store,
+        repo_with_passing_hook,
+        {},
+        (b'Bash hook', b'Skipped'),
+        0,
+        True,
+        environ_override={'SKIP': 'foo'}
+    )
 
 
 def test_skip_bypasses_installation(cap_out, store, repo_with_passing_hook):

--- a/tests/repository_test.py
+++ b/tests/repository_test.py
@@ -1015,6 +1015,7 @@ def test_manifest_hooks(tempdir_factory, store):
             'post-commit', 'manual', 'post-checkout', 'push', 'post-merge',
             'post-rewrite',
         ),
+        tags=['foo'],
         types=['file'],
         types_or=[],
         verbose=False,


### PR DESCRIPTION
It seemed rather useful and easy-to-implement to have a way of tagging your hooks so that you can more closely control which subset is run/skipped. For example, you may want to designate some subset to only run during CI (like tests that might take a long time) or to only run locally (like compiling your dependencies).

The reason I started on this was mainly because I wanted local typechecking and linting to be fast, but to validate everything in CI, the tools had to be containerized, which digs into your flow a little bit.

If I were smarter and more experienced, I probably would've come up with a better solution to this, but again, this seemed pretty simple and potentially useful for other reasons.