### PR TITLE
[rfc] Support Sapling (alternative SCM) when using precommit

### DIFF
--- a/pre_commit/commands/run.py
+++ b/pre_commit/commands/run.py
@@ -322,6 +322,10 @@ def _run_hooks(
 
 
 def _has_unmerged_paths() -> bool:
+    if git.is_sapling():
+        # FIXME: Implement this properly.
+        return False
+
     _, stdout, _ = cmd_output_b('git', 'ls-files', '--unmerged')
     return bool(stdout.strip())
 

--- a/pre_commit/git.py
+++ b/pre_commit/git.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
 import logging
-import os
 import os.path
 import sys
 from collections.abc import Mapping
-from enum import Flag, auto
+from enum import auto
+from enum import Flag
 
 from pre_commit.errors import FatalError
 from pre_commit.util import CalledProcessError
@@ -90,6 +90,7 @@ def get_root() -> str:
 
 SAPLING_CLI = 'sl'
 
+
 def get_sapling_root() -> str | None:
     try:
         sapling_root = sapling_output('root')[1].strip()
@@ -111,7 +112,7 @@ class SaplingStatus(Flag):
 
 
 def sapling_status(status_flags: SaplingStatus) -> list[str]:
-    args = ["status", "--print0", "--root-relative", "--no-status"]
+    args = ['status', '--print0', '--root-relative', '--no-status']
     for enum_value, flag in [
         (SaplingStatus.MODIFIED, '--modified'),
         (SaplingStatus.ADDED, '--added'),

--- a/pre_commit/staged_files_only.py
+++ b/pre_commit/staged_files_only.py
@@ -109,5 +109,9 @@ def staged_files_only(patch_dir: str) -> Generator[None, None, None]:
     """Clear any unstaged changes from the git working directory inside this
     context.
     """
-    with _intent_to_add_cleared(), _unstaged_changes_cleared(patch_dir):
+    if git.is_sapling():
+        # FIXME: what is the intention here?
         yield
+    else:
+        with _intent_to_add_cleared(), _unstaged_changes_cleared(patch_dir):
+            yield


### PR DESCRIPTION
[rfc] Support Sapling (alternative SCM) when using precommit

When using [Sapling SCM](https://sapling-scm.com/) with a Git
repository, precommit expectedly fails today because it shells
out to `git` to get the list of modified files in the working
copy. In a Sapling clone of a Git repository, these calls will
fail.

While most of the logic in precommit that deals with talking
to Git today is encapsulated in `git.py`, calls to `git` are
sprinkled throughout the project and are called directly. In
order to support alternative SCMs, such as Sapling, ideally
there would be a more generic "SCM" interface that business
logic would call into with both Git and Sapling implementations.

Though this PR does not attempt to introduce such an interface.
Instead, it is just a basic PoC to provide evidence that
something like this could be made to work. For the moment, it
takes a shortcut and simply sprinkles "if Sapling" checks
in `git.py` in enough places that I could get precommit to
run in a Sapling working copy in the simple case where I had
only one file modified locally.

My higher-level question is whether the precommit project
would be open to accepting changes to support Sapling,
either via the introduction of an SCM-agnostic interface or
some other means.
