### PR TITLE
expose commit_msg_filename as environment variable for the hooks

### DIFF
--- a/pre_commit/commands/run.py
+++ b/pre_commit/commands/run.py
@@ -371,8 +371,8 @@ def run(
     ):
         return 0
 
-    # Expose prepare_commit_message_source / commit_object_name / commit_msg_filename
-    # as environment variables for the hooks
+    # Expose prepare_commit_message_source / commit_object_name /
+    # commit_msg_filename as environment variables for the hooks
     if args.prepare_commit_message_source:
         environ['PRE_COMMIT_COMMIT_MSG_SOURCE'] = (
             args.prepare_commit_message_source

--- a/pre_commit/commands/run.py
+++ b/pre_commit/commands/run.py
@@ -371,7 +371,7 @@ def run(
     ):
         return 0
 
-    # Expose prepare_commit_message_source / commit_object_name
+    # Expose prepare_commit_message_source / commit_object_name / commit_msg_filename
     # as environment variables for the hooks
     if args.prepare_commit_message_source:
         environ['PRE_COMMIT_COMMIT_MSG_SOURCE'] = (
@@ -380,6 +380,9 @@ def run(
 
     if args.commit_object_name:
         environ['PRE_COMMIT_COMMIT_OBJECT_NAME'] = args.commit_object_name
+
+    if args.commit_msg_filename:
+        environ['PRE_COMMIT_COMMIT_MSG_FILENAME'] = args.commit_msg_filename
 
     # Expose from-ref / to-ref as environment variables for hooks to consume
     if args.from_ref and args.to_ref:


### PR DESCRIPTION
Solved #3292 ,so now we can use **commit_msg_filename** parameter in **prepare-commit-msg** and **commit-msg** hooks.