### PR TITLE
[RFC] Add possibility to specify paths relative to .pre-commit-config.yaml in the configuration

### DIFF
--- a/pre_commit/commands/run.py
+++ b/pre_commit/commands/run.py
@@ -412,6 +412,10 @@ def run(
     if args.rewrite_command:
         environ['PRE_COMMIT_REWRITE_COMMAND'] = args.rewrite_command
 
+    environ['PRE_COMMIT_CONFIG_PATH'] = (
+        os.path.dirname(os.path.abspath(config_file))
+    )
+
     # Set pre_commit flag
     environ['PRE_COMMIT'] = '1'
 

--- a/pre_commit/yaml.py
+++ b/pre_commit/yaml.py
@@ -1,11 +1,26 @@
 from __future__ import annotations
 
 import functools
+import os
+import re
 from typing import Any
 
 import yaml
 
+
+def env_constructor(loader: yaml.Loader, node: yaml.ScalarNode) -> str:
+    """Load !Env tag"""
+    value = str(loader.construct_scalar(node))
+    match = re.compile('.*?\\${(\\w+)}.*?').findall(value)
+    if match:
+        for key in match:
+            value = value.replace(f'${{{key}}}', os.getenv(key, ''))
+    return value
+
+
 Loader = getattr(yaml, 'CSafeLoader', yaml.SafeLoader)
+Loader.add_constructor(tag='!Env', constructor=env_constructor)
+
 yaml_compose = functools.partial(yaml.compose, Loader=Loader)
 yaml_load = functools.partial(yaml.load, Loader=Loader)
 Dumper = getattr(yaml, 'CSafeDumper', yaml.SafeDumper)

--- a/tests/commands/run_test.py
+++ b/tests/commands/run_test.py
@@ -1233,3 +1233,14 @@ def test_pre_commit_env_variable_set(cap_out, store, repo_with_passing_hook):
         cap_out, store, repo_with_passing_hook, args, environ,
     )
     assert environ['PRE_COMMIT'] == '1'
+
+
+def test_pre_commit_config_path_env_variable_set(
+        cap_out, store, repo_with_passing_hook,
+):
+    args = run_opts()
+    environ: MutableMapping[str, str] = {}
+    ret, printed = _do_run(
+        cap_out, store, repo_with_passing_hook, args, environ,
+    )
+    assert environ['PRE_COMMIT_CONFIG_PATH'] == repo_with_passing_hook

--- a/tests/commands/validate_config_test.py
+++ b/tests/commands/validate_config_test.py
@@ -62,3 +62,16 @@ def test_mains_not_ok(tmpdir):
     assert validate_config(('does-not-exist',))
     assert validate_config((not_yaml.strpath,))
     assert validate_config((not_schema.strpath,))
+
+
+def test_validate_config_with_env_ok(tmpdir, caplog):
+    f = tmpdir.join('cfg.yaml')
+    f.write(
+        'repos:\n'
+        '-   repo: https://gitlab.com/pycqa/flake8\n'
+        '    rev: 3.7.7\n'
+        '    hooks:\n'
+        '    -   id: flake8\n'
+        '    args: [--config, !Env "${HOME}/flake8.cfg"]\n',
+    )
+    assert not validate_config((f.strpath,))


### PR DESCRIPTION
I open this as a Draft RFC PR to discuss if something like this could be merged or if there is a better solution.

**Usecase**

We use pre-commit hooks in a yocto project were multiple git repositories are used. To prevent copy-and-paste only one of these repositories contains the `.pre-commit-config.yaml`. When executing pre-commit, this config file is always used: `pre-commit run --config <main project>/.pre-commit-config.yaml`. The path `<main project>` differs in different environments and is not fixed.

This works fine if every hook is completely configured via the command line, without using any config files. But if we want to use a config file for a hook and this file is checked into the same repository as the `.pre-commit-config.yaml` file, it is not possible to specify the correct path in the `.pre-commit-config.yaml`. This is the issue this PR tries to solve.

**Proposed Solution**

The implementation consists of two steps:
1. Provide the environment variable `PRE_COMMIT_CONFIG_PATH` which contains the abolute path of the directory of the used pre-commit configuration file.
2. Add the possibility to use environment variable in `.pre-commit-config.yaml`. The variable is replaced when the configuration is parsed.

**Open Issues**

1. The unit test coverage is not 100% anymore, because i implemented one test in `tests/commands/validate_config_test.py` which is ignored when the coverage is evaluated.
2. How should it be handled if the specified environment variable is not available? Currently this is silently ignored and an empty string is used.