### PR TITLE
Fix highlighted text not readable with some color schemes

### DIFF
--- a/pre_commit/color.py
+++ b/pre_commit/color.py
@@ -56,10 +56,10 @@ if sys.platform == 'win32':  # pragma: no cover (windows)
 else:  # pragma: win32 no cover
     terminal_supports_color = True
 
-RED = '\033[41m'
-GREEN = '\033[42m'
-YELLOW = '\033[43;30m'
-TURQUOISE = '\033[46;30m'
+RED = '\033[31;7m'
+GREEN = '\033[32;7m'
+YELLOW = '\033[33;7m'
+TURQUOISE = '\033[36;7m'
 SUBTLE = '\033[2m'
 NORMAL = '\033[m'
 


### PR DESCRIPTION
Make the foreground (text) color be the usual background color, when highlighting text. This is done by setting the foreground color instead of the background color, then inverting (code 7) to swap the foreground and background colors.

Previously, with some color schemes there was not enough contrast between the text and highlight color.
Based on the assumption that there should be contrast between terminal colors and the background, this should make the text readable with a wider set of color schemes.

To check text readability with the old values, run:

```sh
echo -e "\033[41mFail\033[m \033[42mPass\033[m \033[43;30mWarn\033[m \033[46;30mSkip\033[m"
```

and to see how it looks with the new values, run:

```sh
echo -e "\033[31;7mFail\033[m \033[32;7mPass\033[m \033[33;7mWarn\033[m \033[36;7mSkip\033[m"
```

For context these are the colors in my current scheme:

```
Background=#282C34
Foreground=#A7AAB0
Color0=#101012
Color1=#DE5D68
Color2=#8FB573
Color3=#DBB671
Color4=#57A5E5
Color5=#BB70D2
Color6=#51A8B3
Color7=#ABB2BF
Color8=#5C6370
```