### PR TITLE
remove support for top-level list format

### DIFF
--- a/pre_commit/clientlib.py
+++ b/pre_commit/clientlib.py
@@ -391,23 +391,10 @@ class InvalidConfigError(FatalError):
     pass
 
 
-def ordered_load_normalize_legacy_config(contents: str) -> dict[str, Any]:
-    data = yaml_load(contents)
-    if isinstance(data, list):
-        logger.warning(
-            'normalizing pre-commit configuration to a top-level map.  '
-            'support for top level list will be removed in a future version.  '
-            'run: `pre-commit migrate-config` to automatically fix this.',
-        )
-        return {'repos': data}
-    else:
-        return data
-
-
 load_config = functools.partial(
     cfgv.load_from_filename,
     schema=CONFIG_SCHEMA,
-    load_strategy=ordered_load_normalize_legacy_config,
+    load_strategy=yaml_load,
     exc_tp=InvalidConfigError,
 )
 

--- a/tests/clientlib_test.py
+++ b/tests/clientlib_test.py
@@ -120,14 +120,6 @@ def test_validate_config_main_ok():
     assert not validate_config_main(('.pre-commit-config.yaml',))
 
 
-def test_validate_config_old_list_format_ok(tmpdir, cap_out):
-    f = tmpdir.join('cfg.yaml')
-    f.write('-  {repo: meta, hooks: [{id: identity}]}')
-    assert not validate_config_main((f.strpath,))
-    msg = '[WARNING] normalizing pre-commit configuration to a top-level map'
-    assert msg in cap_out.get()
-
-
 def test_validate_warn_on_unknown_keys_at_repo_level(tmpdir, caplog):
     f = tmpdir.join('cfg.yaml')
     f.write(

--- a/tests/commands/install_uninstall_test.py
+++ b/tests/commands/install_uninstall_test.py
@@ -739,20 +739,22 @@ def test_commit_msg_legacy(commit_msg_repo, tempdir_factory, store):
 
 def test_post_commit_integration(tempdir_factory, store):
     path = git_dir(tempdir_factory)
-    config = [
-        {
-            'repo': 'local',
-            'hooks': [{
-                'id': 'post-commit',
-                'name': 'Post commit',
-                'entry': 'touch post-commit.tmp',
-                'language': 'system',
-                'always_run': True,
-                'verbose': True,
-                'stages': ['post-commit'],
-            }],
-        },
-    ]
+    config = {
+        'repos': [
+            {
+                'repo': 'local',
+                'hooks': [{
+                    'id': 'post-commit',
+                    'name': 'Post commit',
+                    'entry': 'touch post-commit.tmp',
+                    'language': 'system',
+                    'always_run': True,
+                    'verbose': True,
+                    'stages': ['post-commit'],
+                }],
+            },
+        ],
+    }
     write_config(path, config)
     with cwd(path):
         _get_commit_output(tempdir_factory)
@@ -765,20 +767,22 @@ def test_post_commit_integration(tempdir_factory, store):
 
 def test_post_merge_integration(tempdir_factory, store):
     path = git_dir(tempdir_factory)
-    config = [
-        {
-            'repo': 'local',
-            'hooks': [{
-                'id': 'post-merge',
-                'name': 'Post merge',
-                'entry': 'touch post-merge.tmp',
-                'language': 'system',
-                'always_run': True,
-                'verbose': True,
-                'stages': ['post-merge'],
-            }],
-        },
-    ]
+    config = {
+        'repos': [
+            {
+                'repo': 'local',
+                'hooks': [{
+                    'id': 'post-merge',
+                    'name': 'Post merge',
+                    'entry': 'touch post-merge.tmp',
+                    'language': 'system',
+                    'always_run': True,
+                    'verbose': True,
+                    'stages': ['post-merge'],
+                }],
+            },
+        ],
+    }
     write_config(path, config)
     with cwd(path):
         #  create a simple diamond of commits for a non-trivial merge
@@ -807,20 +811,22 @@ def test_post_merge_integration(tempdir_factory, store):
 
 def test_post_rewrite_integration(tempdir_factory, store):
     path = git_dir(tempdir_factory)
-    config = [
-        {
-            'repo': 'local',
-            'hooks': [{
-                'id': 'post-rewrite',
-                'name': 'Post rewrite',
-                'entry': 'touch post-rewrite.tmp',
-                'language': 'system',
-                'always_run': True,
-                'verbose': True,
-                'stages': ['post-rewrite'],
-            }],
-        },
-    ]
+    config = {
+        'repos': [
+            {
+                'repo': 'local',
+                'hooks': [{
+                    'id': 'post-rewrite',
+                    'name': 'Post rewrite',
+                    'entry': 'touch post-rewrite.tmp',
+                    'language': 'system',
+                    'always_run': True,
+                    'verbose': True,
+                    'stages': ['post-rewrite'],
+                }],
+            },
+        ],
+    }
     write_config(path, config)
     with cwd(path):
         open('init', 'a').close()
@@ -836,21 +842,23 @@ def test_post_rewrite_integration(tempdir_factory, store):
 
 def test_post_checkout_integration(tempdir_factory, store):
     path = git_dir(tempdir_factory)
-    config = [
-        {
-            'repo': 'local',
-            'hooks': [{
-                'id': 'post-checkout',
-                'name': 'Post checkout',
-                'entry': 'bash -c "echo ${PRE_COMMIT_TO_REF}"',
-                'language': 'system',
-                'always_run': True,
-                'verbose': True,
-                'stages': ['post-checkout'],
-            }],
-        },
-        {'repo': 'meta', 'hooks': [{'id': 'identity'}]},
-    ]
+    config = {
+        'repos': [
+            {
+                'repo': 'local',
+                'hooks': [{
+                    'id': 'post-checkout',
+                    'name': 'Post checkout',
+                    'entry': 'bash -c "echo ${PRE_COMMIT_TO_REF}"',
+                    'language': 'system',
+                    'always_run': True,
+                    'verbose': True,
+                    'stages': ['post-checkout'],
+                }],
+            },
+            {'repo': 'meta', 'hooks': [{'id': 'identity'}]},
+        ],
+    }
     write_config(path, config)
     with cwd(path):
         cmd_output('git', 'add', '.')


### PR DESCRIPTION
this has been producing a warning since july of 2020:

```console
$ pre-commit run flake8 --all-files
[WARNING] normalizing pre-commit configuration to a top-level map.  support for top level list will be removed in a future version.  run: `pre-commit migrate-config` to automatically fix this.
flake8...................................................................Passed
```

this now produces this error:

```console
$ pre-commit run flake8 --all-files
An error has occurred: InvalidConfigError: 
==> File .pre-commit-config.yaml
=====> Expected a Config map but got a list
Check the log at /home/asottile/.cache/pre-commit/pre-commit.log
```

this can be fixed automatically by running `pre-commit migrate-config`:

```console
$ pre-commit migrate-config
Configuration has been migrated.
$ pre-commit run flake8 --all-files
flake8...................................................................Passed
```