### PR TITLE
Advise user to unset `core.hooksPath` git config globally as well as locally

### DIFF
--- a/pre_commit/commands/install_uninstall.py
+++ b/pre_commit/commands/install_uninstall.py
@@ -123,7 +123,7 @@ def install(
     if git_dir is None and git.has_core_hookpaths_set():
         logger.error(
             'Cowardly refusing to install hooks with `core.hooksPath` set.\n'
-            'hint: `git config --unset-all core.hooksPath`',
+            'hint: `git config --unset-all core.hooksPath && git config --unset-all --global core.hooksPath`',
         )
         return 1
 


### PR DESCRIPTION
This is a very simple PR that should not need a test of an issue (but feel free to advise otherwise).

Global `core.hooksPath` configurations are rare but not unheard of. I just happened to work on a project that set this config globally on my machine and this broke my ability to install pre-commit. This simple change would have saved me a bit of time.