### PR TITLE
conda: Allow installation without any `environment.yml`

### DIFF
--- a/pre_commit/languages/conda.py
+++ b/pre_commit/languages/conda.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import contextlib
 import os
+import pathlib
 from typing import Generator
 from typing import Sequence
 
@@ -63,6 +64,13 @@ def install_environment(
     lang_base.assert_version_default('conda', version)
 
     conda_exe = _conda_exe()
+    envfile_dir = pathlib.Path(prefix.prefix_dir)
+    default_environment_yml = '''\
+channels: [conda-forge, defaults]
+dependencies: [openssl]
+'''
+    if not (envfile_dir / "environment.yml").exists():
+        (envfile_dir / "environment.yml").write_text(default_environment_yml)
 
     env_dir = lang_base.environment_dir(prefix, ENVIRONMENT_DIR, version)
     cmd_output_b(


### PR DESCRIPTION
Currently, if the hook's repository does not contain an `environment.yml` the installation fails as no environment can be created.

For example `.pre-commit-hooks.yaml` of a tool that installs all dependencies using `additional_dependencies`:
```yaml
- id: texcleanup-conda
  name: texcleanup
  description: Run texcleanup
  minimum_pre_commit_version: 2.1.0
  entry: texcleanup
  language: conda
  additional_dependencies: [-c, conda-forge, texplain, latexindent.pl]
  types: [tex]
```

After running 
```
pre-commit try-repo /path/to/my/tool
```

```
cat ~/.cache/pre-commit/pre-commit.log
### version information

'''
pre-commit version: 3.0.4
git --version: git version 2.37.1 (Apple Git-137.1)
sys.version:
    3.9.16 | packaged by conda-forge | (main, Feb  1 2023, 21:38:11)
    [Clang 14.0.6 ]
sys.executable: /Users/tdegeus/miniforge3/envs/stable/bin/python
os.name: posix
sys.platform: darwin
'''

### error information

'''
An unexpected error has occurred: CalledProcessError: command: ('/Users/tdegeus/miniforge3/bin/python', '/Users/tdegeus/miniforge3/condabin/conda', 'env', 'create', '-p', '/var/folders/4z/74x3z8gs7pq77drzss82p5mc0000gq/T/tmp4xcxnnja/repouphtxwld/conda-default', '--file', 'environment.yml')
return code: 1
stdout: (none)
stderr:

    EnvironmentFileNotFound: '/private/var/folders/4z/74x3z8gs7pq77drzss82p5mc0000gq/T/tmp4xcxnnja/repouphtxwld/environment.yml' file not found


'''

'''
Traceback (most recent call last):
  File "/Users/tdegeus/miniforge3/envs/stable/lib/python3.9/site-packages/pre_commit/error_handler.py", line 73, in error_handler
    yield
  File "/Users/tdegeus/miniforge3/envs/stable/lib/python3.9/site-packages/pre_commit/main.py", line 398, in main
    return try_repo(args)
  File "/Users/tdegeus/miniforge3/envs/stable/lib/python3.9/site-packages/pre_commit/commands/try_repo.py", line 77, in try_repo
    return run(config_filename, store, args)
  File "/Users/tdegeus/miniforge3/envs/stable/lib/python3.9/site-packages/pre_commit/commands/run.py", line 437, in run
    install_hook_envs(to_install, store)
  File "/Users/tdegeus/miniforge3/envs/stable/lib/python3.9/site-packages/pre_commit/repository.py", line 239, in install_hook_envs
    _hook_install(hook)
  File "/Users/tdegeus/miniforge3/envs/stable/lib/python3.9/site-packages/pre_commit/repository.py", line 86, in _hook_install
    lang.install_environment(
  File "/Users/tdegeus/miniforge3/envs/stable/lib/python3.9/site-packages/pre_commit/languages/conda.py", line 68, in install_environment
    cmd_output_b(
  File "/Users/tdegeus/miniforge3/envs/stable/lib/python3.9/site-packages/pre_commit/util.py", line 115, in cmd_output_b
    raise CalledProcessError(returncode, cmd, stdout_b, stderr_b)
pre_commit.util.CalledProcessError: command: ('/Users/tdegeus/miniforge3/bin/python', '/Users/tdegeus/miniforge3/condabin/conda', 'env', 'create', '-p', '/var/folders/4z/74x3z8gs7pq77drzss82p5mc0000gq/T/tmp4xcxnnja/repouphtxwld/conda-default', '--file', 'environment.yml')
return code: 1
stdout: (none)
stderr:

    EnvironmentFileNotFound: '/private/var/folders/4z/74x3z8gs7pq77drzss82p5mc0000gq/T/tmp4xcxnnja/repouphtxwld/environment.yml' file not found
'''
```

The are two possible solutions.

1. (Current PR) Create an empty `environment.yml` (well as empty as possible) if `environment.yml` does not exist, and install all needed dependencies from `additional_dependencies` (see above).

1. Allow a configuration variable for the hook in which a custom filename can be specified. As far as I can see from the implementation this is current not possible (although the reply to https://github.com/pre-commit/pre-commit/issues/2792 hints otherwise?).