### PR TITLE
fix r local hooks

### DIFF
--- a/pre_commit/commands/run.py
+++ b/pre_commit/commands/run.py
@@ -195,6 +195,7 @@ def _run_single_hook(
                 hook.entry,
                 hook.args,
                 filenames,
+                is_local=hook.src == 'local',
                 require_serial=hook.require_serial,
                 color=use_color,
             )

--- a/pre_commit/languages/all.py
+++ b/pre_commit/languages/all.py
@@ -66,6 +66,7 @@ class Language(Protocol):
             args: Sequence[str],
             file_args: Sequence[str],
             *,
+            is_local: bool,
             require_serial: bool,
             color: bool,
     ) -> tuple[int, bytes]:

--- a/pre_commit/languages/docker.py
+++ b/pre_commit/languages/docker.py
@@ -127,6 +127,7 @@ def run_hook(
         args: Sequence[str],
         file_args: Sequence[str],
         *,
+        is_local: bool,
         require_serial: bool,
         color: bool,
 ) -> tuple[int, bytes]:  # pragma: win32 no cover

--- a/pre_commit/languages/docker_image.py
+++ b/pre_commit/languages/docker_image.py
@@ -19,6 +19,7 @@ def run_hook(
         args: Sequence[str],
         file_args: Sequence[str],
         *,
+        is_local: bool,
         require_serial: bool,
         color: bool,
 ) -> tuple[int, bytes]:  # pragma: win32 no cover

--- a/pre_commit/languages/fail.py
+++ b/pre_commit/languages/fail.py
@@ -18,6 +18,7 @@ def run_hook(
         args: Sequence[str],
         file_args: Sequence[str],
         *,
+        is_local: bool,
         require_serial: bool,
         color: bool,
 ) -> tuple[int, bytes]:

--- a/pre_commit/languages/helpers.py
+++ b/pre_commit/languages/helpers.py
@@ -146,6 +146,7 @@ def basic_run_hook(
         args: Sequence[str],
         file_args: Sequence[str],
         *,
+        is_local: bool,
         require_serial: bool,
         color: bool,
 ) -> tuple[int, bytes]:

--- a/pre_commit/languages/pygrep.py
+++ b/pre_commit/languages/pygrep.py
@@ -93,6 +93,7 @@ def run_hook(
         args: Sequence[str],
         file_args: Sequence[str],
         *,
+        is_local: bool,
         require_serial: bool,
         color: bool,
 ) -> tuple[int, bytes]:

--- a/pre_commit/languages/script.py
+++ b/pre_commit/languages/script.py
@@ -18,6 +18,7 @@ def run_hook(
         args: Sequence[str],
         file_args: Sequence[str],
         *,
+        is_local: bool,
         require_serial: bool,
         color: bool,
 ) -> tuple[int, bytes]:

--- a/testing/language_helpers.py
+++ b/testing/language_helpers.py
@@ -16,6 +16,7 @@ def run_language(
         file_args: Sequence[str] = (),
         version: str = C.DEFAULT,
         deps: Sequence[str] = (),
+        is_local: bool = False,
 ) -> tuple[int, bytes]:
     prefix = Prefix(str(path))
 
@@ -26,6 +27,7 @@ def run_language(
             exe,
             args,
             file_args,
+            is_local=is_local,
             require_serial=True,
             color=False,
         )

--- a/tests/languages/r_test.py
+++ b/tests/languages/r_test.py
@@ -14,7 +14,12 @@ from testing.language_helpers import run_language
 
 
 def test_r_parsing_file_no_opts_no_args(tmp_path):
-    cmd = r._cmd_from_hook(Prefix(str(tmp_path)), 'Rscript some-script.R', ())
+    cmd = r._cmd_from_hook(
+        Prefix(str(tmp_path)),
+        'Rscript some-script.R',
+        (),
+        is_local=False,
+    )
     assert cmd == (
         'Rscript',
         '--no-save', '--no-restore', '--no-site-file', '--no-environ',
@@ -38,6 +43,7 @@ def test_r_parsing_file_no_opts_args(tmp_path):
         Prefix(str(tmp_path)),
         'Rscript some-script.R',
         ('--no-cache',),
+        is_local=False,
     )
     assert cmd == (
         'Rscript',
@@ -48,11 +54,30 @@ def test_r_parsing_file_no_opts_args(tmp_path):
 
 
 def test_r_parsing_expr_no_opts_no_args1(tmp_path):
-    cmd = r._cmd_from_hook(Prefix(str(tmp_path)), "Rscript -e '1+1'", ())
+    cmd = r._cmd_from_hook(
+        Prefix(str(tmp_path)),
+        "Rscript -e '1+1'",
+        (),
+        is_local=False,
+    )
     assert cmd == (
         'Rscript',
         '--no-save', '--no-restore', '--no-site-file', '--no-environ',
         '-e', '1+1',
+    )
+
+
+def test_r_parsing_local_hook_path_is_not_expanded(tmp_path):
+    cmd = r._cmd_from_hook(
+        Prefix(str(tmp_path)),
+        'Rscript path/to/thing.R',
+        (),
+        is_local=True,
+    )
+    assert cmd == (
+        'Rscript',
+        '--no-save', '--no-restore', '--no-site-file', '--no-environ',
+        'path/to/thing.R',
     )
 
 

--- a/tests/repository_test.py
+++ b/tests/repository_test.py
@@ -48,6 +48,7 @@ def _hook_run(hook, filenames, color):
             hook.entry,
             hook.args,
             filenames,
+            is_local=hook.src == 'local',
             require_serial=hook.require_serial,
             color=color,
         )


### PR DESCRIPTION
`language: r` acts more like `language: script` so we have to *not* append
the prefix when run with `repo: local`