### PR TITLE
Introduce `use_filesnames_file` to aid with tools with expensive per-run overhead

### DIFF
--- a/pre_commit/clientlib.py
+++ b/pre_commit/clientlib.py
@@ -128,6 +128,7 @@ MANIFEST_HOOK_DICT = cfgv.Map(
     cfgv.Optional('always_run', cfgv.check_bool, False),
     cfgv.Optional('fail_fast', cfgv.check_bool, False),
     cfgv.Optional('pass_filenames', cfgv.check_bool, True),
+    cfgv.Optional('use_filesnames_file', cfgv.check_bool, False),
     cfgv.Optional('description', cfgv.check_string, ''),
     cfgv.Optional('language_version', cfgv.check_string, C.DEFAULT),
     cfgv.Optional('log_file', cfgv.check_string, ''),

--- a/pre_commit/commands/run.py
+++ b/pre_commit/commands/run.py
@@ -189,8 +189,8 @@ def _run_single_hook(
         if not hook.pass_filenames:
             filenames = ()
         elif hook.use_filesnames_file:
-            filenames_file = tempfile.NamedTemporaryFile("w+")
-            filenames_file.write("\n".join(filenames))
+            filenames_file = tempfile.NamedTemporaryFile('w+')
+            filenames_file.write('\n'.join(filenames))
             filenames = (f"@{filenames_file}",)
 
         time_before = time.monotonic()

--- a/pre_commit/commands/run.py
+++ b/pre_commit/commands/run.py
@@ -7,6 +7,7 @@ import logging
 import os
 import re
 import subprocess
+import tempfile
 import time
 import unicodedata
 from collections.abc import Generator
@@ -187,6 +188,11 @@ def _run_single_hook(
 
         if not hook.pass_filenames:
             filenames = ()
+        elif hook.use_filesnames_file:
+            filenames_file = tempfile.NamedTemporaryFile("w+")
+            filenames_file.write("\n".join(filenames))
+            filenames = (f"@{filenames_file}",)
+
         time_before = time.monotonic()
         language = languages[hook.language]
         with language.in_env(hook.prefix, hook.language_version):

--- a/pre_commit/hook.py
+++ b/pre_commit/hook.py
@@ -28,6 +28,7 @@ class Hook(NamedTuple):
     always_run: bool
     fail_fast: bool
     pass_filenames: bool
+    use_filesnames_file: bool
     description: str
     language_version: str
     log_file: str

--- a/tests/commands/run_test.py
+++ b/tests/commands/run_test.py
@@ -1085,8 +1085,8 @@ def test_use_filesnames_file(
         cap_out, store, repo_with_passing_hook, run_opts(verbose=True),
     )
     out_lines = printed.splitlines()
-    out_lines[-1] == b'Hello World'
-    assert out_lines[-2].startswith(b'@') == use_filesnames_file
+    assert out_lines[-2] == b'Hello World'
+    assert out_lines[-3].startswith(b'@') == use_filesnames_file
 
 
 def test_fail_fast(cap_out, store, repo_with_failing_hook):

--- a/tests/commands/run_test.py
+++ b/tests/commands/run_test.py
@@ -1085,8 +1085,8 @@ def test_use_filesnames_file(
         cap_out, store, repo_with_passing_hook, run_opts(verbose=True),
     )
     out_lines = printed.splitlines()
-    out_lines[-1] == b"Hello World"
-    assert out_lines[-2].startswith(b"@") == use_filesnames_file
+    out_lines[-1] == b'Hello World'
+    assert out_lines[-2].startswith(b'@') == use_filesnames_file
 
 
 def test_fail_fast(cap_out, store, repo_with_failing_hook):

--- a/tests/commands/run_test.py
+++ b/tests/commands/run_test.py
@@ -1064,6 +1064,31 @@ def test_pass_filenames(
     assert (b'foo.py' in printed) == pass_filenames
 
 
+@pytest.mark.parametrize(
+    ('use_filesnames_file', 'hook_args'),
+    (
+        (True, []),
+        (False, []),
+        (True, ['some', 'args']),
+        (False, ['some', 'args']),
+    ),
+)
+def test_use_filesnames_file(
+        cap_out, store, repo_with_passing_hook,
+        use_filesnames_file, hook_args,
+):
+    with modify_config() as config:
+        config['repos'][0]['hooks'][0]['use_filesnames_file'] = use_filesnames_file
+        config['repos'][0]['hooks'][0]['args'] = hook_args
+    stage_a_file()
+    ret, printed = _do_run(
+        cap_out, store, repo_with_passing_hook, run_opts(verbose=True),
+    )
+    out_lines = printed.splitlines()
+    out_lines[-1] == b"Hello World"
+    assert out_lines[-2].startswith(b"@") == use_filesnames_file
+
+
 def test_fail_fast(cap_out, store, repo_with_failing_hook):
     with modify_config() as config:
         # More than one hook

--- a/tests/repository_test.py
+++ b/tests/repository_test.py
@@ -455,6 +455,7 @@ def test_manifest_hooks(tempdir_factory, store):
         minimum_pre_commit_version='0',
         name='Bash hook',
         pass_filenames=True,
+        use_filesnames_file=False,
         require_serial=False,
         stages=[
             'commit-msg',


### PR DESCRIPTION
This PR works around a performance issue observed when running pre-commit on large repositories with tools that may have expensive overhead when invoked concurrently (such as tools that load configs remotely, operate on whole directories, have semi-expensive imports, or don't run well concurrently)

(I don't consider this a "problem" with pre-commit, but rather a "quirk" of tools being called in ways they weren't expecting)

I've added unit tests for the new functionality. I'm open to feedback and happy to refine the approach as needed.

(Example benchmark before/after)
```
% time pre-commit run -a infer-deps
Infer dependencies.......................................................Passed
pre-commit run -a infer-deps  4.87s user 6.94s system 100% cpu 11.572 total
% time pre-commit run -a infer-deps
Infer dependencies.......................................................Passed
pre-commit run -a infer-deps  2.79s user 6.71s system 121% cpu 7.75 total
```