### PR TITLE
Add freeze config option for autoupdate command

### DIFF
--- a/pre_commit/clientlib.py
+++ b/pre_commit/clientlib.py
@@ -466,6 +466,7 @@ CONFIG_SCHEMA = cfgv.Map(
     cfgv.Optional('files', check_string_regex, ''),
     cfgv.Optional('exclude', check_string_regex, '^$'),
     cfgv.Optional('fail_fast', cfgv.check_bool, False),
+    cfgv.Optional('freeze', cfgv.check_bool, False),
     cfgv.WarnAdditionalKeys(
         (
             'repos',
@@ -477,6 +478,7 @@ CONFIG_SCHEMA = cfgv.Map(
             'fail_fast',
             'minimum_pre_commit_version',
             'ci',
+            'freeze',
         ),
         warn_unknown_keys_root,
     ),

--- a/pre_commit/commands/autoupdate.py
+++ b/pre_commit/commands/autoupdate.py
@@ -176,6 +176,8 @@ def autoupdate(
         if repo['repo'] not in {LOCAL, META}
     ]
 
+    freeze = freeze or load_config(config_file)['freeze']
+
     rev_infos: list[RevInfo | None] = [None] * len(config_repos)
     jobs = jobs or xargs.cpu_count()  # 0 => number of cpus
     jobs = min(jobs, len(repos) or len(config_repos))  # max 1-per-thread

--- a/tests/commands/autoupdate_test.py
+++ b/tests/commands/autoupdate_test.py
@@ -139,6 +139,17 @@ def test_rev_info_update_does_not_freeze_if_already_sha(out_of_date):
     assert new_info.frozen is None
 
 
+def test_autoupdate_freeze_from_config(tagged, tmpdir):
+    git_commit(cwd=tagged.path)
+    repo = make_config_from_repo(tagged.path, rev=tagged.original_rev)
+    contents = {'repos': [repo], 'freeze': True}
+    cfg = tmpdir.join(C.CONFIG_FILE)
+    write_config(str(tmpdir), contents)
+
+    assert autoupdate(str(cfg), freeze=False, tags_only=True) == 0
+    assert f'rev: {tagged.head_rev}  # frozen: v1.2.3' in cfg.read()
+
+
 def test_autoupdate_up_to_date_repo(up_to_date, tmpdir):
     contents = (
         f'repos:\n'


### PR DESCRIPTION
This is an idea that starts with a PR to see how much implementation effort this is and how much acceptable it is.

It enables users to activate hook freezing/pinning by setting 'freeze: true' in their pre-commit configuration file.

The intend are two effects, when setting `freeze: true`:
* Enables freeze automatically when running `pre-commit autoupdate` (no need then anymore to specify --freeze for repeated `autoupdate` calls).
* Enables https://pre-commit.ci/ to freeze hooks as part of update PRs. (this is an assumption: does pre-commit.ci actually use the `autoupdate` subcommand during update PR generation?)

This is done in context of e.g. https://semgrep.dev/blog/2025/popular-github-action-tj-actionschanged-files-is-compromised/ where a gh account got compromised and somebody mutated a git tag to point a malicious commit. This could also happen to pre-commit hooks, where then a local hook execution can do all kind of unwanted things. Pinning to sha can prevent this or at least makes such happenings visible (in case of sha changes while semver remains unchanged).

Happy to also propose a doc update PR to https://github.com/pre-commit/pre-commit.com or implement this in a different way in case the idea is acceptable.