### PR TITLE
add docker support for cgroup v2 implementations

### DIFF
--- a/pre_commit/languages/docker.py
+++ b/pre_commit/languages/docker.py
@@ -10,6 +10,7 @@ from pre_commit.prefix import Prefix
 from pre_commit.util import CalledProcessError
 from pre_commit.util import cmd_output_b
 
+ENV_VAR_OVERRIDE_HOST_PATH = 'PRE_COMMIT_OVERRIDE_DOCKER_HOST_PATH'
 ENVIRONMENT_DIR = 'docker'
 PRE_COMMIT_LABEL = 'PRE_COMMIT'
 get_default_version = lang_base.basic_get_default_version
@@ -37,6 +38,8 @@ def _get_container_id() -> str:
 
 
 def _get_docker_path(path: str) -> str:
+    if ENV_VAR_OVERRIDE_HOST_PATH in os.environ:
+        return os.environ[ENV_VAR_OVERRIDE_HOST_PATH]
     if not _is_in_docker():
         return path
 


### PR DESCRIPTION
## The problem:

The current implementation of "_is_in_docker" unfortunately only covers cases where the container engine is running `version 1` of cgroups.  This is only a problem due to `version 2` now becoming more widely adopted.  (ie. Docker Desktop for Mac)

I’d like to make use of pre-commit inside containers for various projects I’m working on but the lack of compatibility with `version 2` makes this infeasible, so I did some reading and then some testing…

### Sources:

- [baeldung.com](https://www.baeldung.com/linux/is-process-running-inside-container)
- [is-docker](https://www.npmjs.com/package/is-docker)
- [toradex.com](https://community.toradex.com/t/python-nullresource-error-when-running-torizoncore-builder-build/15240/3)
- [kubernetes.io](https://kubernetes.io/docs/concepts/architecture/cgroups/)
- [docs.kernel.org](https://docs.kernel.org/admin-guide/cgroup-v2.html)

### Main takeaways on detecting version 2 containerization:

- You cannot identify anything related to containerization by looking at the cgroup entry for process 1 anymore… this is what “_is_in_docker” relies on.
- Although you can OFTEN still get the container ID through network-related files (hosts and hostname for example) that are derived from the host machine (`/proc/self/mountinfo`) ([Source](https://www.baeldung.com/linux/is-process-running-inside-container)) it's not consistent across all docker implementations and container use cases.
- Likewise, although LXC has been removed from docker, there are STILL a lot of folks using the '.dockerenv' file to determine if the current environment is a container- but this is NOT a standard.
 
## PR:

This PR went through two cycles:
1. Very complex, I was parsing the `/proc/self/mountinfo` file to extract the container ID, before doing more testing and realizing it's NOT always available in `version 2` cgroups.  There are exceptions to this.
2. I learned from my mistaken assumption and opted to go an arguably simpler route of exposing an environment variable to allow the user to override the default behaviour.

I have named the variable "PRE_COMMIT_OVERRIDE_DOCKER_HOST_PATH", which is a bit wordy.
Please feel free to request additional changes...

### Example Implementation of PR

```yaml
---
version: "3.8"

services:
  my_python_service:
    build:
      args:
        BUILD_ARG_CONTAINER_UID: "${DOCKER_USER_UID:-1000}"
        BUILD_ARG_CONTAINER_GID: "${DOCKER_USER_UID:-1000}"
        BUILD_ARG_PIP_INDEX_URL: "https://pypi.org/simple"
        BUILD_ARG_PLATFORM: "amd64"
      context: .
      dockerfile: assets/Dockerfile
      target: development
    platform: linux/amd64
    env_file:
      - assets/local.env
    environment:
      ENVIRONMENT: "DEVELOPMENT"
      PRE_COMMIT_OVERRIDE_DOCKER_HOST_PATH: "${PWD}"
    volumes:
      - ./:/app
      - /var/run/docker.sock:/var/run/docker.sock
```

I'm hoping this simpler approach (although potentially falling victim to bad user input) would allow support for a wider range of docker implementations.

Thanks again for all your work supporting this incredibly useful tool.