### PR TITLE
Bump Node.js version to 18.14.0 and Go to 1.21.1

### DIFF
--- a/tests/languages/golang_test.py
+++ b/tests/languages/golang_test.py
@@ -111,11 +111,11 @@ def test_golang_versioned(tmp_path):
         tmp_path,
         golang,
         'go version',
-        version='1.18.4',
+        version='1.21.1',
     )
 
     assert ret == 0
-    assert out.startswith(b'go version go1.18.4')
+    assert out.startswith(b'go version go1.21.1')
 
 
 def test_local_golang_additional_deps(tmp_path):

--- a/tests/languages/node_test.py
+++ b/tests/languages/node_test.py
@@ -139,7 +139,7 @@ def test_node_with_user_config_set(tmp_path):
         test_node_hook_system(tmp_path)
 
 
-@pytest.mark.parametrize('version', (C.DEFAULT, '18.13.0'))
+@pytest.mark.parametrize('version', (C.DEFAULT, '18.14.0'))
 def test_node_hook_versions(tmp_path, version):
     _make_hello_world(tmp_path)
     ret = run_language(tmp_path, node, 'node-hello', version=version)


### PR DESCRIPTION
On riscv64, nodeenv will pull binary from unofficial-builds [1], and unfortunately 18.13.0 seems to be the only version above 18 that is missing riscv64 builds. Shifting the version slightly to make test work.

Go's binary now ships with linux/riscv64 binary since 1.21.