### PR TITLE
Use `--locked` when installing tools via Cargo

### DIFF
--- a/pre_commit/languages/rust.py
+++ b/pre_commit/languages/rust.py
@@ -155,6 +155,6 @@ def install_environment(
 
         for args in packages_to_install:
             cmd_output_b(
-                'cargo', 'install', '--bins', '--root', envdir, *args,
+                'cargo', 'install', '--bins', '--locked', '--root', envdir, *args,
                 cwd=prefix.prefix_dir,
             )


### PR DESCRIPTION
Closes #3162 