### PR TITLE
Setup `env` explicitly on Windows

### DIFF
--- a/pre_commit/util.py
+++ b/pre_commit/util.py
@@ -81,6 +81,8 @@ class CalledProcessError(RuntimeError):
 def _setdefault_kwargs(kwargs: dict[str, Any]) -> None:
     for arg in ('stdin', 'stdout', 'stderr'):
         kwargs.setdefault(arg, subprocess.PIPE)
+    if sys.platform == 'win32':
+        kwargs.setdefault('env', os.environ)
 
 
 def _oserror_to_output(e: OSError) -> tuple[int, bytes, None]:


### PR DESCRIPTION
- Fixes #3245

All signs point towards the discrepancies in the above issue being tied to the unmodified `subprocess` environment on Windows machines. While everything works as expected on Unix, Windows doesn't get empty environment variables saved by default; however, this issue is circumvented if the environment is explicitly set to `os.environ`.

To verify that these changes work, I ran local tests with a modified `tox.ini` as seen below. It's not part of the PR, as it likely qualifies as infrastructure, but I can add it if desired.
```ini
...
[pytest]
env =
    GIT_AUTHOR_NAME=test
    GIT_COMMITTER_NAME=test
    GIT_AUTHOR_EMAIL=test@example.com
    GIT_COMMITTER_EMAIL=test@example.com
    GIT_ALLOW_PROTOCOL=file
    VIRTUALENV_NO_DOWNLOAD=1
    PRE_COMMIT_NO_CONCURRENCY=1
    GIT_CONFIG_COUNT=1
    GIT_CONFIG_KEY_0=credential.helper
    GIT_CONFIG_VALUE_0=
```

---

Before:
```
PS D:\Python\pre-commit\pre-commit> pytest tests -k git_test
============================================ test session starts =============================================
platform win32 -- Python 3.12.4, pytest-8.3.1, pluggy-1.5.0
rootdir: D:\Python\pre-commit\pre-commit
configfile: tox.ini
plugins: env-1.1.3
collected 750 items / 718 deselected / 32 selected

tests\git_test.py EEEEEFFFEEEEEEEE..EE....EEEEEE..                                                      [100%]

=================================================== ERRORS =================================================== 
<see gist>
========================================== short test summary info =========================================== 
FAILED tests/git_test.py::test_get_root_bare_worktree - pre_commit.util.CalledProcessError: command: ('C:\\Program Files\\Git\\cmd\\git.EXE', 'init', 'C:\\Users\\...
FAILED tests/git_test.py::test_get_git_dir - pre_commit.util.CalledProcessError: command: ('C:\\Program Files\\Git\\cmd\\git.EXE', 'init', 'C:\\Users\\...
FAILED tests/git_test.py::test_get_root_worktree_in_git - pre_commit.util.CalledProcessError: command: ('C:\\Program Files\\Git\\cmd\\git.EXE', 'init', 'C:\\Users\\...
ERROR tests/git_test.py::test_get_root_at_root - pre_commit.util.CalledProcessError: command: ('C:\\Program Files\\Git\\cmd\\git.EXE', 'init')
ERROR tests/git_test.py::test_get_root_deeper - pre_commit.util.CalledProcessError: command: ('C:\\Program Files\\Git\\cmd\\git.EXE', 'init')
ERROR tests/git_test.py::test_get_root_in_git_sub_dir - pre_commit.util.CalledProcessError: command: ('C:\\Program Files\\Git\\cmd\\git.EXE', 'init')
ERROR tests/git_test.py::test_get_root_not_in_working_dir - pre_commit.util.CalledProcessError: command: ('C:\\Program Files\\Git\\cmd\\git.EXE', 'init')
ERROR tests/git_test.py::test_in_exactly_dot_git - pre_commit.util.CalledProcessError: command: ('C:\\Program Files\\Git\\cmd\\git.EXE', 'init')
ERROR tests/git_test.py::test_get_staged_files_deleted - pre_commit.util.CalledProcessError: command: ('C:\\Program Files\\Git\\cmd\\git.EXE', 'init')
ERROR tests/git_test.py::test_is_not_in_merge_conflict - pre_commit.util.CalledProcessError: command: ('C:\\Program Files\\Git\\cmd\\git.EXE', 'init')
ERROR tests/git_test.py::test_is_in_merge_conflict - pre_commit.util.CalledProcessError: command: ('C:\\Program Files\\Git\\cmd\\git.EXE', '-c', 'init.defaultB...
ERROR tests/git_test.py::test_is_in_merge_conflict_submodule - pre_commit.util.CalledProcessError: command: ('C:\\Program Files\\Git\\cmd\\git.EXE', '-c', 'init.defaultB...
ERROR tests/git_test.py::test_cherry_pick_conflict - pre_commit.util.CalledProcessError: command: ('C:\\Program Files\\Git\\cmd\\git.EXE', '-c', 'init.defaultB...
ERROR tests/git_test.py::test_get_conflicted_files - pre_commit.util.CalledProcessError: command: ('C:\\Program Files\\Git\\cmd\\git.EXE', '-c', 'init.defaultB...
ERROR tests/git_test.py::test_get_conflicted_files_in_submodule - pre_commit.util.CalledProcessError: command: ('C:\\Program Files\\Git\\cmd\\git.EXE', '-c', 'init.defaultB...
ERROR tests/git_test.py::test_get_conflicted_files_unstaged_files - pre_commit.util.CalledProcessError: command: ('C:\\Program Files\\Git\\cmd\\git.EXE', '-c', 'init.defaultB...
ERROR tests/git_test.py::test_get_changed_files - pre_commit.util.CalledProcessError: command: ('C:\\Program Files\\Git\\cmd\\git.EXE', 'init')
ERROR tests/git_test.py::test_get_changed_files_disparate_histories - pre_commit.util.CalledProcessError: command: ('C:\\Program Files\\Git\\cmd\\git.EXE', 'init')
ERROR tests/git_test.py::test_all_files_non_ascii - pre_commit.util.CalledProcessError: command: ('C:\\Program Files\\Git\\cmd\\git.EXE', 'init')
ERROR tests/git_test.py::test_staged_files_non_ascii - pre_commit.util.CalledProcessError: command: ('C:\\Program Files\\Git\\cmd\\git.EXE', 'init')
ERROR tests/git_test.py::test_changed_files_non_ascii - pre_commit.util.CalledProcessError: command: ('C:\\Program Files\\Git\\cmd\\git.EXE', 'init')
ERROR tests/git_test.py::test_get_conflicted_files_non_ascii - pre_commit.util.CalledProcessError: command: ('C:\\Program Files\\Git\\cmd\\git.EXE', '-c', 'init.defaultB...
ERROR tests/git_test.py::test_intent_to_add - pre_commit.util.CalledProcessError: command: ('C:\\Program Files\\Git\\cmd\\git.EXE', 'init')
ERROR tests/git_test.py::test_status_output_with_rename - pre_commit.util.CalledProcessError: command: ('C:\\Program Files\\Git\\cmd\\git.EXE', 'init')
=========================== 3 failed, 8 passed, 718 deselected, 21 errors in 1.65s ===========================
```
https://gist.github.com/Repiteo/b975a67925bcf248b2bca48959bcc940

After:
```
PS D:\Python\pre-commit\pre-commit> pytest tests -k git_test
============================================ test session starts =============================================
platform win32 -- Python 3.12.4, pytest-8.3.1, pluggy-1.5.0
rootdir: D:\Python\pre-commit\pre-commit
configfile: tox.ini
plugins: env-1.1.3
collected 750 items / 718 deselected / 32 selected

tests\git_test.py ................................                                                      [100%]

=============================== 32 passed, 718 deselected in 63.60s (0:01:03) ================================
```
