### PR TITLE
Drop support for Python 3.6 in add-trailing-comma

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
     rev: v2.4.0
     hooks:
     -   id: add-trailing-comma
-        args: [--py36-plus]
+        args: [--py38-plus]
 -   repo: https://github.com/asottile/pyupgrade
     rev: v3.3.1
     hooks:


### PR DESCRIPTION
One line change to drop support for Python 3.6 to match the `args` of the other `repo`s in this file