### PR TITLE
Use the --include command, hides warning messages

### DIFF
--- a/pre_commit/languages/node.py
+++ b/pre_commit/languages/node.py
@@ -93,7 +93,7 @@ def install_environment(
         # install as if we installed from git
 
         local_install_cmd = (
-            'npm', 'install', '--dev', '--prod',
+            'npm', 'install', '--include=dev', '--include=prod',
             '--ignore-prepublish', '--no-progress', '--no-save',
         )
         lang_base.setup_cmd(prefix, local_install_cmd)


### PR DESCRIPTION
Fixes #1983

---

This PR is our first contribution. We are very open to suggestions and improvements.

This PR was a group effort by Ordina Pythoneers, they would like to thank Ordina for the time to do this.

@SanderBeekhuis
@RoelAdriaans
@Coen-Smulders