### PR TITLE
Allow hook installation even when global core.hooksPath is set via --allow-global-hooks

### DIFF
--- a/pre_commit/commands/install_uninstall.py
+++ b/pre_commit/commands/install_uninstall.py
@@ -118,9 +118,14 @@ def install(
         overwrite: bool = False,
         hooks: bool = False,
         skip_on_missing_config: bool = False,
+        allow_global_hooks: bool = False,
         git_dir: str | None = None,
 ) -> int:
-    if git_dir is None and git.has_core_hookpaths_set():
+    if (
+            git_dir is None and
+            git.has_core_hookpaths_set() and
+            not allow_global_hooks
+    ):
         logger.error(
             'Cowardly refusing to install hooks with `core.hooksPath` set.\n'
             'hint: `git config --unset-all core.hooksPath`',

--- a/pre_commit/main.py
+++ b/pre_commit/main.py
@@ -278,6 +278,13 @@ def main(argv: Sequence[str] | None = None) -> int:
             'or exit with a failure code.'
         ),
     )
+    install_parser.add_argument(
+        '--allow-global-hooks', action='store_true',
+        help=(
+            'Whether to allow installation of hooks if core.hooksPath '
+            'is configured in the global git configuration.'
+        ),
+    )
 
     install_hooks_parser = _add_cmd(
         'install-hooks',
@@ -399,6 +406,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 overwrite=args.overwrite,
                 hooks=args.install_hooks,
                 skip_on_missing_config=args.allow_missing_config,
+                allow_global_hooks=args.allow_global_hooks,
             )
         elif args.command == 'init-templatedir':
             return init_templatedir(


### PR DESCRIPTION
In corporate environments it is common to have global git hooks (such as a `pre-push` check) installed via `core.hooksPath` (set in the global gitconfig). When global hooks are installed per-repository hooks will not be executed so right now `pre-commit` reasonably checks for this condition and refuses to install:
```
$ pre-commit install
[ERROR] Cowardly refusing to install hooks with `core.hooksPath` set.
hint: `git config --unset-all core.hooksPath`
```
However it's possible/common to setup any global hooks to still explicitly execute any per-repository hooks such as via the following:
```bash
if [ -e "$GIT_DIR/.git/hooks/pre-commit" ]; then
  $GIT_DIR/.git/hooks/pre-commit "$@"
fi
```
In this circumstance users may still wish to install per-repository hooks but `pre-commit` will refuse to allow this. This PR permits the `pre-commit install` command even if a global `core.hooksPath` has been configured if the user provides the new (opt-in) `--allow-global-hooks` flag.