### PR TITLE
Hacky, Horrible, No Good, Very Bad UV support.

### DIFF
--- a/pre_commit/languages/python.py
+++ b/pre_commit/languages/python.py
@@ -235,12 +235,9 @@ def install_environment(
 
                     if name is None:
                         name = try_navigate('project', 'name')
-            print(name)
             if name is None:
                 setup = prefix.prefix_dir / Path('setup.py')
-                print(setup)
                 if setup.exists():
-                    print('it exists')
                     with tempfile.TemporaryDirectory() as td:
                         try:
                             lang_base.setup_cmd(
@@ -254,7 +251,7 @@ def install_environment(
                                     'setup.py',
                                     'egg_info',
                                     '-e',
-                                    f"{td}",
+                                    f'{td}',
                                 ),
                             )
                             candidates = list(Path(td).glob('*.egg-info'))
@@ -271,7 +268,7 @@ def install_environment(
                     'uv',
                     'pip',
                     'install',
-                    f"{name} @ .",
+                    f'{name} @ .',
                     *additional_dependencies,
                 )
         if pip_cmd is not None:

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,7 @@ install_requires =
     identify>=1.0.0
     nodeenv>=0.11.1
     pyyaml>=5.1
+    tomlkit>=0.12.4
     virtualenv>=20.10.0
 python_requires = >=3.9
 


### PR DESCRIPTION
Hello everyone,
I implemented support for using UV instead of pip to install Python packages. It uses various strategies to figure out the package name to work around https://github.com/astral-sh/uv/issues/313 and falls back to `pip` on failure. It is enabled by the `PRE_COMMIT_USE_UV` env variable. 

I don't expect this to be merged right away, because it's missing a bit of polish. For example, it'd be nice to log if UV was actually able to be used or not. In addition, depending on tomlkit might not be desirable. However, I'm hoping someone can build off of this to get a more polished feature merged.

**Important:** I believe the latest UV release has a regression that makes this no longer work. I've tested with uv `0.1.11` instead.

# Benchmarks (ran on the pre-commit repository):

## Just venvs
`hyperfine --warmup 2 -r 30 --prepare "rm -rf ~/.cache/pre-commit/*/py_env*/; sync" "unset PRE_COMMIT_USE_UV; pre-commit install-hooks" "PRE_COMMIT_USE_UV=1 pre-commit install-hooks"`

| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `unset PRE_COMMIT_USE_UV; pre-commit install-hooks` | 39.863 ± 1.986 | 37.897 | 44.239 | 10.82 ± 0.54 |
| `PRE_COMMIT_USE_UV=1 pre-commit install-hooks` | 3.685 ± 0.010 | 3.666 | 3.717 | 1.00 |

## No pre-install caches
`hyperfine --warmup 2 -r 30 --prepare "rm -rf ~/.cache/pre-commit/; sync" "unset PRE_COMMIT_USE_UV; pre-commit install-hooks" "PRE_COMMIT_USE_UV=1 pre-commit install-hooks"`
| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `unset PRE_COMMIT_USE_UV; pre-commit install-hooks` | 48.025 ± 1.061 | 46.420 | 50.491 | 2.58 ± 0.08 |
| `PRE_COMMIT_USE_UV=1 pre-commit install-hooks` | 18.617 ± 0.402 | 18.230 | 19.595 | 1.00 |

## No pre-install and pip/uv caches
`hyperfine --warmup 2 -r 30 --prepare "rm -rf ~/.cache/pre-commit/; rm -rf ~.cache/uv/; rm -rf ~.cache/pip/; sync" "unset PRE_COMMIT_USE_UV; pre-commit install-hooks" "PRE_COMMIT_USE_UV=1 pre-commit install-hooks"`

| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `unset PRE_COMMIT_USE_UV; pre-commit install-hooks` | 47.785 ± 0.717 | 46.467 | 49.976 | 2.56 ± 0.06 |
| `PRE_COMMIT_USE_UV=1 pre-commit install-hooks` | 18.654 ± 0.288 | 18.261 | 19.385 | 1.00 |


