### PR TITLE
some updates and fixes for newer python versions

### DIFF
--- a/pre_commit/git.py
+++ b/pre_commit/git.py
@@ -219,12 +219,12 @@ def check_for_cygwin_mismatch() -> None:
 
         if is_cygwin_python ^ is_cygwin_git:
             exe_type = {True: '(cygwin)', False: '(windows)'}
-            logger.warn(
-                f'pre-commit has detected a mix of cygwin python / git\n'
-                f'This combination is not supported, it is likely you will '
-                f'receive an error later in the program.\n'
-                f'Make sure to use cygwin git+python while using cygwin\n'
-                f'These can be installed through the cygwin installer.\n'
+            logger.warning(
+                'pre-commit has detected a mix of cygwin python / git\n'
+                'This combination is not supported, it is likely you will '
+                'receive an error later in the program.\n'
+                'Make sure to use cygwin git+python while using cygwin\n'
+                'These can be installed through the cygwin installer.\n'
                 f' - python {exe_type[is_cygwin_python]}\n'
                 f' - git {exe_type[is_cygwin_git]}\n',
             )

--- a/pre_commit/repository.py
+++ b/pre_commit/repository.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import sys
 import shlex
 from typing import Any
 from typing import Sequence
@@ -72,9 +73,9 @@ def _hook_install(hook: Hook) -> None:
     if hook.language == 'python_venv':
         logger.warning(
             f'`repo: {hook.src}` uses deprecated `language: python_venv`.  '
-            f'This is an alias for `language: python`.  '
+            'This is an alias for `language: python`.  '
             f'Often `pre-commit autoupdate --repo {shlex.quote(hook.src)}` '
-            f'will fix this.',
+            'will fix this.',
         )
 
     lang = languages[hook.language]
@@ -99,8 +100,8 @@ def _hook_install(hook: Hook) -> None:
         if health_error:
             raise AssertionError(
                 f'BUG: expected environment for {hook.language} to be healthy '
-                f'immediately after install, please open an issue describing '
-                f'your environment\n\n'
+                'immediately after install, please open an issue describing '
+                'your environment\n\n'
                 f'more info:\n\n{health_error}',
             )
 
@@ -129,9 +130,9 @@ def _hook(
         logger.error(
             f'The hook `{ret["id"]}` requires pre-commit version {version} '
             f'but version {C.VERSION} is installed.  '
-            f'Perhaps run `pip install --upgrade pre-commit`.',
+            'Perhaps run `pip install --upgrade pre-commit`.',
         )
-        exit(1)
+        sys.exit(1)
 
     lang = ret['language']
     if ret['language_version'] == C.DEFAULT:
@@ -147,18 +148,18 @@ def _hook(
             logger.error(
                 f'The hook `{ret["id"]}` specifies `language_version` but is '
                 f'using language `{lang}` which does not install an '
-                f'environment.  '
-                f'Perhaps you meant to use a specific language?',
+                'environment.  '
+                'Perhaps you meant to use a specific language?',
             )
-            exit(1)
+            sys.exit(1)
         if ret['additional_dependencies']:
             logger.error(
                 f'The hook `{ret["id"]}` specifies `additional_dependencies` '
                 f'but is using language `{lang}` which does not install an '
-                f'environment.  '
-                f'Perhaps you meant to use a specific language?',
+                'environment.  '
+                'Perhaps you meant to use a specific language?',
             )
-            exit(1)
+            sys.exit(1)
 
     return ret
 
@@ -200,10 +201,10 @@ def _cloned_repository_hooks(
         if hook['id'] not in by_id:
             logger.error(
                 f'`{hook["id"]}` is not present in repository {repo}.  '
-                f'Typo? Perhaps it is introduced in a newer version?  '
-                f'Often `pre-commit autoupdate` fixes this.',
+                'Typo? Perhaps it is introduced in a newer version?  '
+                'Often `pre-commit autoupdate` fixes this.',
             )
-            exit(1)
+            sys.exit(1)
 
     hook_dcts = [
         _hook(by_id[hook['id']], hook, root_config=root_config)

--- a/pre_commit/repository.py
+++ b/pre_commit/repository.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 import json
 import logging
 import os
-import sys
 import shlex
+import sys
 from typing import Any
 from typing import Sequence
 

--- a/testing/fixtures.py
+++ b/testing/fixtures.py
@@ -121,7 +121,7 @@ def read_config(directory, config_file=C.CONFIG_FILE):
 
 
 def write_config(directory, config, config_file=C.CONFIG_FILE):
-    if type(config) is not list and 'repos' not in config:
+    if not isinstance(config, list) and 'repos' not in config:
         assert isinstance(config, dict), config
         config = {'repos': [config]}
     with open(os.path.join(directory, config_file), 'w') as outfile:

--- a/tests/error_handler_test.py
+++ b/tests/error_handler_test.py
@@ -201,7 +201,7 @@ def test_error_handler_read_only_filesystem(mock_store_dir, cap_out, capsys):
     # already been set up
     Store()
 
-    write = (stat.S_IWGRP | stat.S_IWOTH | stat.S_IWUSR)
+    write = stat.S_IWGRP | stat.S_IWOTH | stat.S_IWUSR
     os.chmod(mock_store_dir, os.stat(mock_store_dir).st_mode & ~write)
 
     with pytest.raises(SystemExit):

--- a/tests/languages/docker_test.py
+++ b/tests/languages/docker_test.py
@@ -59,7 +59,7 @@ def test_docker_fallback_user():
             getuid=invalid_attribute,
             getgid=invalid_attribute,
     ):
-        assert docker.get_docker_user() == ()
+        assert not docker.get_docker_user()
 
 
 def test_in_docker_no_file():


### PR DESCRIPTION
Didn't get around to it in my previous attempt, so doing it now.
 - updated deprecated .warn() to .warning()
 - unnecessary f-strings
 - imported sys to allow sys.exit calls instead of exit
 - simplified some not checks
 - replaced type with isinstance