### PR TITLE
Proof-of-concept for `--dry-run` param in run command

### DIFF
--- a/pre_commit/commands/run.py
+++ b/pre_commit/commands/run.py
@@ -147,6 +147,7 @@ def _run_single_hook(
         diff_before: bytes,
         verbose: bool,
         use_color: bool,
+        dry_run: bool,
 ) -> tuple[bool, bytes]:
     filenames = tuple(classifier.filenames_for_hook(hook))
 
@@ -198,6 +199,7 @@ def _run_single_hook(
                 is_local=hook.src == 'local',
                 require_serial=hook.require_serial,
                 color=use_color,
+                dry_run=dry_run,
             )
         duration = round(time.monotonic() - time_before, 2) or 0
         diff_after = _get_diff()
@@ -296,6 +298,7 @@ def _run_hooks(
         current_retval, prior_diff = _run_single_hook(
             classifier, hook, skips, cols, prior_diff,
             verbose=args.verbose, use_color=args.color,
+            dry_run=args.dry_run,
         )
         retval |= current_retval
         if retval and (config['fail_fast'] or hook.fail_fast):

--- a/pre_commit/lang_base.py
+++ b/pre_commit/lang_base.py
@@ -55,6 +55,7 @@ class Language(Protocol):
             is_local: bool,
             require_serial: bool,
             color: bool,
+            dry_run: bool,
     ) -> tuple[int, bytes]:
         ...
 
@@ -158,6 +159,7 @@ def run_xargs(
         *,
         require_serial: bool,
         color: bool,
+        dry_run: bool,
 ) -> tuple[int, bytes]:
     if require_serial:
         jobs = 1
@@ -167,7 +169,7 @@ def run_xargs(
         # ordering.
         file_args = _shuffled(file_args)
         jobs = target_concurrency()
-    return xargs.xargs(cmd, file_args, target_concurrency=jobs, color=color)
+    return xargs.xargs(cmd, file_args, target_concurrency=jobs, color=color, dry_run=dry_run)
 
 
 def hook_cmd(entry: str, args: Sequence[str]) -> tuple[str, ...]:
@@ -183,10 +185,12 @@ def basic_run_hook(
         is_local: bool,
         require_serial: bool,
         color: bool,
+        dry_run: bool,
 ) -> tuple[int, bytes]:
     return run_xargs(
         hook_cmd(entry, args),
         file_args,
         require_serial=require_serial,
         color=color,
+        dry_run=dry_run,
     )

--- a/pre_commit/languages/docker.py
+++ b/pre_commit/languages/docker.py
@@ -130,6 +130,7 @@ def run_hook(
         is_local: bool,
         require_serial: bool,
         color: bool,
+        dry_run: bool,
 ) -> tuple[int, bytes]:  # pragma: win32 no cover
     # Rebuild the docker image in case it has gone missing, as many people do
     # automated cleanup of docker images.
@@ -143,4 +144,5 @@ def run_hook(
         file_args,
         require_serial=require_serial,
         color=color,
+        dry_run=dry_run,
     )

--- a/pre_commit/languages/docker_image.py
+++ b/pre_commit/languages/docker_image.py
@@ -22,6 +22,7 @@ def run_hook(
         is_local: bool,
         require_serial: bool,
         color: bool,
+        dry_run: bool,
 ) -> tuple[int, bytes]:  # pragma: win32 no cover
     cmd = docker_cmd() + lang_base.hook_cmd(entry, args)
     return lang_base.run_xargs(
@@ -29,4 +30,5 @@ def run_hook(
         file_args,
         require_serial=require_serial,
         color=color,
+        dry_run=dry_run,
     )

--- a/pre_commit/languages/pygrep.py
+++ b/pre_commit/languages/pygrep.py
@@ -96,9 +96,10 @@ def run_hook(
         is_local: bool,
         require_serial: bool,
         color: bool,
+        dry_run: bool,
 ) -> tuple[int, bytes]:
     cmd = (sys.executable, '-m', __name__, *args, entry)
-    return xargs(cmd, file_args, color=color)
+    return xargs(cmd, file_args, color=color, dry_run=dry_run)
 
 
 def main(argv: Sequence[str] | None = None) -> int:

--- a/pre_commit/languages/r.py
+++ b/pre_commit/languages/r.py
@@ -185,6 +185,7 @@ def run_hook(
         is_local: bool,
         require_serial: bool,
         color: bool,
+        dry_run: bool,
 ) -> tuple[int, bytes]:
     cmd = _cmd_from_hook(prefix, entry, args, is_local=is_local)
     return lang_base.run_xargs(
@@ -192,4 +193,5 @@ def run_hook(
         file_args,
         require_serial=require_serial,
         color=color,
+        dry_run=dry_run,
     )

--- a/pre_commit/languages/script.py
+++ b/pre_commit/languages/script.py
@@ -21,6 +21,7 @@ def run_hook(
         is_local: bool,
         require_serial: bool,
         color: bool,
+        dry_run: bool,
 ) -> tuple[int, bytes]:
     cmd = lang_base.hook_cmd(entry, args)
     cmd = (prefix.path(cmd[0]), *cmd[1:])
@@ -29,4 +30,5 @@ def run_hook(
         file_args,
         require_serial=require_serial,
         color=color,
+        dry_run=dry_run,
     )

--- a/pre_commit/main.py
+++ b/pre_commit/main.py
@@ -60,6 +60,12 @@ def _add_hook_type_option(parser: argparse.ArgumentParser) -> None:
 def _add_run_options(parser: argparse.ArgumentParser) -> None:
     parser.add_argument('hook', nargs='?', help='A single hook-id to run')
     parser.add_argument('--verbose', '-v', action='store_true', default=False)
+    parser.add_argument(
+        '--dry-run',
+        action='store_true',
+        help='Display the hook commands instead of run them (useful for debugging).',
+        default=False,
+    )
     mutex_group = parser.add_mutually_exclusive_group(required=False)
     mutex_group.add_argument(
         '--all-files', '-a', action='store_true', default=False,

--- a/pre_commit/xargs.py
+++ b/pre_commit/xargs.py
@@ -175,9 +175,9 @@ def xargs(
         )
     if dry_run:
         for run_cmd in partitions:
-            print("DRY RUN EXEC: ", " ".join(run_cmd))
+            print('DRY RUN EXEC: ', ' '.join(run_cmd))
         retcode = 0
-        stdout = b""
+        stdout = b''
     else:
         threads = min(len(partitions), target_concurrency)
         with _thread_mapper(threads) as thread_map:

--- a/testing/language_helpers.py
+++ b/testing/language_helpers.py
@@ -18,6 +18,7 @@ def run_language(
         is_local: bool = False,
         require_serial: bool = True,
         color: bool = False,
+        dry_run: bool = False
 ) -> tuple[int, bytes]:
     prefix = Prefix(str(path))
     version = version or language.get_default_version()
@@ -35,6 +36,7 @@ def run_language(
             is_local=is_local,
             require_serial=require_serial,
             color=color,
+            dry_run=dry_run,
         )
         out = out.replace(b'\r\n', b'\n')
         return ret, out

--- a/testing/language_helpers.py
+++ b/testing/language_helpers.py
@@ -18,7 +18,7 @@ def run_language(
         is_local: bool = False,
         require_serial: bool = True,
         color: bool = False,
-        dry_run: bool = False
+        dry_run: bool = False,
 ) -> tuple[int, bytes]:
     prefix = Prefix(str(path))
     version = version or language.get_default_version()


### PR DESCRIPTION
Hello,

First and foremost, fell free to close this PR right away you don't have time or don't want to deal with it :smiley: 

I'm sorry my issue #3070 wasn't well received, by this PR I'd like to show:

1) I was serious when I stated I wasn't ranting about pre-commit and I was willing to put some work into improving it ;-)
2) Implementing the feature I proposed is doable (see issue #3070 for why I think this feature would have real use-case)

Of course this PR is by no mean a finished work: tests are missing, and it's very possible my implementation was trivial only because I missed bigger problems due to my poor knowledge on the internals of this project ^^

In any case, I'd be interested to have your opinion on this. You said " there are many duplicates including an intended mechanism for this and a rationale for why it's intentionally not implemented", but I couldn't find any issue related to mine (I have to admit is hard to do an exhaustive search of the ~1900 issues though).
The closest I could found was issue #1003, but it was about outputing hook command stdout with `--verbose`, which has nothing to do with my proposal of providing a way to know what is the hook command being run.

Examples of the output:

```shell
$ pre-commit run black --all-files --dry-run
black (using `poetry run ruff format`)...................................DRY RUN EXEC:  /home/emmanuel/.local/pipx/venvs/poetry/bin/python /home/emmanuel/.local/bin/poetry --directory ./server run ruff format --config=server/pyproject.toml .github/scripts/check_commit_signature.py .github/scripts/check_newsfragments.py 
Passed
```
or with a hook with `require_serial=False`

```shell
../pre-commit/venv/bin/pre-commit run yamllint --all-files --dry-run
yamllint.................................................................DRY RUN EXEC:  /home/emmanuel/.cache/pre-commit/repoa2nqsg8u/py_env-python3.9/bin/python /home/emmanuel/.cache/pre-commit/repoa2nqsg8u/py_env-python3.9/bin/yamllint .pre-commit-config.yaml .github/filters/codeql.yml .yamllint.yml .github/workflows/ci-web.yml
DRY RUN EXEC:  /home/emmanuel/.cache/pre-commit/repoa2nqsg8u/py_env-python3.9/bin/python /home/emmanuel/.cache/pre-commit/repoa2nqsg8u/py_env-python3.9/bin/yamllint .github/workflows/ci-docs.yml .cspell/cspell.config.yml .github/workflows/releaser.yml .github/workflows/ci-rust.yml
DRY RUN EXEC:  /home/emmanuel/.cache/pre-commit/repoa2nqsg8u/py_env-python3.9/bin/python /home/emmanuel/.cache/pre-commit/repoa2nqsg8u/py_env-python3.9/bin/yamllint .github/actions/use-pre-commit/action.yml .github/workflows/docker-server.yml docs/adminguide/hosting/parsec-server.docker.yaml .github/workflows/codeql.yml
DRY RUN EXEC:  /home/emmanuel/.cache/pre-commit/repoa2nqsg8u/py_env-python3.9/bin/python /home/emmanuel/.cache/pre-commit/repoa2nqsg8u/py_env-python3.9/bin/yamllint .github/ISSUE_TEMPLATE/feature-request.yml .syft.yaml .github/ISSUE_TEMPLATE/bug-report.yml .github/ISSUE_TEMPLATE/config.yml
Passed
```
