### PR TITLE
Add `pre-commit autoupdate --semver`

### DIFF
--- a/pre_commit/main.py
+++ b/pre_commit/main.py
@@ -200,6 +200,18 @@ def main(argv: Sequence[str] | None = None) -> int:
     )
     _add_config_option(autoupdate_parser)
     autoupdate_parser.add_argument(
+        '--semver', action='store_true',
+        help=(
+            'Use the highest version according to semantic versoning.'
+        ),
+    )
+    autoupdate_parser.add_argument(
+        '--semver-prerelease', action='store_true',
+        help=(
+            'Use pre-release versions according to semver.'
+        ),
+    )
+    autoupdate_parser.add_argument(
         '--bleeding-edge', action='store_true',
         help=(
             'Update to the bleeding edge of `HEAD` instead of the latest '
@@ -355,6 +367,8 @@ def main(argv: Sequence[str] | None = None) -> int:
             return autoupdate(
                 args.config, store,
                 tags_only=not args.bleeding_edge,
+                semver=args.semver,
+                semver_stable_only=not args.semver_prerelease,
                 freeze=args.freeze,
                 repos=args.repos,
             )

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,7 @@ install_requires =
     identify>=1.0.0
     nodeenv>=0.11.1
     pyyaml>=5.1
+    semver>=2.13.0
     virtualenv>=20.10.0
     importlib-metadata;python_version<"3.8"
 python_requires = >=3.7

--- a/tests/commands/gc_test.py
+++ b/tests/commands/gc_test.py
@@ -44,7 +44,10 @@ def test_gc(tempdir_factory, store, in_git_dir, cap_out):
 
     # update will clone both the old and new repo, making the old one gc-able
     install_hooks(C.CONFIG_FILE, store)
-    assert not autoupdate(C.CONFIG_FILE, store, freeze=False, tags_only=False)
+    assert not autoupdate(
+        C.CONFIG_FILE, store, freeze=False, tags_only=False,
+        semver=False, semver_stable_only=False,
+    )
 
     assert _config_count(store) == 1
     assert _repo_count(store) == 2


### PR DESCRIPTION
This new, optional mode chooses the best version number according to semantic versioning, rather than according to `git describe`. Prereleases are only chosen if `--semver-prerelease` is also specified.

This behavior has been requested by multiple pre-commit users in closed issues such as https://github.com/pre-commit/pre-commit/issues/2513

I'm opening this PR in part to gauge interest. I think it's likely that the final form of this feature would e.g., look in the pre-commit-config.yaml file to find out for each repo whether semantic versioning should be used or not. A commandline flag to override and upgrade to latest ref or to prerelease versions would still be useful as a way to check whether there are any problems "coming down the pike", as it were.