### PR TITLE
Fix command normalization when a custom env is passed

### DIFF
--- a/pre_commit/util.py
+++ b/pre_commit/util.py
@@ -99,7 +99,7 @@ def cmd_output_b(
     _setdefault_kwargs(kwargs)
 
     try:
-        cmd = parse_shebang.normalize_cmd(cmd)
+        cmd = parse_shebang.normalize_cmd(cmd, env=kwargs.get('env'))
     except parse_shebang.ExecutableNotFoundError as e:
         returncode, stdout_b, stderr_b = e.to_output()
     else:

--- a/tests/languages/rust_test.py
+++ b/tests/languages/rust_test.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from typing import Mapping
 from unittest import mock
 
 import pytest
@@ -48,7 +49,9 @@ def test_installs_with_bootstrapped_rustup(tmpdir, language_version):
 
     original_find_executable = parse_shebang.find_executable
 
-    def mocked_find_executable(exe: str) -> str | None:
+    def mocked_find_executable(
+            exe: str, *, env: Mapping[str, str] | None = None,
+    ) -> str | None:
         """
         Return `None` the first time `find_executable` is called to ensure
         that the bootstrapping code is executed, then just let the function
@@ -59,7 +62,7 @@ def test_installs_with_bootstrapped_rustup(tmpdir, language_version):
         find_executable_exes.append(exe)
         if len(find_executable_exes) == 1:
             return None
-        return original_find_executable(exe)
+        return original_find_executable(exe, env=env)
 
     with mock.patch.object(parse_shebang, 'find_executable') as find_exe_mck:
         find_exe_mck.side_effect = mocked_find_executable

--- a/tests/parse_shebang_test.py
+++ b/tests/parse_shebang_test.py
@@ -75,10 +75,10 @@ def test_find_executable_path_ext(in_tmpdir):
     env_path = {'PATH': os.path.dirname(exe_path)}
     env_path_ext = dict(env_path, PATHEXT=os.pathsep.join(('.exe', '.myext')))
     assert parse_shebang.find_executable('run') is None
-    assert parse_shebang.find_executable('run', _environ=env_path) is None
-    ret = parse_shebang.find_executable('run.myext', _environ=env_path)
+    assert parse_shebang.find_executable('run', env=env_path) is None
+    ret = parse_shebang.find_executable('run.myext', env=env_path)
     assert ret == exe_path
-    ret = parse_shebang.find_executable('run', _environ=env_path_ext)
+    ret = parse_shebang.find_executable('run', env=env_path_ext)
     assert ret == exe_path
 
 


### PR DESCRIPTION
Custom envs can't be passed to `normalize_cmd` which causes `find_executable` to default to `os.environ` -- works as expected when injecting directly `os.environ`.

