### PR TITLE
Change deprecated `swift build` `-C` command line option to replacement `--package-path`

### DIFF
--- a/pre_commit/languages/swift.py
+++ b/pre_commit/languages/swift.py
@@ -44,7 +44,7 @@ def install_environment(
     os.mkdir(envdir)
     cmd_output_b(
         'swift', 'build',
-        '-C', prefix.prefix_dir,
+        '--package-path', prefix.prefix_dir,
         '-c', BUILD_CONFIG,
         '--build-path', os.path.join(envdir, BUILD_DIR),
     )


### PR DESCRIPTION
Based on this comment: https://github.com/pre-commit/pre-commit/issues/2835#issuecomment-1494873806

Sorry, I'm not a python dev and I don't see how to run unit tests or anything, or even how to test this locally, but looking at the swift docs it seems like this makes sense:

```
$ swift build -help
OVERVIEW: Build sources into binary products

SEE ALSO: swift run, swift package, swift test

USAGE: swift build <options>

OPTIONS:
  --package-path <package-path>
                          Specify the package path to operate on (default current directory). This changes the working directory before any other operation
...
```