### PR TITLE
Require nodeenv 1.9.0+ to support Python 3.13

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ packages = find:
 install_requires =
     cfgv>=2.0.0
     identify>=1.0.0
-    nodeenv>=0.11.1
+    nodeenv>=1.9.0
     pyyaml>=5.1
     virtualenv>=20.10.0
 python_requires = >=3.9


### PR DESCRIPTION
Installing a hook that uses `language: node` on Python 3.13:

```pytb
[INFO] This may take a few minutes...
An unexpected error has occurred: CalledProcessError: command: ('/Library/Frameworks/Python.framework/Versions/3.13/bin/python3', '-mnodeenv', '--prebuilt', '--clean-src', '/Users/hugo/.cache/pre-commit/repovkr1eg6m/node_env-system', '-n', 'system')
return code: 1
stdout: (none)
stderr:
    Traceback (most recent call last):
      File "<frozen runpy>", line 198, in _run_module_as_main
      File "<frozen runpy>", line 88, in _run_code
      File "/Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/site-packages/nodeenv.py", line 26, in <module>
        import pipes
    ModuleNotFoundError: No module named 'pipes'
Check the log at /Users/hugo/.cache/pre-commit/pre-commit.log
```

The log:

<details>
<summary>pre-commit.log</summary>

### version information

```
pre-commit version: 3.8.0
git --version: git version 2.46.0
sys.version:
    3.13.0rc1 (v3.13.0rc1:e4a3e786a5e, Jul 31 2024, 19:49:53) [Clang 15.0.0 (clang-1500.3.9.4)]
sys.executable: /Library/Frameworks/Python.framework/Versions/3.13/bin/python3
os.name: posix
sys.platform: darwin
```

### error information

```pytb
An unexpected error has occurred: CalledProcessError: command: ('/Library/Frameworks/Python.framework/Versions/3.13/bin/python3', '-mnodeenv', '--prebuilt', '--clean-src', '/Users/hugo/.cache/pre-commit/repovkr1eg6m/node_env-system', '-n', 'system')
return code: 1
stdout: (none)
stderr:
    Traceback (most recent call last):
      File "<frozen runpy>", line 198, in _run_module_as_main
      File "<frozen runpy>", line 88, in _run_code
      File "/Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/site-packages/nodeenv.py", line 26, in <module>
        import pipes
    ModuleNotFoundError: No module named 'pipes'
```

```pytb
Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/site-packages/pre_commit/error_handler.py", line 73, in error_handler
    yield
  File "/Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/site-packages/pre_commit/main.py", line 417, in main
    return run(args.config, store, args)
  File "/Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/site-packages/pre_commit/commands/run.py", line 442, in run
    install_hook_envs(to_install, store)
    ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/site-packages/pre_commit/repository.py", line 238, in install_hook_envs
    _hook_install(hook)
    ~~~~~~~~~~~~~^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/site-packages/pre_commit/repository.py", line 94, in _hook_install
    lang.install_environment(
    ~~~~~~~~~~~~~~~~~~~~~~~~^
        hook.prefix, hook.language_version, hook.additional_dependencies,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/site-packages/pre_commit/languages/node.py", line 89, in install_environment
    cmd_output_b(*cmd)
    ~~~~~~~~~~~~^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/site-packages/pre_commit/util.py", line 111, in cmd_output_b
    raise CalledProcessError(returncode, cmd, stdout_b, stderr_b)
pre_commit.util.CalledProcessError: command: ('/Library/Frameworks/Python.framework/Versions/3.13/bin/python3', '-mnodeenv', '--prebuilt', '--clean-src', '/Users/hugo/.cache/pre-commit/repovkr1eg6m/node_env-system', '-n', 'system')
return code: 1
stdout: (none)
stderr:
    Traceback (most recent call last):
      File "<frozen runpy>", line 198, in _run_module_as_main
      File "<frozen runpy>", line 88, in _run_code
      File "/Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/site-packages/nodeenv.py", line 26, in <module>
        import pipes
    ModuleNotFoundError: No module named 'pipes'
```


</details>

This is because I had nodeenv 1.8.0 installed and the `pipes` module has been removed from the stdlib in 3.13 as part of [PEP 594](https://peps.python.org/pep-0594/):

* https://docs.python.org/3.13/whatsnew/3.13.html#removed-modules-and-apis

This has been fixed in nodeenv 1.9.0:

* https://github.com/ekalinin/nodeenv/pull/342
* https://github.com/ekalinin/nodeenv/releases/tag/1.9.0
