### PR TITLE
simplify install state

### DIFF
--- a/pre_commit/constants.py
+++ b/pre_commit/constants.py
@@ -5,8 +5,6 @@ import importlib.metadata
 CONFIG_FILE = '.pre-commit-config.yaml'
 MANIFEST_FILE = '.pre-commit-hooks.yaml'
 
-# Bump when installation changes in a backwards / forwards incompatible way
-INSTALLED_STATE_VERSION = '1'
 # Bump when modifying `empty_template`
 LOCAL_REPO_VERSION = '1'
 


### PR DESCRIPTION
the additional bookkeeping has been unnecessary since b827694520be0f39bfc0599f3680b6c08b4516cf

unfortunately this will cause a rebuild of all hooks in order to be forward/backward compatible -- shrugs