### PR TITLE
Adjust permission only if needed

### DIFF
--- a/pre_commit/util.py
+++ b/pre_commit/util.py
@@ -42,8 +42,10 @@ def resource_text(filename: str) -> str:
 
 def make_executable(filename: str) -> None:
     original_mode = os.stat(filename).st_mode
-    new_mode = original_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
-    os.chmod(filename, new_mode)
+    exe_mask = stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
+    if (original_mode & exe_mask) != exe_mask:
+        new_mode = original_mode | exe_mask
+        os.chmod(filename, new_mode)
 
 
 class CalledProcessError(RuntimeError):


### PR DESCRIPTION
We are using pre-commit in a environment where we are not the owner of the repository but we are part of the group having it. In this scenario pre_commit was failing with error:

```
An unexpected error has occurred: PermissionError: [Errno 1] Operation not permitted: '.git/hooks/pre-commit'
```

This change adjust permission only if needed.