### PR TITLE
disable automatic toolchain switching for golang hooks

### DIFF
--- a/pre_commit/languages/golang.py
+++ b/pre_commit/languages/golang.py
@@ -75,6 +75,7 @@ def get_env_patch(venv: str, version: str) -> PatchesT:
 
     return (
         ('GOROOT', os.path.join(venv, '.go')),
+        ('GOTOOLCHAIN', 'local'),
         (
             'PATH', (
                 os.path.join(venv, 'bin'), os.pathsep,
@@ -145,6 +146,7 @@ def install_environment(
     env = no_git_env(dict(os.environ, GOPATH=gopath))
     env.pop('GOBIN', None)
     if version != 'system':
+        env['GOTOOLCHAIN'] = 'local'
         env['GOROOT'] = os.path.join(env_dir, '.go')
         env['PATH'] = os.pathsep.join((
             os.path.join(env_dir, '.go', 'bin'), os.environ['PATH'],


### PR DESCRIPTION
Resolves #3300 

I only disabled the toolchain switching if the version is not `system`. I did this because `system` is the default if go is installed globally and no `language_version` is explicitly specified.  In this case users likely doesn't care which version of go is used as long as their hooks are working, so I think it makes more sense to allow the toolchain switching since it doesn't break user expectations and other than a small performance hit on hook installation doesn't have negative impact.

If we were to disable toolchain switching regardless of the version, many hooks would break since many environments lag with their go version. For example, in GitHub-hosted runners for GitHub Actions the pre-installed go version is `1.21` which is two versions behind the current version, so it's likely that a lot of hooks work thanks to automatic toolchain switching without even knowing.