### PR TITLE
Fix mypy on MacOS

### DIFF
--- a/pre_commit/xargs.py
+++ b/pre_commit/xargs.py
@@ -24,13 +24,11 @@ TRet = TypeVar('TRet')
 
 
 def cpu_count() -> int:
-    try:
-        # On systems that support it, this will return a more accurate count of
-        # usable CPUs for the current process, which will take into account
-        # cgroup limits
+    # On systems that support it, this will return a more accurate count of
+    # usable CPUs for the current process, which will take into account
+    # cgroup limits
+    if hasattr(os, 'sched_getaffinity'):
         return len(os.sched_getaffinity(0))
-    except AttributeError:
-        pass
 
     try:
         return multiprocessing.cpu_count()


### PR DESCRIPTION
Without this change, `mypy` fails with

```
pre_commit/xargs.py:31: error: Module has no attribute "sched_getaffinity"  [attr-defined]
```