### PR TITLE
Support lifecycle scripts for node

### DIFF
--- a/pre_commit/languages/node.py
+++ b/pre_commit/languages/node.py
@@ -99,7 +99,7 @@ def install_environment(
         lang_base.setup_cmd(prefix, local_install_cmd)
 
         _, pkg, _ = cmd_output('npm', 'pack', cwd=prefix.prefix_dir)
-        pkg = prefix.path(pkg.strip())
+        pkg = prefix.path(pkg.strip().split()[-1])
 
         install = ('npm', 'install', '-g', pkg, *additional_dependencies)
         lang_base.setup_cmd(prefix, install)

--- a/tests/languages/node_test.py
+++ b/tests/languages/node_test.py
@@ -113,8 +113,8 @@ def test_installs_without_links_outside_env(tmpdir):
         assert cmd_output('foo')[1] == 'success!\n'
 
 
-def _make_hello_world(tmp_path):
-    package_json = '''\
+def _make_hello_world(tmp_path, package_json=None):
+    package_json = package_json or '''\
 {"name": "t", "version": "0.0.1", "bin": {"node-hello": "./bin/main.js"}}
 '''
     tmp_path.joinpath('package.json').write_text(package_json)
@@ -128,6 +128,20 @@ def _make_hello_world(tmp_path):
 
 def test_node_hook_system(tmp_path):
     _make_hello_world(tmp_path)
+    ret = run_language(tmp_path, node, 'node-hello')
+    assert ret == (0, b'Hello World\n')
+
+
+def test_node_with_prepare_script(tmp_path):
+    package_json = '''
+{
+  "name": "t",
+  "version": "0.0.1",
+  "bin": {"node-hello": "./bin/main.js"},
+  "scripts": {"prepare": "echo prepare"}
+}
+'''
+    _make_hello_world(tmp_path, package_json)
     ret = run_language(tmp_path, node, 'node-hello')
     assert ret == (0, b'Hello World\n')
 


### PR DESCRIPTION
The `npm pack` runs lifecycle scripts which can
spoil the standard output of the command and prevent
correct parsing of the created tarball.

For details see:

https://docs.npmjs.com/cli/v8/using-npm/scripts#life-cycle-scripts

Include a simple fix to parse out the tarball from the last line
and cover the fix with a simple test.

Signed-off-by: Miroslav Vadkerti <mvadkert@redhat.com>
