### PR TITLE
fix: failing post-checkout on single file checkout when solving merge conflicts

### DIFF
--- a/tests/commands/run_test.py
+++ b/tests/commands/run_test.py
@@ -536,6 +536,22 @@ def test_merge_conflict(cap_out, store, in_merge_conflict):
     assert b'Unmerged files.  Resolve before committing.' in printed
 
 
+def test_merge_conflict_post_checkout(cap_out, store, in_merge_conflict):
+    ret, printed = _do_run(
+        cap_out,
+        store,
+        in_merge_conflict,
+        run_opts(hook_stage='post-checkout'),
+    )
+    assert ret == 0
+    assert b'Unmerged files.  Resolve before committing.' not in printed
+    msg = (
+        b'Skipping `post-checkout` hooks since '
+        b'it\'s a file checkout or same head ref'
+    )
+    assert msg in printed
+
+
 def test_files_during_merge_conflict(cap_out, store, in_merge_conflict):
     opts = run_opts(files=['placeholder'])
     ret, printed = _do_run(cap_out, store, in_merge_conflict, opts)
@@ -552,6 +568,29 @@ def test_merge_conflict_modified(cap_out, store, in_merge_conflict):
     ret, printed = _do_run(cap_out, store, in_merge_conflict, run_opts())
     assert ret == 1
     assert b'Unmerged files.  Resolve before committing.' in printed
+
+
+def test_merge_conflict_modified_post_checkout(
+    cap_out, store, in_merge_conflict
+):
+    # Touch another file so we have unstaged non-conflicting things
+    assert os.path.exists('placeholder')
+    with open('placeholder', 'w') as placeholder_file:
+        placeholder_file.write('bar\nbaz\n')
+
+    ret, printed = _do_run(
+        cap_out,
+        store,
+        in_merge_conflict,
+        run_opts(hook_stage='post-checkout'),
+    )
+    assert ret == 0
+    assert b'Unmerged files.  Resolve before committing.' not in printed
+    msg = (
+        b'Skipping `post-checkout` hooks since '
+        b'it\'s a file checkout or same head ref'
+    )
+    assert msg in printed
 
 
 def test_merge_conflict_resolved(cap_out, store, in_merge_conflict):

--- a/tests/commands/run_test.py
+++ b/tests/commands/run_test.py
@@ -571,7 +571,7 @@ def test_merge_conflict_modified(cap_out, store, in_merge_conflict):
 
 
 def test_merge_conflict_modified_post_checkout(
-    cap_out, store, in_merge_conflict
+    cap_out, store, in_merge_conflict,
 ):
     # Touch another file so we have unstaged non-conflicting things
     assert os.path.exists('placeholder')


### PR DESCRIPTION
### Current behavior 
pre-commit doesn't allow to solve merge conflicts as `git checkout --theirs -- <paths>`.

Reason: git status returns unmerged files 🤷.

But this is wrong, since there are a lot of unmerged paths I'm trying to resolve with `git checkout`. Which triggers the post-checkout hook.

### New behavior
Do not run post-checkout hooks if there are unmerged files.
 
This handles cases when there are unmerged paths and:
 * resolving conflict with `git checkout --ours/--theirs -- <paths>`
 * or checking out single files with `git checkout <branch> -- <paths>`


### Afterthoughts
I understand it kinda breaks expectations on pre-commit behavior, but at least it doesn't break git operations.

As I understand this is the reason:
```python
    with contextlib.ExitStack() as exit_stack:
        if stash:
            exit_stack.enter_context(staged_files_only(store.directory))
```
But I don't have enough knowledge about how to pre-commit works with those stashes to fix it correctly. And especially cover the case with unmerged pre-commit config.

That's why I suggest to have this little limitation in behavior, but working git checkout with unmerged files and installed post-checkout hook.