### PR TITLE
Remove trailing dot after repo URL

### DIFF
--- a/pre_commit/repository.py
+++ b/pre_commit/repository.py
@@ -65,7 +65,7 @@ def _hook_installed(hook: Hook) -> bool:
 
 
 def _hook_install(hook: Hook) -> None:
-    logger.info(f'Installing environment for {hook.src}.')
+    logger.info(f'Installing environment for {hook.src}')
     logger.info('Once installed this environment will be reused.')
     logger.info('This may take a few minutes...')
 

--- a/pre_commit/store.py
+++ b/pre_commit/store.py
@@ -156,7 +156,7 @@ class Store:
             if result:  # pragma: no cover (race)
                 return result
 
-            logger.info(f'Initializing environment for {repo}.')
+            logger.info(f'Initializing environment for {repo}')
 
             directory = tempfile.mkdtemp(prefix='repo', dir=self.directory)
             with clean_path_on_failure(directory):

--- a/tests/commands/install_uninstall_test.py
+++ b/tests/commands/install_uninstall_test.py
@@ -143,7 +143,7 @@ FILES_CHANGED = (
 
 
 NORMAL_PRE_COMMIT_RUN = re_assert.Matches(
-    fr'^\[INFO\] Initializing environment for .+\.\n'
+    fr'^\[INFO\] Initializing environment for .+\n'
     fr'Bash hook\.+Passed\n'
     fr'\[master [a-f0-9]{{7}}\] commit!\n'
     fr'{FILES_CHANGED}'
@@ -297,7 +297,7 @@ def test_environment_not_sourced(tempdir_factory, store):
 
 
 FAILING_PRE_COMMIT_RUN = re_assert.Matches(
-    r'^\[INFO\] Initializing environment for .+\.\n'
+    r'^\[INFO\] Initializing environment for .+\n'
     r'Failing hook\.+Failed\n'
     r'- hook id: failing_hook\n'
     r'- exit code: 1\n'
@@ -394,7 +394,7 @@ def test_install_with_existing_non_utf8_script(tmpdir, store):
 
 FAIL_OLD_HOOK = re_assert.Matches(
     r'fail!\n'
-    r'\[INFO\] Initializing environment for .+\.\n'
+    r'\[INFO\] Initializing environment for .+\n'
     r'Bash hook\.+Passed\n',
 )
 


### PR DESCRIPTION
When running on GitHub, pre-commit prints log entries with dots at the end of line (as period):

```
[INFO] Initializing environment for https://github.com/pre-commit/pre-commit-hooks.
[INFO] Installing environment for https://github.com/pre-commit/pre-commit-hooks.
```

GitHub interprets them as part of URL and breaks the links. I'd suggest removing these trailing dots.