### PR TITLE
Refactor cross-platform `bin/` / `Scripts/` path lookup

### DIFF
--- a/pre_commit/languages/conda.py
+++ b/pre_commit/languages/conda.py
@@ -12,6 +12,7 @@ from pre_commit.envcontext import PatchesT
 from pre_commit.envcontext import SubstitutionT
 from pre_commit.envcontext import UNSET
 from pre_commit.envcontext import Var
+from pre_commit.languages.python import bin_dir
 from pre_commit.prefix import Prefix
 from pre_commit.util import cmd_output_b
 
@@ -26,10 +27,9 @@ def get_env_patch(env: str) -> PatchesT:
     # they can be in $CONDA_PREFIX/bin, $CONDA_PREFIX/Library/bin,
     # $CONDA_PREFIX/Scripts and $CONDA_PREFIX. Whereas the latter only
     # seems to be used for python.exe.
-    path: SubstitutionT = (os.path.join(env, 'bin'), os.pathsep, Var('PATH'))
+    path: SubstitutionT = (str(bin_dir(env)), os.pathsep, Var('PATH'))
     if sys.platform == 'win32':  # pragma: win32 cover
         path = (env, os.pathsep, *path)
-        path = (os.path.join(env, 'Scripts'), os.pathsep, *path)
         path = (os.path.join(env, 'Library', 'bin'), os.pathsep, *path)
 
     return (

--- a/pre_commit/languages/python.py
+++ b/pre_commit/languages/python.py
@@ -4,8 +4,10 @@ import contextlib
 import functools
 import os
 import sys
+import sysconfig
 from collections.abc import Generator
 from collections.abc import Sequence
+from pathlib import Path
 
 import pre_commit.constants as C
 from pre_commit import lang_base
@@ -46,10 +48,9 @@ def _read_pyvenv_cfg(filename: str) -> dict[str, str]:
     return ret
 
 
-def bin_dir(venv: str) -> str:
+def bin_dir(venv: str) -> Path:
     """On windows there's a different directory for the virtualenv"""
-    bin_part = 'Scripts' if sys.platform == 'win32' else 'bin'
-    return os.path.join(venv, bin_part)
+    return Path(venv) / Path(sysconfig.get_path('scripts')).name
 
 
 def get_env_patch(venv: str) -> PatchesT:


### PR DESCRIPTION
Cygwin isn't the only edge-case for a differing `bin/` path. In addition there also is MSYS2, which behaves differently than Cygwin when using the MinGW POSIX emulation layer. CPython compiled against Microsoft Visual C++ Runtime (MSVCRT) through MinGW, will correctly identify as an 'nt' platform, yet will prefer a POSIX path scheme. In order to avoid having to patch every edge-case, we can spy on the system configurations install paths through the `sysconfig` module and get the basenam of the global scripts path, which will be returned in accordance with the preferred install path scheme of the system/platform.

This is a fix for [issue #3448](https://github.com/pre-commit/pre-commit/issues/3448)