### PR TITLE
Force gem installation into envdir

### DIFF
--- a/pre_commit/languages/ruby.py
+++ b/pre_commit/languages/ruby.py
@@ -114,6 +114,8 @@ def _install_ruby(
 def install_environment(
         prefix: Prefix, version: str, additional_dependencies: Sequence[str],
 ) -> None:
+    envdir = lang_base.environment_dir(prefix, ENVIRONMENT_DIR, version)
+
     if version != 'system':  # pragma: win32 no cover
         _install_rbenv(prefix, version)
         with in_env(prefix, version):
@@ -135,6 +137,8 @@ def install_environment(
                 'gem', 'install',
                 '--no-document', '--no-format-executable',
                 '--no-user-install',
+                '--install-dir', os.path.join(envdir, 'gems'),
+                '--bindir',  os.path.join(envdir, 'gems', 'bin'),
                 *prefix.star('.gem'), *additional_dependencies,
             ),
         )

--- a/pre_commit/languages/ruby.py
+++ b/pre_commit/languages/ruby.py
@@ -138,7 +138,7 @@ def install_environment(
                 '--no-document', '--no-format-executable',
                 '--no-user-install',
                 '--install-dir', os.path.join(envdir, 'gems'),
-                '--bindir',  os.path.join(envdir, 'gems', 'bin'),
+                '--bindir', os.path.join(envdir, 'gems', 'bin'),
                 *prefix.star('.gem'), *additional_dependencies,
             ),
         )


### PR DESCRIPTION
RubyGems allows OS packagers to specify defaults for `--install-dir` and `--bindir` and these take precedence over `GEM_HOME`. The only way to override the defaults is to explicitly specify the options ourselves when running `gem install`.

Examples of OSes where this is the case are RedHat 9.2 and Gentoo.

Fixes #2799.