### PR TITLE
add in an option to disable a hook when run with --all-files

### DIFF
--- a/pre_commit/clientlib.py
+++ b/pre_commit/clientlib.py
@@ -81,6 +81,7 @@ MANIFEST_HOOK_DICT = cfgv.Map(
     cfgv.Optional('require_serial', cfgv.check_bool, False),
     cfgv.Optional('stages', cfgv.check_array(cfgv.check_one_of(C.STAGES)), []),
     cfgv.Optional('verbose', cfgv.check_bool, False),
+    cfgv.Optional('run_all', cfgv.check_bool, True),
 )
 MANIFEST_SCHEMA = cfgv.Array(MANIFEST_HOOK_DICT)
 

--- a/pre_commit/commands/run.py
+++ b/pre_commit/commands/run.py
@@ -126,7 +126,11 @@ class Classifier:
         return Classifier(filenames)
 
 
-def _get_skips(environ: MutableMapping[str, str], args: argparse.Namespace, hooks: list[Hook]) -> set[str]:
+def _get_skips(
+        environ: MutableMapping[str, str],
+        args: argparse.Namespace,
+        hooks: list[Hook],
+) -> set[str]:
     skips = environ.get('SKIP', '')
     environ_skips = {skip.strip() for skip in skips.split(',') if skip.strip()}
     context_skips = {h.id for h in hooks if args.all_files and not h.run_all}

--- a/pre_commit/commands/run.py
+++ b/pre_commit/commands/run.py
@@ -126,9 +126,11 @@ class Classifier:
         return Classifier(filenames)
 
 
-def _get_skips(environ: MutableMapping[str, str]) -> set[str]:
+def _get_skips(environ: MutableMapping[str, str], args: argparse.Namespace, hooks: list[Hook]) -> set[str]:
     skips = environ.get('SKIP', '')
-    return {skip.strip() for skip in skips.split(',') if skip.strip()}
+    environ_skips = {skip.strip() for skip in skips.split(',') if skip.strip()}
+    context_skips = {h.id for h in hooks if args.all_files and not h.run_all}
+    return environ_skips | context_skips
 
 
 SKIPPED = 'Skipped'
@@ -419,7 +421,7 @@ def run(
             )
             return 1
 
-        skips = _get_skips(environ)
+        skips = _get_skips(environ, args, hooks)
         to_install = [
             hook
             for hook in hooks

--- a/pre_commit/hook.py
+++ b/pre_commit/hook.py
@@ -36,6 +36,7 @@ class Hook(NamedTuple):
     require_serial: bool
     stages: Sequence[str]
     verbose: bool
+    run_all: bool
 
     @property
     def cmd(self) -> tuple[str, ...]:

--- a/testing/get-swift.sh
+++ b/testing/get-swift.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 . /etc/lsb-release
-if [ "$DISTRIB_CODENAME" = "focal" ]; then
+if [ "$DISTRIB_CODENAME" = "jammy" ]; then
     SWIFT_URL='https://download.swift.org/swift-5.6.1-release/ubuntu2004/swift-5.6.1-RELEASE/swift-5.6.1-RELEASE-ubuntu20.04.tar.gz'
     SWIFT_HASH='2b4f22d4a8b59fe8e050f0b7f020f8d8f12553cbda56709b2340a4a3bb90cfea'
 else

--- a/testing/get-swift.sh
+++ b/testing/get-swift.sh
@@ -4,8 +4,8 @@ set -euo pipefail
 
 . /etc/lsb-release
 if [ "$DISTRIB_CODENAME" = "jammy" ]; then
-    SWIFT_URL='https://download.swift.org/swift-5.6.1-release/ubuntu2004/swift-5.6.1-RELEASE/swift-5.6.1-RELEASE-ubuntu20.04.tar.gz'
-    SWIFT_HASH='2b4f22d4a8b59fe8e050f0b7f020f8d8f12553cbda56709b2340a4a3bb90cfea'
+    SWIFT_URL='https://download.swift.org/swift-5.7.1-release/ubuntu2204/swift-5.7.1-RELEASE/swift-5.7.1-RELEASE-ubuntu22.04.tar.gz'
+    SWIFT_HASH='7f60291f5088d3e77b0c2364beaabd29616ee7b37260b7b06bdbeb891a7fe161'
 else
     echo "unknown dist: ${DISTRIB_CODENAME}" 1>&2
     exit 1

--- a/testing/get-swift.sh
+++ b/testing/get-swift.sh
@@ -6,6 +6,9 @@ set -euo pipefail
 if [ "$DISTRIB_CODENAME" = "jammy" ]; then
     SWIFT_URL='https://download.swift.org/swift-5.7.1-release/ubuntu2204/swift-5.7.1-RELEASE/swift-5.7.1-RELEASE-ubuntu22.04.tar.gz'
     SWIFT_HASH='7f60291f5088d3e77b0c2364beaabd29616ee7b37260b7b06bdbeb891a7fe161'
+elif [ "$DISTRIB_CODENAME" = "focal" ]; then
+    SWIFT_URL='https://download.swift.org/swift-5.6.1-release/ubuntu2004/swift-5.6.1-RELEASE/swift-5.6.1-RELEASE-ubuntu20.04.tar.gz'
+    SWIFT_HASH='2b4f22d4a8b59fe8e050f0b7f020f8d8f12553cbda56709b2340a4a3bb90cfea'
 else
     echo "unknown dist: ${DISTRIB_CODENAME}" 1>&2
     exit 1

--- a/tests/commands/run_test.py
+++ b/tests/commands/run_test.py
@@ -594,7 +594,7 @@ def test_compute_cols(hooks, expected):
     ),
 )
 def test_get_skips(environ, expected_output):
-    ret = _get_skips(environ)
+    ret = _get_skips(environ, args=mock.MagicMock(), hooks=mock.MagicMock())
     assert ret == expected_output
 
 

--- a/tests/repository_test.py
+++ b/tests/repository_test.py
@@ -1019,6 +1019,7 @@ def test_manifest_hooks(tempdir_factory, store):
         types_or=[],
         verbose=False,
         fail_fast=False,
+        run_all=True,
     )
 
 


### PR DESCRIPTION
This adds in a simple option for a hook to disable it when pre-commit is run with the `--all-files` flag. The option is True by default. This should help with heavier weight hooks or making incremental improvements to a large repo. This way, if a user runs `pre-commit run --all-files` it will not run this hook, but it will run normally during the pre-commit stage