### PR TITLE
Address deprecation warning in `shutil.rmtree(onerror=...)`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,5 +19,5 @@ jobs:
   main-linux:
     uses: asottile/workflows/.github/workflows/tox.yml@v1.6.0
     with:
-      env: '["py39", "py310", "py311"]'
+      env: '["py39", "py310", "py311", "py312"]'
       os: ubuntu-latest


### PR DESCRIPTION
<blockquote>
<p><a href="https://docs.python.org/3.12/library/shutil.html#shutil.rmtree"><code>shutil.rmtree()</code></a> now accepts a new argument <em>onexc</em> which is an
error handler like <em>onerror</em> but which expects an exception instance
rather than a <em>(typ, val, tb)</em> triplet. <em>onerror</em> is deprecated and
will be removed in Python 3.14.
(Contributed by Irit Katriel in <a class="reference external" href="https://github.com/python/cpython/issues/102828">gh-102828</a>.)</p>
</blockquote>

https://docs.python.org/3.12/whatsnew/3.12.html#shutil
