### PR TITLE
feat(autoupdate): add tags prefix matching

### DIFF
--- a/pre_commit/main.py
+++ b/pre_commit/main.py
@@ -217,13 +217,20 @@ def main(argv: Sequence[str] | None = None) -> int:
         help="Auto-update pre-commit config to the latest repos' versions.",
     )
     _add_config_option(autoupdate_parser)
-    autoupdate_parser.add_argument(
+
+    autoupdate_group = autoupdate_parser.add_mutually_exclusive_group()
+    autoupdate_group.add_argument(
         '--bleeding-edge', action='store_true',
         help=(
             'Update to the bleeding edge of `HEAD` instead of the latest '
             'tagged version (the default behavior).'
         ),
     )
+    autoupdate_group.add_argument(
+        '--tags-prefix',
+        help='Filter tags based on the provided prefix.',
+    )
+
     autoupdate_parser.add_argument(
         '--freeze', action='store_true',
         help='Store "frozen" hashes in `rev` instead of tag names',
@@ -380,6 +387,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 freeze=args.freeze,
                 repos=args.repos,
                 jobs=args.jobs,
+                tags_prefix=args.tags_prefix,
             )
         elif args.command == 'clean':
             return clean(store)

--- a/tests/commands/autoupdate_test.py
+++ b/tests/commands/autoupdate_test.py
@@ -406,6 +406,71 @@ def test_autoupdate_tags_only(tagged, in_tmpdir):
         assert 'v1.2.3' in f.read()
 
 
+def test_autoupdate_tags_only_with_v_tag_prefix(tagged, in_tmpdir):
+    # add some commits after the tag
+    git_commit(cwd=tagged.path)
+
+    config = make_config_from_repo(tagged.path, rev=tagged.original_rev)
+    write_config('.', config)
+
+    assert autoupdate(
+        C.CONFIG_FILE,
+        freeze=False,
+        tags_only=True,
+        tags_prefix='v',
+    ) == 0
+    with open(C.CONFIG_FILE) as f:
+        assert 'v1.2.3' in f.read()
+
+
+def test_autoupdate_tags_only_with_empty_tag_prefix(tagged, in_tmpdir):
+    # add some commits after the tag
+    git_commit(cwd=tagged.path)
+
+    config = make_config_from_repo(tagged.path, rev=tagged.original_rev)
+    write_config('.', config)
+
+    assert autoupdate(
+        C.CONFIG_FILE,
+        freeze=False,
+        tags_only=True,
+        tags_prefix='',
+    ) == 0
+    with open(C.CONFIG_FILE) as f:
+        assert 'v1.2.3' in f.read()
+
+
+def test_autoupdate_tags_only_and_freeze_with_v_tag_prefix(tagged, in_tmpdir):
+    # add some commits after the tag
+    git_commit(cwd=tagged.path)
+
+    config = make_config_from_repo(tagged.path, rev=tagged.original_rev)
+    write_config('.', config)
+
+    info = RevInfo.from_config(config)
+    new_info = info.update(tags_only=True, freeze=True, tags_prefix='v')
+    assert new_info.rev == tagged.head_rev
+    assert new_info.frozen == 'v1.2.3'
+
+
+def test_autoupdate_tags_only_with_invalid_tag_prefix(tagged, in_tmpdir):
+    # add some commits after the tag
+    git_commit(cwd=tagged.path)
+
+    config = make_config_from_repo(tagged.path, rev=tagged.original_rev)
+    write_config('.', config)
+
+    assert autoupdate(
+        C.CONFIG_FILE,
+        freeze=False,
+        tags_only=True,
+        tags_prefix='thisisinvalid',
+    ) == 0
+    with open(C.CONFIG_FILE) as f:
+        # This will be the same as tags_only=False
+        assert 'v1.2.3' not in f.read()
+
+
 def test_autoupdate_latest_no_config(out_of_date, in_tmpdir):
     config = make_config_from_repo(
         out_of_date.path, rev=out_of_date.original_rev,

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -222,3 +222,25 @@ def test_hook_stage_migration(mock_store_dir):
     with mock.patch.object(main, 'run') as mck:
         main.main(('run', '--hook-stage', 'commit'))
     assert mck.call_args[0][2].hook_stage == 'pre-commit'
+
+
+def test_expected_mutually_exclusive(capsys, mock_store_dir):
+    args = (
+        'autoupdate',
+        '--tags-prefix',
+        'abc123',
+        '--bleeding-edge',
+    )
+    with pytest.raises(SystemExit) as excinfo:
+        main.main(args)
+
+    captured = capsys.readouterr()
+    cap_out_lines = captured.err.splitlines()  # Get the error output in lines
+    # cap_out_lines = cap_out.get().splitlines()
+
+    assert (
+        cap_out_lines[-1] ==
+        'pre-commit autoupdate: error: argument --bleeding-edge: '
+        'not allowed with argument --tags-prefix'
+    )
+    assert excinfo.value.code == 2


### PR DESCRIPTION
Resolves https://github.com/pre-commit/pre-commit/issues/3326

This adds `--tags-prefix` to `autoupdate`, allowing users to specify a tag match format for the tags they'd like to autoupdate to.

For example:

```bash
$ pre-commit autoupdate --repo https://github.com/asottile/reorder-python-imports --tags-prefix 'v2' # Update to the latest v2 release
[https://github.com/asottile/reorder-python-imports] updating v3.13.0 -> v2.8.0
$ pre-commit autoupdate --repo https://github.com/asottile/reorder-python-imports --tags-prefix 'v' # Update to the latest release
[https://github.com/asottile/reorder-python-imports] already up to date!
```

It makes no changes to existing `autoupdate` functionality.

```bash
$ pre-commit autoupdate --repo https://github.com/asottile/reorder-python-imports --bleeding-edge
[https://github.com/asottile/reorder-python-imports] updating v3.13.0 -> 6b7af8f29423f6d97500ce234249faeb18f156b3
$ pre-commit autoupdate --repo https://github.com/asottile/reorder-python-imports --bleeding-edge --freeze
[https://github.com/asottile/reorder-python-imports] updating v3.13.0 -> 6b7af8f29423f6d97500ce234249faeb18f156b3
```

It is mutually exclusive with `--bleeding-edge`.

```bash
$ pre-commit autoupdate --repo https://github.com/asottile/reorder-python-imports --bleeding-edge --tags-prefix 'v'
usage: pre-commit autoupdate [-h] [--color {auto,always,never}] [-c CONFIG] [--bleeding-edge | --tags-prefix TAGS_PREFIX] [--freeze] [--repo REPO] [-j JOBS]
pre-commit autoupdate: error: argument --tags-prefix: not allowed with argument --bleeding-edge
```