### PR TITLE
fix(git): Use diff-tree instead of diff

### DIFF
--- a/pre_commit/git.py
+++ b/pre_commit/git.py
@@ -156,14 +156,11 @@ def get_all_files() -> list[str]:
 
 
 def get_changed_files(old: str, new: str) -> list[str]:
-    diff_cmd = ('git', 'diff', '--name-only', '--no-ext-diff', '-z')
-    try:
-        _, out, _ = cmd_output(*diff_cmd, f'{old}...{new}')
-    except CalledProcessError:  # pragma: no cover (new git)
-        # on newer git where old and new do not have a merge base git fails
-        # so we try a full diff (this is what old git did for us!)
-        _, out, _ = cmd_output(*diff_cmd, f'{old}..{new}')
-
+    _, out, _ = cmd_output(
+        'git', 'diff-tree',
+        '--name-only', '--raw', '-z',
+        old, new,
+    )
     return zsplit(out)
 
 


### PR DESCRIPTION
which does not require all intermediate commits to exists, which helps when running from CI/CD pipelines which do shallow clones for performance reasons.

# Background
In addition to running `pre-commit` locally when using `git commit` we also run `pre-commit` as part of our GitLab-CI/CD pipeline to catch those merge-requests (MR), where `pre-commit` as not run locally before.
GitLab supports so-called [Merge Request Pipelines](https://docs.gitlab.com/ee/ci/pipelines/merge_request_pipelines.html), which run when a MR is opened or changes are pushed to the branch associated with the MR. As the MR has a _target branch_ associated with it, which specifies where the branch should be merged into, this allows the pipeline to run on the _changed_ files touched by the added commits only instead of running on all files of the latest commit.
For this we use the command `pre-commit run --from-ref "${CI_MERGE_REQUEST_DIFF_BASE_SHA}" --to-ref "${CI_COMMIT_SHA}"` using some [pre-defined variables](https://docs.gitlab.com/ee/ci/variables/#predefined-cicd-variables) from GitLab.

But with the current code using `git diff "$from...$to"` to work all commits from the branch-point `CI_MERGE_REQUEST_DIFF_BASE_SHA` up to tip `CI_COMMIT_SHA` must be available to `pre-commit`. For performance reasons GitLab (and other CI-systems) used [shallow cloning](https://docs.gitlab.com/ee/ci/large_repositories/) and defaults to [20 / 50 commits only](https://docs.gitlab.com/ee/ci/pipelines/settings.html#limit-the-number-of-changes-fetched-during-clone). This can be changed via the environment variabel `GIT_DEPTH`, but choosing a good default is tricky: Fetching too many commits is a performance problem for `git` and GitLab.
On the other hand if the feature branch has more commits that that, `CI_MERGE_REQUEST_DIFF_BASE_SHA` cannot be referenced and `pre-commit` fails:
```
An unexpected error has occurred: CalledProcessError: command: ('/usr/bin/git', 'diff', '--name-only', '--no-ext-diff', '-z', 'f8c213260044905fe0ad5a6127b5bf97f7ecc68f...acb7ea59de3aed22792173f4ed6ea22db36474c0')
return code: 128
expected return code: 0
stdout: (none)
stderr:
    fatal: Invalid symmetric difference expression f8c213260044905fe0ad5a6127b5bf97f7ecc68f...acb7ea59de3aed22792173f4ed6ea22db36474c0
```

There are 2 problems here:

The merge-point `$CI_MERGE_REQUEST_DIFF_BASE_SHA` must be cloned. There is this [proposed fix](https://forum.gitlab.com/t/ci-cd-pipeline-get-list-of-changed-files/26847/25) to do an explicit `git fetch --depth 1 origin "${CI_MERGE_REQUEST_DIFF_BASE_SHA}"` before running `pre-commit` to make sure that that commit  is available.

But this is not enough as `pre-commit` uses a _symmetric diff_ `...` to calculate the set of files modified between those commits, which also needs all intermediate commits (and their tree objects). Sadly `git fetch` does not provide an option to fetch commits between two commits, but only by _depth_ or by _date_.
My current work-around for this is to get the date from the merge-point and then do another fetch to extends the shallow clone back to that date:
```sh
since=$(git show --no-patch --format=tformat:%cI "${CI_MERGE_REQUEST_DIFF_BASE_SHA}")
git fetch --no-tags --shallow-since="${since}" --filter=tree:0 origin "${CI_MERGE_REQUEST_SOURCE_BRANCH_NAME}"
```

But there is an easier way to solve this, which the above mentioned _proposed fix_ mentions:
As `pre-commit` only needs the set of files modified between those commits — more correctly their trees — it should use `git diff-tree --name-only --raw -z "${CI_MERGE_REQUEST_DIFF_BASE_SHA}" "${CI_COMMIT_SHA}"` instead of the symmetric search.

# Test
```sh
# clone some (random) GIT repository with a working `pre-commit` setup — assumes branch 'main'
git clone -b main … ./repo
cd ./repo
# get head of your current branch:
CI_COMMIT_SHA=$(git rev-parse @)
# get a (random) previous commit:
CI_MERGE_REQUEST_DIFF_BASE_SHA=$(git rev-parse @~3)
# Create a shallow clone of branch 'main' with depth 1:
git clone -l --depth 1 --single-branch -b main file://$PWD ../clone
cd ../clone
# Check access to HEAD: should succeed
git show "$CI_COMMIT_SHA"
# Check access to MERGE-POINT: will fail
git show "$CI_MERGE_REQUEST_DIFF_BASE_SHA"
# Just fetch that ref:
git fetch --depth 1 origin "${CI_MERGE_REQUEST_DIFF_BASE_SHA}"
# Now the previous check should succeed:
git show "$CI_MERGE_REQUEST_DIFF_BASE_SHA"
# Not run pre-commit between those commands:
pre-commit run --from-ref "${CI_MERGE_REQUEST_DIFF_BASE_SHA}" --to-ref "${CI_COMMIT_SHA}"
```

It will fail with the old code — unless you run the extra two lines mentions above — but using my patch it does work.