### PR TITLE
[Python3.12] Fix `virtualenv` lower limit to remain PEP 632 compliant.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ install_requires =
     identify>=1.0.0
     nodeenv>=0.11.1
     pyyaml>=5.1
-    virtualenv>=20.10.0
+    virtualenv>=20.25.1
 python_requires = >=3.9
 
 [options.packages.find]


### PR DESCRIPTION
In Python 3.12 PEP 632 [0] kicks into effect and removes distutils from the standard libraries. This has downstream effects with older versions of pip (23.1.x) now broken at its core and unable to install anything.

As the current low-bound of `virtualenv` installs 23.1.x of pip, when you use pre-commit + python 3.12, you also break all your hooks. Since it's not normal to explicitly set the dependency of `virtual`, we should increase the lower bounds to also make `pre-commit` PEP 632 compatible.

I'm using `virtualenv` v20.25.1, as it's the only version that supports the final release of PY3.12 [1].

[0] https://peps.python.org/pep-0632/#migration-advice
[1] https://github.com/pypa/virtualenv/commit/f56fb61d0f620477f5fdb55ed6a441962c67343f