### PR TITLE
Fix URL links of logs in Github Actions

### DIFF
--- a/pre_commit/store.py
+++ b/pre_commit/store.py
@@ -156,7 +156,7 @@ class Store:
             if result:  # pragma: no cover (race)
                 return result
 
-            logger.info(f'Initializing environment for {repo}.')
+            logger.info(f'Initializing environment for {repo}')
 
             directory = tempfile.mkdtemp(prefix='repo', dir=self.directory)
             with clean_path_on_failure(directory):

--- a/tests/commands/install_uninstall_test.py
+++ b/tests/commands/install_uninstall_test.py
@@ -143,7 +143,7 @@ FILES_CHANGED = (
 
 
 NORMAL_PRE_COMMIT_RUN = re_assert.Matches(
-    fr'^\[INFO\] Initializing environment for .+\.\n'
+    fr'^\[INFO\] Initializing environment for .+\n'
     fr'Bash hook\.+Passed\n'
     fr'\[master [a-f0-9]{{7}}\] commit!\n'
     fr'{FILES_CHANGED}'
@@ -297,7 +297,7 @@ def test_environment_not_sourced(tempdir_factory, store):
 
 
 FAILING_PRE_COMMIT_RUN = re_assert.Matches(
-    r'^\[INFO\] Initializing environment for .+\.\n'
+    r'^\[INFO\] Initializing environment for .+\n'
     r'Failing hook\.+Failed\n'
     r'- hook id: failing_hook\n'
     r'- exit code: 1\n'
@@ -396,7 +396,7 @@ def test_install_with_existing_non_utf8_script(tmpdir, store):
 
 FAIL_OLD_HOOK = re_assert.Matches(
     r'fail!\n'
-    r'\[INFO\] Initializing environment for .+\.\n'
+    r'\[INFO\] Initializing environment for .+\n'
     r'Bash hook\.+Passed\n',
 )
 


### PR DESCRIPTION
**The Problem**
In GitHub Actions the URL generated from the following log output is not parsed correctly because of the trailing period(.)
`logger.info(f'Initializing environment for {repo}.')` and it leads to a 404/Not Found page.

These are some examples:
```
[INFO] Initializing environment for https://github.com/Yelp/detect-secrets.git.
[INFO] Initializing environment for https://github.com/pre-commit/pre-commit-hooks.
[INFO] Initializing environment for https://github.com/pre-commit/mirrors-isort.
[INFO] Initializing environment for https://github.com/ambv/black.
[INFO] Initializing environment for https://github.com/PyCQA/flake8.git.
```
**The Effect**
Having a broken link in the logs output undermines the project's credibility and could frustrate users. It's unfortunate because "pre-commit" is a widely-used and highly maintained project.

**The Fix**
The PR just removes the trailing period from the log output.
I believe this is a useful change because it doesn't remove any information while it restores the functionality of the URL links in GitHub Actions console.