### PR TITLE
Adapt extension of R executable depending on os

### DIFF
--- a/pre_commit/languages/r.py
+++ b/pre_commit/languages/r.py
@@ -15,6 +15,7 @@ from pre_commit.languages import helpers
 from pre_commit.prefix import Prefix
 from pre_commit.util import clean_path_on_failure
 from pre_commit.util import cmd_output_b
+from pre_commit.util import win_exe
 
 ENVIRONMENT_DIR = 'renv'
 RSCRIPT_OPTS = ('--no-save', '--no-restore', '--no-site-file', '--no-environ')
@@ -63,7 +64,7 @@ def _rscript_exec() -> str:
     if r_home is None:
         return 'Rscript'
     else:
-        return os.path.join(r_home, 'bin', 'Rscript')
+        return os.path.join(r_home, 'bin', win_exe('Rscript'))
 
 
 def _entry_validate(entry: Sequence[str]) -> None:

--- a/tests/languages/r_test.py
+++ b/tests/languages/r_test.py
@@ -6,6 +6,7 @@ import pytest
 
 from pre_commit import envcontext
 from pre_commit.languages import r
+from pre_commit.util import win_exe
 from testing.fixtures import make_config_from_repo
 from testing.fixtures import make_repo
 from tests.repository_test import _get_hook_no_install
@@ -133,7 +134,7 @@ def test_r_parsing_file_local(tempdir_factory, store):
 
 
 def test_rscript_exec_relative_to_r_home():
-    expected = os.path.join('r_home_dir', 'bin', 'Rscript')
+    expected = os.path.join('r_home_dir', 'bin', win_exe('Rscript'))
     with envcontext.envcontext((('R_HOME', 'r_home_dir'),)):
         assert r._rscript_exec() == expected
 


### PR DESCRIPTION
Closes #2599 by adding ensuring `.exe` suffix to the `Rscript` executable on Windows. But I don't understand if that change breaks current uses or if some versions of Windows / shells just add `.exe. when it's missing while others don't.

Also, I am not sure if it also closes https://github.com/lorenzwalthert/precommit/issues/441 or if the added `~` in the Rscript path is of any harm or not and `ctypes.windll.kernel32.GetLongPathNameW` from the standard library is needed to use get full path. 