### PR TITLE
Show additional information when a hook fails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 *.egg-info
 *.py[co]
+*.pytest_cache
 /.coverage
 /.tox
+/build
 /dist
 .vscode/

--- a/pre_commit/commands/run.py
+++ b/pre_commit/commands/run.py
@@ -222,6 +222,13 @@ def _run_single_hook(
 
         if retcode:
             _subtle_line(f'- exit code: {retcode}', use_color)
+            if verbose and hook.description:
+                if '\n' in hook.description:
+                    _subtle_line('- description: |', use_color)
+                    for l in hook.description.splitlines():
+                        _subtle_line('  ' + l, use_color)
+                else:
+                    _subtle_line(f'- description: {hook.description}', use_color)
 
         # Print a message if failing due to file modifications
         if files_modified:

--- a/pre_commit/commands/run.py
+++ b/pre_commit/commands/run.py
@@ -223,12 +223,12 @@ def _run_single_hook(
         if retcode:
             _subtle_line(f'- exit code: {retcode}', use_color)
             if verbose and hook.description:
+                description = hook.description
                 if '\n' in hook.description:
-                    _subtle_line('- description: |', use_color)
-                    for l in hook.description.splitlines():
-                        _subtle_line('  ' + l, use_color)
-                else:
-                    _subtle_line(f'- description: {hook.description}', use_color)
+                    description = '|'
+                    for line in hook.description.splitlines():
+                        description += '\n  ' + line
+                _subtle_line(f'- description: {description}', use_color)
 
         # Print a message if failing due to file modifications
         if files_modified:

--- a/pre_commit/util.py
+++ b/pre_commit/util.py
@@ -206,14 +206,14 @@ def _handle_readonly(
         func: Callable[[str], object],
         path: str,
         exc: OSError,
-):
+) -> object:
     if (
             func in (os.rmdir, os.remove, os.unlink) and
             exc.errno in {errno.EACCES, errno.EPERM}
     ):
         for p in (path, os.path.dirname(path)):
             os.chmod(p, os.stat(p).st_mode | stat.S_IWUSR)
-        func(path)
+        return func(path)
     else:
         raise
 
@@ -223,8 +223,8 @@ if sys.version_info < (3, 12):  # pragma: <3.12 cover
         func: Callable[[str], object],
         path: str,
         excinfo: tuple[type[OSError], OSError, TracebackType],
-    ):
-        return _handle_readonly(func, path, excinfo[1])
+    ) -> None:
+        _handle_readonly(func, path, excinfo[1])
 
     def rmtree(path: str) -> None:
         shutil.rmtree(path, ignore_errors=False, onerror=_handle_readonly_old)

--- a/pre_commit/util.py
+++ b/pre_commit/util.py
@@ -206,8 +206,7 @@ def _handle_readonly(
         func: Callable[[str], object],
         path: str,
         exc: OSError,
-        object: object = None,  # Ignored.
-) -> None:
+):
     if (
             func in (os.rmdir, os.remove, os.unlink) and
             exc.errno in {errno.EACCES, errno.EPERM}
@@ -224,7 +223,7 @@ if sys.version_info < (3, 12):  # pragma: <3.12 cover
         func: Callable[[str], object],
         path: str,
         excinfo: tuple[type[OSError], OSError, TracebackType],
-    ) -> None:
+    ):
         return _handle_readonly(func, path, excinfo[1])
 
     def rmtree(path: str) -> None:

--- a/pre_commit/util.py
+++ b/pre_commit/util.py
@@ -206,6 +206,7 @@ def _handle_readonly(
         func: Callable[[str], object],
         path: str,
         exc: OSError,
+        object: object = None,  # Ignored.
 ) -> None:
     if (
             func in (os.rmdir, os.remove, os.unlink) and

--- a/pre_commit/util.py
+++ b/pre_commit/util.py
@@ -12,6 +12,7 @@ from collections.abc import Generator
 from types import TracebackType
 from typing import Any
 from typing import Callable
+from typing import cast
 
 from pre_commit import parse_shebang
 
@@ -205,11 +206,11 @@ else:  # pragma: no cover
 def _handle_readonly(
         func: Callable[[str], object],
         path: str,
-        exc: OSError,
+        exc: Exception,
 ) -> object:
     if (
-            func in (os.rmdir, os.remove, os.unlink) and
-            exc.errno in {errno.EACCES, errno.EPERM}
+        func in (os.rmdir, os.remove, os.unlink) and exc is OSError and
+        cast(OSError, exc).errno in {errno.EACCES, errno.EPERM}
     ):
         for p in (path, os.path.dirname(path)):
             os.chmod(p, os.stat(p).st_mode | stat.S_IWUSR)

--- a/pre_commit/util.py
+++ b/pre_commit/util.py
@@ -209,7 +209,8 @@ def _handle_readonly(
         exc: Exception,
 ) -> object:
     if (
-        func in (os.rmdir, os.remove, os.unlink) and exc is OSError and
+        func in (os.rmdir, os.remove, os.unlink) and
+        issubclass(type(exc), OSError) and
         cast(OSError, exc).errno in {errno.EACCES, errno.EPERM}
     ):
         for p in (path, os.path.dirname(path)):

--- a/testing/resources/failing_hook_repo/.pre-commit-hooks.yaml
+++ b/testing/resources/failing_hook_repo/.pre-commit-hooks.yaml
@@ -1,5 +1,8 @@
 -   id: failing_hook
     name: Failing hook
+    description: |
+        Failing Hook Description
+        Longer description.
     entry: bin/hook.sh
     language: script
     files: .

--- a/tests/commands/run_test.py
+++ b/tests/commands/run_test.py
@@ -173,6 +173,26 @@ def test_run_all_hooks_failing(cap_out, store, repo_with_failing_hook):
     )
 
 
+def test_run_all_hooks_failing_verbose(cap_out, store, repo_with_failing_hook):
+    _test_run(
+        cap_out,
+        store,
+        repo_with_failing_hook,
+        {'verbose': True},
+        (
+            b'Failing hook',
+            b'Failed',
+            b'hook id: failing_hook',
+            b'description: |',
+            b'  Failing Hook Description',
+            b'  Longer description.',
+            b'Fail\nfoo.py\n',
+        ),
+        expected_ret=1,
+        stage=True,
+    )
+
+
 def test_arbitrary_bytes_hook(cap_out, store, tempdir_factory):
     git_path = make_consuming_repo(tempdir_factory, 'arbitrary_bytes_repo')
     with cwd(git_path):


### PR DESCRIPTION
Possible implementation for https://github.com/pre-commit/pre-commit/issues/3189

When `run` is called with `-v`, then show `hook.description` if available.

When developers run the pre-commit, they don't always understand what to or where to find more information. The hook description field is already present and often used to provide more descriptive information. For brevity this is not shown in normal cases, but this PR changes the tool behavior to show the description in verbose mode (`-v`). So most users won't see any difference but this can easily be enabled for people who want it.

Alternatives considered:
* Always show the description: Some people may not like this though as it can be spammy.
* Provide a new field: Possible but seems to be just more work with description already present and not otherwise used.
* Show the `repo` link. This is at the wrong level and has a slightly different purpose. Though description can just be set to the same url where that is correct.