### PR TITLE
special rmtree is not needed for TemporaryDirectory in 3.8+

### DIFF
--- a/pre_commit/commands/autoupdate.py
+++ b/pre_commit/commands/autoupdate.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os.path
 import re
+import tempfile
 from typing import Any
 from typing import NamedTuple
 from typing import Sequence
@@ -19,7 +20,6 @@ from pre_commit.store import Store
 from pre_commit.util import CalledProcessError
 from pre_commit.util import cmd_output
 from pre_commit.util import cmd_output_b
-from pre_commit.util import tmpdir
 from pre_commit.util import yaml_dump
 from pre_commit.util import yaml_load
 
@@ -47,7 +47,7 @@ class RevInfo(NamedTuple):
                 'FETCH_HEAD', '--tags', '--exact',
             )
 
-        with tmpdir() as tmp:
+        with tempfile.TemporaryDirectory() as tmp:
             git.init_repo(tmp, self.repo)
             cmd_output_b(
                 *git_cmd, 'fetch', 'origin', 'HEAD', '--tags',

--- a/pre_commit/commands/try_repo.py
+++ b/pre_commit/commands/try_repo.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import logging
 import os.path
+import tempfile
 
 import pre_commit.constants as C
 from pre_commit import git
@@ -11,7 +12,6 @@ from pre_commit.clientlib import load_manifest
 from pre_commit.commands.run import run
 from pre_commit.store import Store
 from pre_commit.util import cmd_output_b
-from pre_commit.util import tmpdir
 from pre_commit.util import yaml_dump
 from pre_commit.xargs import xargs
 
@@ -49,7 +49,7 @@ def _repo_ref(tmpdir: str, repo: str, ref: str | None) -> tuple[str, str]:
 
 
 def try_repo(args: argparse.Namespace) -> int:
-    with tmpdir() as tempdir:
+    with tempfile.TemporaryDirectory() as tempdir:
         repo, ref = _repo_ref(tempdir, args.repo, args.ref)
 
         store = Store(tempdir)

--- a/pre_commit/util.py
+++ b/pre_commit/util.py
@@ -9,7 +9,6 @@ import shutil
 import stat
 import subprocess
 import sys
-import tempfile
 from types import TracebackType
 from typing import Any
 from typing import Callable
@@ -50,18 +49,6 @@ def clean_path_on_failure(path: str) -> Generator[None, None, None]:
         if os.path.exists(path):
             rmtree(path)
         raise
-
-
-@contextlib.contextmanager
-def tmpdir() -> Generator[str, None, None]:
-    """Contextmanager to create a temporary directory.  It will be cleaned up
-    afterwards.
-    """
-    tempdir = tempfile.mkdtemp()
-    try:
-        yield tempdir
-    finally:
-        rmtree(tempdir)
 
 
 def resource_bytesio(filename: str) -> IO[bytes]:

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -14,7 +14,6 @@ from pre_commit.util import cmd_output_p
 from pre_commit.util import make_executable
 from pre_commit.util import parse_version
 from pre_commit.util import rmtree
-from pre_commit.util import tmpdir
 
 
 def test_CalledProcessError_str():
@@ -72,12 +71,6 @@ def test_clean_path_on_failure_cleans_for_system_exit(in_tmpdir):
             raise MySystemExit
 
     assert not os.path.exists('foo')
-
-
-def test_tmpdir():
-    with tmpdir() as tempdir:
-        assert os.path.exists(tempdir)
-    assert not os.path.exists(tempdir)
 
 
 def test_cmd_output_exe_not_found():


### PR DESCRIPTION
see also: https://github.com/python/cpython/commit/e9b51c0ad81da1da11ae65840ac8b50a8521373c