### PR TITLE
Work around a bug in fsmonitor daemon by stopping it

### DIFF
--- a/pre_commit/staged_files_only.py
+++ b/pre_commit/staged_files_only.py
@@ -49,6 +49,8 @@ def _intent_to_add_cleared() -> Generator[None, None, None]:
 
 @contextlib.contextmanager
 def _unstaged_changes_cleared(patch_dir: str) -> Generator[None, None, None]:
+    # Work around a bug in fsmonitor daemon by stopping it.
+    cmd_output('git', 'fsmonitor--daemon', 'stop')
     tree = cmd_output('git', 'write-tree')[1].strip()
     diff_cmd = (
         'git', 'diff-index', '--ignore-submodules', '--binary',


### PR DESCRIPTION
#2795 is still a thing and [someone claimed](https://lore.kernel.org/git/8afb1988-df49-d759-ead8-1bd384f09c82@gmx.de/) that commands like `git update-index --[really]-refresh` should work. 

However, they didn’t, so I am resorting to temporally stopping the daemon all together to work around it. If a future version fixes it, it’s possible re-enable the daemon again. Worse perfomance is better than deleting random files. 