### PR TITLE
update .net tests to use .net 8

### DIFF
--- a/tests/languages/dotnet_test.py
+++ b/tests/languages/dotnet_test.py
@@ -27,7 +27,7 @@ def _csproj(tool_name):
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6</TargetFramework>
+    <TargetFramework>net8</TargetFramework>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>{tool_name}</ToolCommandName>
     <PackageOutputPath>./nupkg</PackageOutputPath>


### PR DESCRIPTION
.net 6 and 7 were removed from github actions runners