### PR TITLE
feat: utilize cpanminus for perl dependencies if available

### DIFF
--- a/.github/workflows/languages.yaml
+++ b/.github/workflows/languages.yaml
@@ -63,6 +63,11 @@ jobs:
         echo 'C:\Strawberry\c\bin' >> "$GITHUB_PATH"
       shell: bash
       if: matrix.os == 'windows-latest' && matrix.language == 'perl'
+    - run: |
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends \
+          cpanminus
+      if: matrix.os == 'ubuntu-latest' && matrix.language == 'perl'
     - uses: haskell/actions/setup@v2
       if: matrix.language == 'haskell'
 

--- a/pre_commit/languages/perl.py
+++ b/pre_commit/languages/perl.py
@@ -45,6 +45,13 @@ def install_environment(
     lang_base.assert_version_default('perl', version)
 
     with in_env(prefix, version):
-        lang_base.setup_cmd(
-            prefix, ('cpan', '-T', '.', *additional_dependencies),
-        )
+        if lang_base.exe_exists('cpanm'):
+            lang_base.setup_cmd(
+                prefix,
+                ('cpanm', '.', *additional_dependencies),
+            )
+        else:
+            lang_base.setup_cmd(
+                prefix,
+                ('cpan', '-T', '.', *additional_dependencies),
+            )

--- a/tests/languages/perl_test.py
+++ b/tests/languages/perl_test.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+from unittest.mock import patch
+
+import pytest
+
 from pre_commit.languages import perl
 from pre_commit.store import _make_local_repo
 from pre_commit.util import make_executable
@@ -56,7 +60,10 @@ sub hello {
     assert ret == (0, b'Hello from perl-commit Perl!\n')
 
 
-def test_perl_additional_dependencies(tmp_path):
+@pytest.mark.parametrize('cpanm', [True, False])
+@patch('pre_commit.lang_base.exe_exists')
+def test_perl_additional_dependencies(mock_exe_exists, cpanm, tmp_path):
+    mock_exe_exists.return_value = cpanm
     _make_local_repo(str(tmp_path))
 
     ret, out = run_language(
@@ -65,5 +72,6 @@ def test_perl_additional_dependencies(tmp_path):
         'perltidy --version',
         deps=('SHANCOCK/Perl-Tidy-20211029.tar.gz',),
     )
+    mock_exe_exists.assert_called_once_with('cpanm')
     assert ret == 0
     assert out.startswith(b'This is perltidy, v20211029')

--- a/tests/languages/perl_test.py
+++ b/tests/languages/perl_test.py
@@ -75,3 +75,16 @@ def test_perl_additional_dependencies(mock_exe_exists, cpanm, tmp_path):
     mock_exe_exists.assert_called_once_with('cpanm')
     assert ret == 0
     assert out.startswith(b'This is perltidy, v20211029')
+
+
+def test_perl_additional_dependencies_at_syntax(tmp_path):
+    _make_local_repo(str(tmp_path))
+
+    ret, out = run_language(
+        tmp_path,
+        perl,
+        'perltidy --version',
+        deps=('Perl::Tidy@20211029',),
+    )
+    assert ret == 0
+    assert out.startswith(b'This is perltidy, v20211029')


### PR DESCRIPTION
[cpanminus](https://metacpan.org/pod/App::cpanminus) is broadly compatible with our syntax use of [cpan](https://metacpan.org/pod/CPAN), but can offer additional benefits such as `Pkg::Name@Version` definitions, as well as built-in modules to reduce the environment requirements on the system when resolving dependencies.

This PR updates the perl dependency resolver to use `cpanm` if available in the environment. Tests have been updated to ensure operation with either utility, and the Github Actions workflow updated to make the utility available on Ubuntu runners (being already provided in the Windows Perl distribution).