### PR TITLE
feat: add options for disabling venv in python

### DIFF
--- a/pre_commit/clientlib.py
+++ b/pre_commit/clientlib.py
@@ -132,6 +132,7 @@ MANIFEST_HOOK_DICT = cfgv.Map(
     cfgv.Optional('language_version', cfgv.check_string, C.DEFAULT),
     cfgv.Optional('log_file', cfgv.check_string, ''),
     cfgv.Optional('require_serial', cfgv.check_bool, False),
+    cfgv.Optional('require_venv', cfgv.check_bool, True),
     StagesMigration('stages', []),
     cfgv.Optional('verbose', cfgv.check_bool, False),
 )

--- a/pre_commit/hook.py
+++ b/pre_commit/hook.py
@@ -33,6 +33,7 @@ class Hook(NamedTuple):
     log_file: str
     minimum_pre_commit_version: str
     require_serial: bool
+    require_venv: bool
     stages: Sequence[str]
     verbose: bool
 

--- a/pre_commit/repository.py
+++ b/pre_commit/repository.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
-import sys
 import json
 import logging
 import os
 import shlex
+import sys
 from collections.abc import Sequence
 from typing import Any
 
@@ -85,7 +85,7 @@ def _hook_install(hook: Hook) -> None:
         lang.ENVIRONMENT_DIR,
         hook.language_version,
     )
-    
+
     if hook.language == 'python' and not hook.require_venv:
         logger.info(f'Disabling creation of virtual environment for hook {hook.src}')
         # Path to the Python executable inside the virtual environment


### PR DESCRIPTION
In many cases, the dependencies we need are not available on PyPI but are bundled within an image, such as the Arm64 version of Nvidia/TensorRT, which does not offer a wheel file. When using virtualenv, it becomes impossible to locate this package. This PR introduces an option allowing users to use the current Python Environment directly. This is particularly beneficial in CI/CD scenarios.