### PR TITLE
Improve hook duration timing

### DIFF
--- a/pre_commit/commands/run.py
+++ b/pre_commit/commands/run.py
@@ -187,7 +187,7 @@ def _run_single_hook(
 
         if not hook.pass_filenames:
             filenames = ()
-        time_before = time.time()
+        time_before = time.monotonic()
         language = languages[hook.language]
         with language.in_env(hook.prefix, hook.language_version):
             retcode, out = language.run_hook(
@@ -199,7 +199,7 @@ def _run_single_hook(
                 require_serial=hook.require_serial,
                 color=use_color,
             )
-        duration = round(time.time() - time_before, 2) or 0
+        duration = round(time.monotonic() - time_before, 2) or 0
         diff_after = _get_diff()
 
         # if the hook makes changes, fail the commit

--- a/tests/commands/run_test.py
+++ b/tests/commands/run_test.py
@@ -293,7 +293,7 @@ def test_verbose_duration(cap_out, store, in_git_dir, t1, t2, expected):
     write_config('.', {'repo': 'meta', 'hooks': [{'id': 'identity'}]})
     cmd_output('git', 'add', '.')
     opts = run_opts(verbose=True)
-    with mock.patch.object(time, 'time', side_effect=(t1, t2)):
+    with mock.patch.object(time, 'monotonic', side_effect=(t1, t2)):
         ret, printed = _do_run(cap_out, store, str(in_git_dir), opts)
     assert ret == 0
     assert expected in printed

--- a/tests/commands/try_repo_test.py
+++ b/tests/commands/try_repo_test.py
@@ -43,7 +43,7 @@ def _run_try_repo(tempdir_factory, **kwargs):
 
 
 def test_try_repo_repo_only(cap_out, tempdir_factory):
-    with mock.patch.object(time, 'time', return_value=0.0):
+    with mock.patch.object(time, 'monotonic', return_value=0.0):
         _run_try_repo(tempdir_factory, verbose=True)
     start, config, rest = _get_out(cap_out)
     assert start == ''


### PR DESCRIPTION
Use `time.monotonic()` to prevent clock slippage error ~, and always output two significant figures to avoid ambiguity~.