### PR TITLE
Adhere more strictly to "dotnet" command-line syntax…

### DIFF
--- a/pre_commit/languages/dotnet.py
+++ b/pre_commit/languages/dotnet.py
@@ -69,7 +69,7 @@ def install_environment(
         (
             'dotnet', 'pack',
             '--configuration', 'Release',
-            '--property', f'PackageOutputPath={build_dir}',
+            f'-p:PackageOutputPath={build_dir}',
         ),
     )
 


### PR DESCRIPTION
 in https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-pack

Context: I'm trying to fix a test failure, reproducible on Arch Linux as below.
My best guess about what happened is that pre-commit's dotnet features worked perfectly until some MSBuild change made its command-line parsing more fragile. Although I'm not sure about that, this change makes the test pass for me by adopting the exact command syntax on that reference page, so it's hopefully solid.

```
# pacman -S dotnet-sdk-6.0
(venv) [justinb@husk pre-commit]$ pytest tests/ -k dotnet
[snip]
E           pre_commit.util.CalledProcessError: command: ('/usr/bin/dotnet', 'pack', '--configuration', 'Release', '--property', 'PackageOutputPath=/tmp/pytest-of-justinb/pytest-19/test_dotnet_combo_proj20/pre-commit-build')
E           return code: 1
E           stdout:
E               Microsoft (R) Build Engine version 17.0.1+b177f8fa7 for .NET
E               Copyright (C) Microsoft Corporation. All rights reserved.
E               
E               MSBUILD : error MSB1005: Specify a property and its value.
E               Switch: --property
E               
E               For switch syntax, type "MSBuild -help"
E           stderr: (none)

pre_commit/util.py:110: CalledProcessError
================================================================================================================================================== short test summary info ===================================================================================================================================================
FAILED tests/languages/dotnet_test.py::test_dotnet_csproj - pre_commit.util.CalledProcessError: command: ('/usr/bin/dotnet', 'pack', '--configuration', 'Release', '--property', 'PackageOutputPath=/tmp/pytest-of-justinb/pytest-19/test_dotnet_csproj0/pre-commit-build')
FAILED tests/languages/dotnet_test.py::test_dotnet_csproj_prefix - pre_commit.util.CalledProcessError: command: ('/usr/bin/dotnet', 'pack', '--configuration', 'Release', '--property', 'PackageOutputPath=/tmp/pytest-of-justinb/pytest-19/test_dotnet_csproj_prefix0/pre-commit-build')
FAILED tests/languages/dotnet_test.py::test_dotnet_sln - pre_commit.util.CalledProcessError: command: ('/usr/bin/dotnet', 'pack', '--configuration', 'Release', '--property', 'PackageOutputPath=/tmp/pytest-of-justinb/pytest-19/test_dotnet_sln0/pre-commit-build')
FAILED tests/languages/dotnet_test.py::test_dotnet_combo_proj1 - pre_commit.util.CalledProcessError: command: ('/usr/bin/dotnet', 'pack', '--configuration', 'Release', '--property', 'PackageOutputPath=/tmp/pytest-of-justinb/pytest-19/test_dotnet_combo_proj10/pre-commit-build')
FAILED tests/languages/dotnet_test.py::test_dotnet_combo_proj2 - pre_commit.util.CalledProcessError: command: ('/usr/bin/dotnet', 'pack', '--configuration', 'Release', '--property', 'PackageOutputPath=/tmp/pytest-of-justinb/pytest-19/test_dotnet_combo_proj20/pre-commit-build')
============================================================================================================================================= 5 failed, 733 deselected in 1.00s ==============================================================================================================================================
```