### PR TITLE
fix: crash on ambiguous ref 'HEAD'

### DIFF
--- a/pre_commit/git.py
+++ b/pre_commit/git.py
@@ -126,7 +126,7 @@ def get_conflicted_files() -> set[str]:
     merge_diff_filenames = zsplit(
         cmd_output(
             'git', 'diff', '--name-only', '--no-ext-diff', '-z',
-            '-m', tree_hash, 'HEAD', 'MERGE_HEAD',
+            '-m', tree_hash, 'HEAD', 'MERGE_HEAD', '--',
         )[1],
     )
     return set(merge_conflict_filenames) | set(merge_diff_filenames)

--- a/tests/git_test.py
+++ b/tests/git_test.py
@@ -141,6 +141,15 @@ def test_get_conflicted_files_unstaged_files(in_merge_conflict):
     assert ret == {'conflict_file'}
 
 
+def test_get_conflicted_files_with_file_named_head(in_merge_conflict):
+    resolve_conflict()
+    open('HEAD', 'w').close()
+    cmd_output('git', 'add', 'HEAD')
+
+    ret = set(git.get_conflicted_files())
+    assert ret == {'conflict_file', 'HEAD'}
+
+
 MERGE_MSG = b"Merge branch 'foo' into bar\n\nConflicts:\n\tconflict_file\n"
 OTHER_MERGE_MSG = MERGE_MSG + b'\tother_conflict_file\n'
 


### PR DESCRIPTION
I lost the log when I faced this crash, but it was of the form:

```
CalledProcessError: ('git', 'diff', '--name-only', '--no-ext-diff', '-z', '-m', '1234abc', 'HEAD', 'MERGE_HEAD'): Ambiguous reference 'HEAD'
... something about prepending '--', like
git diff ref [ref2] -- [files]
```

Likely happened because there is a folder named `head` in the base commit SHA.

And this fixes the issue. If you have more information on how I can create a minimal reproduction of the bug and add it as a test, I'd be happy to.