### PR TITLE
Fix language:r hook installation when initiated in RStudio

### DIFF
--- a/tests/languages/r_test.py
+++ b/tests/languages/r_test.py
@@ -286,7 +286,7 @@ def test_health_check_without_version(prefix, installed_environment, version):
     prefix, env_dir = installed_environment
 
     # simulate old pre-commit install by unsetting the installed version
-    r._execute_vanilla_r_code_as_script(
+    r._execute_r_in_renv(
         f'renv::settings$r.version({version})',
         prefix=prefix, version=C.DEFAULT, cwd=env_dir,
     )


### PR DESCRIPTION
Closes #3385. The bug is that in `install_environment()`, the env patch was not applied in the following snippet:
```python
    with _r_code_in_tempfile(r_code_inst_environment) as f:
        cmd_output_b(_rscript_exec(), '--vanilla', f, cwd=env_dir)
```

The existing `_execute_vanilla_r_code_as_script()` abstracting away 
1) the application of env patch and
1) the writing inline code to file and executing there (since [inline execution lead to parser failures](https://github.com/pre-commit/pre-commit/issues/2870)) 

was only suitable to execute R code *after* the environment has been installed and was for that reason not used when the renv environment was set up initially. 
Hence, the approach I took was to factor out `_execute_r()` that does 1. and 2. and can be parametrised as far as CLI options passed to R go, so it can be used to create the environment itself (`_execute_vanilla_r()`) and also later to run R code in it (`_execute_r_in_renv()`, previously named `_execute_vanilla_r_code_as_script()`). 