### PR TITLE
dotnet: ignore nuget source during tool install

### DIFF
--- a/pre_commit/languages/dotnet.py
+++ b/pre_commit/languages/dotnet.py
@@ -57,6 +57,16 @@ def install_environment(
             ),
         )
 
+        with open(prefix.path('nuget.config'), 'w') as f:
+            f.write(
+                '<?xml version="1.0" encoding="utf-8"?>'
+                '<configuration>'
+                '  <packageSources>'
+                '    <clear />'
+                '  </packageSources>'
+                '</configuration>',
+            )
+
         # Determine tool from the packaged file <tool_name>.<version>.nupkg
         build_outputs = os.listdir(os.path.join(prefix.prefix_dir, build_dir))
         for output in build_outputs:


### PR DESCRIPTION
Removes `nuget.org` from the default lookup configuration so package resolution is performed against the local `build_dir` only.

This fixes an issue where dotnet attempts to install unwanted packages or older versions, as `nuget.org` has higher precedence than the specified sources.