### PR TITLE
Improve Python hook to allow installing additional_dependencies using relative paths

### DIFF
--- a/pre_commit/languages/python.py
+++ b/pre_commit/languages/python.py
@@ -207,8 +207,11 @@ def install_environment(
     python = norm_version(version)
     if python is not None:
         venv_cmd.extend(('-p', python))
-    install_cmd = ('python', '-mpip', 'install', '.', *additional_dependencies)
+    install_cmd = ('python', '-mpip', 'install', '.')
 
     cmd_output_b(*venv_cmd, cwd='/')
     with in_env(prefix, version):
         lang_base.setup_cmd(prefix, install_cmd)
+
+        if additional_dependencies:
+            cmd_output_b(*install_cmd[:-1], *additional_dependencies)

--- a/tests/languages/python_test.py
+++ b/tests/languages/python_test.py
@@ -284,3 +284,14 @@ def test_python_hook_weird_setup_cfg(tmp_path):
 
     ret = run_language(tmp_path, python, 'socks', [os.devnull])
     assert ret == (0, f'[{os.devnull!r}]\nhello hello\n'.encode())
+
+
+def test_simple_python_hook_additional_dependencies(tmp_path):
+    _make_hello_hello(tmp_path)
+
+    requirements_txt = tmp_path.joinpath('requirements.txt')
+    requirements_txt.write_text('')
+    deps = ['-r', requirements_txt]
+
+    ret = run_language(tmp_path, python, 'socks', [os.devnull], deps=deps)
+    assert ret == (0, f'[{os.devnull!r}]\nhello hello\n'.encode())

--- a/tests/repository_test.py
+++ b/tests/repository_test.py
@@ -351,7 +351,8 @@ def local_python_config():
     repo_path = get_resource_path('python_hooks_repo')
     manifest = load_manifest(os.path.join(repo_path, C.MANIFEST_FILE))
     hooks = [
-        dict(hook, additional_dependencies=[repo_path]) for hook in manifest
+        dict(hook, additional_dependencies=[os.path.relpath(repo_path)])
+        for hook in manifest
     ]
     return {'repo': 'local', 'hooks': hooks}
 


### PR DESCRIPTION
This PR improves the Python hook not to change the current working directory on dependencies installation through pip. Thus, with this PR, Python-based hooks' `additional_dependencies` become to accept relative paths from the project root.

<details>
<summary>~/.cache/pre-commit/pre-commit.log</summary>

### version information

```
pre-commit version: 4.0.1
git --version: git version 2.46.0
sys.version:
    3.10.12 (main, Sep 11 2024, 15:47:36) [GCC 11.4.0]
sys.executable: /usr/bin/python3
os.name: posix
sys.platform: linux
```

### error information

```
An unexpected error has occurred: CalledProcessError: command: ('/home/sakurai/.cache/pre-commit/repotfbw004w/py_env-python3/bin/python', '-mpip', 'install', '-e', 'locally-maintained-flake8-plugin')
return code: 1
stdout:
    Obtaining file:///home/sakurai/poc/locally-maintained-flake8-plugin
stderr:
    ERROR: file:///home/sakurai/poc/locally-maintained-flake8-plugin does not appear to be a Python project: neither 'setup.py' nor 'pyproject.toml' found.
```

```
Traceback (most recent call last):
  File "/home/sakurai/.local/lib/python3.10/site-packages/pre_commit/error_handler.py", line 73, in error_handler
    yield
  File "/home/sakurai/.local/lib/python3.10/site-packages/pre_commit/main.py", line 417, in main
    return run(args.config, store, args)
  File "/home/sakurai/.local/lib/python3.10/site-packages/pre_commit/commands/run.py", line 442, in run
    install_hook_envs(to_install, store)
  File "/home/sakurai/.local/lib/python3.10/site-packages/pre_commit/repository.py", line 229, in install_hook_envs
    _hook_install(hook)
  File "/home/sakurai/.local/lib/python3.10/site-packages/pre_commit/repository.py", line 85, in _hook_install
    lang.install_environment(
  File "/home/sakurai/.local/lib/python3.10/site-packages/pre_commit/languages/python.py", line 217, in install_environment
    cmd_output_b(*install_cmd[:-1], *additional_dependencies)
  File "/home/sakurai/.local/lib/python3.10/site-packages/pre_commit/util.py", line 111, in cmd_output_b
    raise CalledProcessError(returncode, cmd, stdout_b, stderr_b)
pre_commit.util.CalledProcessError: command: ('/home/sakurai/.cache/pre-commit/repotfbw004w/py_env-python3/bin/python', '-mpip', 'install', '-e', 'locally-maintained-flake8-plugin')
return code: 1
stdout:
    Obtaining file:///home/sakurai/poc/locally-maintained-flake8-plugin
stderr:
    ERROR: file:///home/sakurai/poc/locally-maintained-flake8-plugin does not appear to be a Python project: neither 'setup.py' nor 'pyproject.toml' found.
```

</details>

Resolves https://github.com/pre-commit/pre-commit/issues/3329