### PR TITLE
remove pre-commit-validate-config and pre-commit-validate-manifest

### DIFF
--- a/pre_commit/clientlib.py
+++ b/pre_commit/clientlib.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import argparse
 import functools
 import logging
 import re
@@ -13,12 +12,8 @@ import cfgv
 from identify.identify import ALL_TAGS
 
 import pre_commit.constants as C
-from pre_commit.color import add_color_option
-from pre_commit.commands.validate_config import validate_config
-from pre_commit.commands.validate_manifest import validate_manifest
 from pre_commit.errors import FatalError
 from pre_commit.languages.all import all_languages
-from pre_commit.logging_handler import logging_handler
 from pre_commit.util import parse_version
 from pre_commit.util import yaml_load
 
@@ -42,14 +37,6 @@ def check_min_version(version: str) -> None:
             f'{C.VERSION} is installed.  '
             f'Perhaps run `pip install --upgrade pre-commit`.',
         )
-
-
-def _make_argparser(filenames_help: str) -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser()
-    parser.add_argument('filenames', nargs='*', help=filenames_help)
-    parser.add_argument('-V', '--version', action='version', version=C.VERSION)
-    add_color_option(parser)
-    return parser
 
 
 MANIFEST_HOOK_DICT = cfgv.Map(
@@ -95,19 +82,6 @@ load_manifest = functools.partial(
     load_strategy=yaml_load,
     exc_tp=InvalidManifestError,
 )
-
-
-def validate_manifest_main(argv: Sequence[str] | None = None) -> int:
-    parser = _make_argparser('Manifest filenames.')
-    args = parser.parse_args(argv)
-
-    with logging_handler(args.color):
-        logger.warning(
-            'pre-commit-validate-manifest is deprecated -- '
-            'use `pre-commit validate-manifest` instead.',
-        )
-
-        return validate_manifest(args.filenames)
 
 
 LOCAL = 'local'
@@ -397,16 +371,3 @@ load_config = functools.partial(
     load_strategy=yaml_load,
     exc_tp=InvalidConfigError,
 )
-
-
-def validate_config_main(argv: Sequence[str] | None = None) -> int:
-    parser = _make_argparser('Config filenames.')
-    args = parser.parse_args(argv)
-
-    with logging_handler(args.color):
-        logger.warning(
-            'pre-commit-validate-config is deprecated -- '
-            'use `pre-commit validate-config` instead.',
-        )
-
-        return validate_config(args.filenames)

--- a/pre_commit/commands/validate_config.py
+++ b/pre_commit/commands/validate_config.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+from typing import Sequence
+
 from pre_commit import clientlib
 
 
-def validate_config(filenames: list[str]) -> int:
+def validate_config(filenames: Sequence[str]) -> int:
     ret = 0
 
     for filename in filenames:

--- a/pre_commit/commands/validate_manifest.py
+++ b/pre_commit/commands/validate_manifest.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+from typing import Sequence
+
 from pre_commit import clientlib
 
 
-def validate_manifest(filenames: list[str]) -> int:
+def validate_manifest(filenames: Sequence[str]) -> int:
     ret = 0
 
     for filename in filenames:

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,8 +34,6 @@ exclude =
 [options.entry_points]
 console_scripts =
     pre-commit = pre_commit.main:main
-    pre-commit-validate-config = pre_commit.clientlib:validate_config_main
-    pre-commit-validate-manifest = pre_commit.clientlib:validate_manifest_main
 
 [options.package_data]
 pre_commit.resources =

--- a/tests/clientlib_test.py
+++ b/tests/clientlib_test.py
@@ -17,8 +17,6 @@ from pre_commit.clientlib import META_HOOK_DICT
 from pre_commit.clientlib import MigrateShaToRev
 from pre_commit.clientlib import OptionalSensibleRegexAtHook
 from pre_commit.clientlib import OptionalSensibleRegexAtTop
-from pre_commit.clientlib import validate_config_main
-from pre_commit.clientlib import validate_manifest_main
 from testing.fixtures import sample_local_config
 
 
@@ -110,70 +108,6 @@ def test_config_schema_does_not_contain_defaults():
     """
     for item in CONFIG_HOOK_DICT.items:
         assert not isinstance(item, cfgv.Optional)
-
-
-def test_validate_manifest_main_ok():
-    assert not validate_manifest_main(('.pre-commit-hooks.yaml',))
-
-
-def test_validate_config_main_ok():
-    assert not validate_config_main(('.pre-commit-config.yaml',))
-
-
-def test_validate_warn_on_unknown_keys_at_repo_level(tmpdir, caplog):
-    f = tmpdir.join('cfg.yaml')
-    f.write(
-        'repos:\n'
-        '-   repo: https://gitlab.com/pycqa/flake8\n'
-        '    rev: 3.7.7\n'
-        '    hooks:\n'
-        '    -   id: flake8\n'
-        '    args: [--some-args]\n',
-    )
-    ret_val = validate_config_main((f.strpath,))
-    assert not ret_val
-    assert caplog.record_tuples == [
-        (
-            'pre_commit',
-            logging.WARNING,
-            'pre-commit-validate-config is deprecated -- '
-            'use `pre-commit validate-config` instead.',
-        ),
-        (
-            'pre_commit',
-            logging.WARNING,
-            'Unexpected key(s) present on https://gitlab.com/pycqa/flake8: '
-            'args',
-        ),
-    ]
-
-
-def test_validate_warn_on_unknown_keys_at_top_level(tmpdir, caplog):
-    f = tmpdir.join('cfg.yaml')
-    f.write(
-        'repos:\n'
-        '-   repo: https://gitlab.com/pycqa/flake8\n'
-        '    rev: 3.7.7\n'
-        '    hooks:\n'
-        '    -   id: flake8\n'
-        'foo:\n'
-        '    id: 1.0.0\n',
-    )
-    ret_val = validate_config_main((f.strpath,))
-    assert not ret_val
-    assert caplog.record_tuples == [
-        (
-            'pre_commit',
-            logging.WARNING,
-            'pre-commit-validate-config is deprecated -- '
-            'use `pre-commit validate-config` instead.',
-        ),
-        (
-            'pre_commit',
-            logging.WARNING,
-            'Unexpected key(s) present at root: foo',
-        ),
-    ]
 
 
 def test_ci_map_key_allowed_at_top_level(caplog):
@@ -360,18 +294,6 @@ def test_validate_optional_sensible_regex_at_top_level(caplog, regex, warning):
     cfgv.validate(config_obj, CONFIG_SCHEMA)
 
     assert caplog.record_tuples == [('pre_commit', logging.WARNING, warning)]
-
-
-@pytest.mark.parametrize('fn', (validate_config_main, validate_manifest_main))
-def test_mains_not_ok(tmpdir, fn):
-    not_yaml = tmpdir.join('f.notyaml')
-    not_yaml.write('{')
-    not_schema = tmpdir.join('notconfig.yaml')
-    not_schema.write('{}')
-
-    assert fn(('does-not-exist',))
-    assert fn((not_yaml.strpath,))
-    assert fn((not_schema.strpath,))
 
 
 @pytest.mark.parametrize(

--- a/tests/commands/validate_config_test.py
+++ b/tests/commands/validate_config_test.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import logging
+
+from pre_commit.commands.validate_config import validate_config
+
+
+def test_validate_config_ok():
+    assert not validate_config(('.pre-commit-config.yaml',))
+
+
+def test_validate_warn_on_unknown_keys_at_repo_level(tmpdir, caplog):
+    f = tmpdir.join('cfg.yaml')
+    f.write(
+        'repos:\n'
+        '-   repo: https://gitlab.com/pycqa/flake8\n'
+        '    rev: 3.7.7\n'
+        '    hooks:\n'
+        '    -   id: flake8\n'
+        '    args: [--some-args]\n',
+    )
+    ret_val = validate_config((f.strpath,))
+    assert not ret_val
+    assert caplog.record_tuples == [
+        (
+            'pre_commit',
+            logging.WARNING,
+            'Unexpected key(s) present on https://gitlab.com/pycqa/flake8: '
+            'args',
+        ),
+    ]
+
+
+def test_validate_warn_on_unknown_keys_at_top_level(tmpdir, caplog):
+    f = tmpdir.join('cfg.yaml')
+    f.write(
+        'repos:\n'
+        '-   repo: https://gitlab.com/pycqa/flake8\n'
+        '    rev: 3.7.7\n'
+        '    hooks:\n'
+        '    -   id: flake8\n'
+        'foo:\n'
+        '    id: 1.0.0\n',
+    )
+    ret_val = validate_config((f.strpath,))
+    assert not ret_val
+    assert caplog.record_tuples == [
+        (
+            'pre_commit',
+            logging.WARNING,
+            'Unexpected key(s) present at root: foo',
+        ),
+    ]
+
+
+def test_mains_not_ok(tmpdir):
+    not_yaml = tmpdir.join('f.notyaml')
+    not_yaml.write('{')
+    not_schema = tmpdir.join('notconfig.yaml')
+    not_schema.write('{}')
+
+    assert validate_config(('does-not-exist',))
+    assert validate_config((not_yaml.strpath,))
+    assert validate_config((not_schema.strpath,))

--- a/tests/commands/validate_manifest_test.py
+++ b/tests/commands/validate_manifest_test.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from pre_commit.commands.validate_manifest import validate_manifest
+
+
+def test_validate_manifest_ok():
+    assert not validate_manifest(('.pre-commit-hooks.yaml',))
+
+
+def test_not_ok(tmpdir):
+    not_yaml = tmpdir.join('f.notyaml')
+    not_yaml.write('{')
+    not_schema = tmpdir.join('notconfig.yaml')
+    not_schema.write('{}')
+
+    assert validate_manifest(('does-not-exist',))
+    assert validate_manifest((not_yaml.strpath,))
+    assert validate_manifest((not_schema.strpath,))


### PR DESCRIPTION
this has been warning since april of 2022:

```console
$ pre-commit-validate-manifest .pre-commit-hooks.yaml 
[WARNING] pre-commit-validate-manifest is deprecated -- use `pre-commit validate-manifest` instead.
$ pre-commit-validate-config .pre-commit-config.yaml 
[WARNING] pre-commit-validate-config is deprecated -- use `pre-commit validate-config` instead.
```

this will now be an error:

```console
$ pre-commit-validate-manifest .pre-commit-hooks.yaml 
bash: pre-commit-validate-manifest: command not found
$ pre-commit-validate-config .pre-commit-config.yaml 
bash: pre-commit-validate-config: command not found
```

instead use the `pre-commit` sub-commands:

```console
$ pre-commit validate-manifest .pre-commit-hooks.yaml 
$ pre-commit validate-config .pre-commit-config.yaml 
```