### PR TITLE
feat: create error message if try-repo fails because there are no commits in the repo

### DIFF
--- a/pre_commit/git.py
+++ b/pre_commit/git.py
@@ -168,7 +168,19 @@ def get_changed_files(old: str, new: str) -> list[str]:
 
 
 def head_rev(remote: str) -> str:
-    _, out, _ = cmd_output('git', 'ls-remote', '--exit-code', remote, 'HEAD')
+    try:
+        _, out, _ = cmd_output(
+            'git', 'ls-remote', '--exit-code',
+            remote, 'HEAD',
+        )
+    except CalledProcessError as e:
+        if e.returncode == 2:
+            raise FatalError(
+                f'repo {remote} found but appears to have no commits. '
+                f'Make a commit in {remote} to use it',
+            )
+        raise e
+
     return out.split()[0]
 
 

--- a/testing/fixtures.py
+++ b/testing/fixtures.py
@@ -42,11 +42,12 @@ def git_dir(tempdir_factory):
     return path
 
 
-def make_repo(tempdir_factory, repo_source):
+def make_repo(tempdir_factory, repo_source, commits=True):
     path = git_dir(tempdir_factory)
     copy_tree_to_path(get_resource_path(repo_source), path)
-    cmd_output('git', 'add', '.', cwd=path)
-    git_commit(msg=make_repo.__name__, cwd=path)
+    if commits:
+        cmd_output('git', 'add', '.', cwd=path)
+        git_commit(msg=make_repo.__name__, cwd=path)
     return path
 
 

--- a/tests/commands/try_repo_test.py
+++ b/tests/commands/try_repo_test.py
@@ -100,19 +100,28 @@ def test_try_repo_relative_path(cap_out, tempdir_factory):
         assert not try_repo(try_repo_opts(relative_repo, hook='bash_hook'))
 
 
-def test_try_repo_no_commits(cap_out, tempdir_factory):
+@pytest.mark.parametrize(
+    'has_commits', [
+        False,
+        True,
+    ],
+)
+def test_try_repo_no_commits(cap_out, tempdir_factory, has_commits):
     repo = make_repo(
         tempdir_factory,
         'modified_file_returns_zero_repo',
-        commits=False,
+        commits=has_commits,
     )
 
     with cwd(git_dir(tempdir_factory)):
         bare_repo = os.path.join(repo, '.git')
         # previously crashed attempting modification changes
-        with pytest.raises(FatalError) as e:
-            try_repo(try_repo_opts(bare_repo, hook='bash_hook'))
-            assert 'appears to have no commits' in e.value
+        if not has_commits:
+            with pytest.raises(FatalError) as e:
+                try_repo(try_repo_opts(bare_repo, hook='bash_hook'))
+                assert 'appears to have no commits' in e.value
+        else:
+            assert not try_repo(try_repo_opts(bare_repo, hook='bash_hook'))
 
 
 def test_try_repo_bare_repo(cap_out, tempdir_factory):

--- a/tests/commands/try_repo_test.py
+++ b/tests/commands/try_repo_test.py
@@ -11,6 +11,7 @@ import re_assert
 from pre_commit import git
 from pre_commit.commands.try_repo import try_repo
 from pre_commit.errors import FatalError
+from pre_commit.util import CalledProcessError
 from pre_commit.util import cmd_output
 from testing.auto_namedtuple import auto_namedtuple
 from testing.fixtures import git_dir
@@ -100,6 +101,13 @@ def test_try_repo_relative_path(cap_out, tempdir_factory):
         assert not try_repo(try_repo_opts(relative_repo, hook='bash_hook'))
 
 
+def test_try_repo_no_commits_no_git(cap_out, tempdir_factory):
+    repo = tempdir_factory.get()
+    with pytest.raises(CalledProcessError) as e:
+        try_repo(try_repo_opts(repo, hook='bash_hook'))
+    assert 'appears to have no commits' not in str(e.value)
+
+
 @pytest.mark.parametrize(
     'has_commits', [
         False,
@@ -119,7 +127,7 @@ def test_try_repo_no_commits(cap_out, tempdir_factory, has_commits):
         if not has_commits:
             with pytest.raises(FatalError) as e:
                 try_repo(try_repo_opts(bare_repo, hook='bash_hook'))
-                assert 'appears to have no commits' in e.value
+            assert 'appears to have no commits' in str(e.value)
         else:
             assert not try_repo(try_repo_opts(bare_repo, hook='bash_hook'))
 


### PR DESCRIPTION
Make it more obvious to the end user that their garbage_in_repo (a bare repo without commits) is indeed garbage by letting them know the reason pre-commit is failing (there are no commits on the repo).

follow up from:
https://github.com/pre-commit/pre-commit/issues/3440

