### PR TITLE
Updated version of pre-commit-hooks when running sample_config

### DIFF
--- a/pre_commit/commands/sample_config.py
+++ b/pre_commit/commands/sample_config.py
@@ -4,7 +4,7 @@ SAMPLE_CONFIG = '''\
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
+    rev: v4.4.0
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer

--- a/tests/commands/sample_config_test.py
+++ b/tests/commands/sample_config_test.py
@@ -12,7 +12,7 @@ def test_sample_config(capsys):
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
+    rev: v4.4.0
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer


### PR DESCRIPTION
Hi!
Here is the problem i faced.

I installed pre-commit
I ran `pre-commit sample-config`
and got the default output.

I used that default config, and added the pre-commit-hook "check-shebang-scripts-are-executable"

So essentially, my .pre-commit-config.yaml file looks like this:

```
repos:
  - repo: https://github.com/pre-commit/pre-commit-hooks
    rev: v3.2.0
    hooks:
      - id: trailing-whitespace
      - id: end-of-file-fixer
      - id: check-yaml
      - id: check-added-large-files
      - id: check-shebang-scripts-are-executable
```

But when i run the command `pre-commit run --all-files` I get this error:

`❯ pre-commit run --all-files
[INFO] Initializing environment for https://github.com/pre-commit/pre-commit-hooks.
[ERROR] `check-shebang-scripts-are-executable` is not present in repository https://github.com/pre-commit/pre-commit-hooks.  Typo? Perhaps it is introduced in a newer version?  Often `pre-commit autoupdate` fixes this.`

Updating the pre-commit-hook to 4.4.0 solved this issue.







