### PR TITLE
Create Python virtual environments with `--system-site-packages`

### DIFF
--- a/pre_commit/languages/python.py
+++ b/pre_commit/languages/python.py
@@ -203,7 +203,7 @@ def install_environment(
         additional_dependencies: Sequence[str],
 ) -> None:
     envdir = lang_base.environment_dir(prefix, ENVIRONMENT_DIR, version)
-    venv_cmd = [sys.executable, '-mvirtualenv', envdir]
+    venv_cmd = [sys.executable, '-mvirtualenv', envdir, '--system-site-packages']
     python = norm_version(version)
     if python is not None:
         venv_cmd.extend(('-p', python))


### PR DESCRIPTION
#### My use case

I have an ansible repository which I want to lint using `ansible-lint` in `pre-commit`. Ansible is installed system wide but `ansible-lint` is installed in the virtual environment of `pre-commit` without access to the system site packages. Thus `ansible-lint` fails to resolve some ansible modules.