### PR TITLE
Fix double shebang in Windows hook template

### DIFF
--- a/pre_commit/commands/install_uninstall.py
+++ b/pre_commit/commands/install_uninstall.py
@@ -99,7 +99,7 @@ def _install_hook_script(
         # bash in "POSIXLY_CORRECT" mode which still supports the features we
         # use: subshells / arrays
         if sys.platform == 'win32':  # pragma: win32 cover
-            before = before.replace("#!/usr/bin/env bash", "#!/bin/sh", 1)
+            before = before.replace('#!/usr/bin/env bash', '#!/bin/sh', 1)
 
         hook_file.write(before + TEMPLATE_START)
         hook_file.write(f'INSTALL_PYTHON={shlex.quote(sys.executable)}\n')

--- a/pre_commit/commands/install_uninstall.py
+++ b/pre_commit/commands/install_uninstall.py
@@ -99,7 +99,7 @@ def _install_hook_script(
         # bash in "POSIXLY_CORRECT" mode which still supports the features we
         # use: subshells / arrays
         if sys.platform == 'win32':  # pragma: win32 cover
-            hook_file.write('#!/bin/sh\n')
+            before = before.replace("#!/usr/bin/env bash", "#!/bin/sh", 1)
 
         hook_file.write(before + TEMPLATE_START)
         hook_file.write(f'INSTALL_PYTHON={shlex.quote(sys.executable)}\n')


### PR DESCRIPTION
In its current form, `_install_hook_script` appends Windows-specific shebang on top of the previous one when it should replace it instead (probably). Here's what it looks like now:

```sh
#!/bin/sh
#!/usr/bin/env bash
# File generated by pre-commit: https://pre-commit.com
# ID: 138fd403232d2ddd5efb44317e38bf03

...
```

I got triggered by this, so I went ahead and wrote a fix.