### PR TITLE
fix: Proper way of finding `npm pack` `filename` output.

### DIFF
--- a/pre_commit/util.py
+++ b/pre_commit/util.py
@@ -4,6 +4,7 @@ import contextlib
 import errno
 import importlib.resources
 import os.path
+import re
 import shutil
 import stat
 import subprocess
@@ -237,3 +238,13 @@ else:  # pragma: >=3.12 cover
 
 def win_exe(s: str) -> str:
     return s if sys.platform != 'win32' else f'{s}.exe'
+
+
+def get_npm_version() -> tuple[int, ...]:
+    _, out, _ = cmd_output('npm', '--version')
+    version_match = re.match(r'^(\d+)\.(\d+)\.(\d+)', out)
+
+    if version_match is None:
+        return 0, 0, 0
+    else:
+        return tuple(map(int, version_match.groups()))

--- a/tests/languages/node_test.py
+++ b/tests/languages/node_test.py
@@ -113,8 +113,8 @@ def test_installs_without_links_outside_env(tmpdir):
         assert cmd_output('foo')[1] == 'success!\n'
 
 
-def _make_hello_world(tmp_path):
-    package_json = '''\
+def _make_hello_world(tmp_path, package_json=None):
+    package_json = package_json or '''\
 {"name": "t", "version": "0.0.1", "bin": {"node-hello": "./bin/main.js"}}
 '''
     tmp_path.joinpath('package.json').write_text(package_json)
@@ -128,6 +128,20 @@ def _make_hello_world(tmp_path):
 
 def test_node_hook_system(tmp_path):
     _make_hello_world(tmp_path)
+    ret = run_language(tmp_path, node, 'node-hello')
+    assert ret == (0, b'Hello World\n')
+
+
+def test_node_with_prepare_script(tmp_path):
+    package_json = '''
+{
+  "name": "t",
+  "version": "0.0.1",
+  "bin": {"node-hello": "./bin/main.js"},
+  "scripts": {"prepare": "echo prepare"}
+}
+'''
+    _make_hello_world(tmp_path, package_json)
     ret = run_language(tmp_path, node, 'node-hello')
     assert ret == (0, b'Hello World\n')
 


### PR DESCRIPTION
That will fix pollution of installation path with TypeScript output:

```bash
E           pre_commit.util.CalledProcessError: command: ('/private/var/folders/sd/qk6llt717b99lp1wgtym5qwm0000gn/T/pytest-of-local.user/pytest-16/test_node_typescript_hook_syst0/node_env-system/bin/node', '/opt/homebrew/bin/npm', 'install', '-g', '/private/var/folders/sd/qk6llt717b99lp1wgtym5qwm0000gn/T/pytest-of-local.user/pytest-16/test_node_typescript_hook_syst0/> t@0.0.1 prepare\n> tsc\n\nt-0.0.1.tgz')
E           return code: 254
E           stdout: (none)
E           stderr:
E               npm warn tarball tarball data for file:/private/var/folders/sd/qk6llt717b99lp1wgtym5qwm0000gn/T/pytest-of-local.user/pytest-16/test_node_typescript_hook_syst0/> t@0.0.1 prepare> tsct-0.0.1.tgz (null) seems to be corrupted. Trying again.
E               npm warn tarball tarball data for file:/private/var/folders/sd/qk6llt717b99lp1wgtym5qwm0000gn/T/pytest-of-local.user/pytest-16/test_node_typescript_hook_syst0/> t@0.0.1 prepare> tsct-0.0.1.tgz (null) seems to be corrupted. Trying again.
E               npm error code ENOENT
E               npm error syscall open
E               npm error path /private/var/folders/sd/qk6llt717b99lp1wgtym5qwm0000gn/T/pytest-of-local.user/pytest-16/test_node_typescript_hook_syst0/> t@0.0.1 prepare> tsct-0.0.1.tgz
E               npm error errno -2
E               npm error enoent ENOENT: no such file or directory, open '/private/var/folders/sd/qk6llt717b99lp1wgtym5qwm0000gn/T/pytest-of-local.user/pytest-16/test_node_typescript_hook_syst0/> t@0.0.1 prepare> tsct-0.0.1.tgz'
E               npm error enoent This is related to npm not being able to find a file.
E               npm error enoent
E               npm error A complete log of this run can be found in: /Users/local.user/.npm/_logs/2025-05-09T10_21_58_861Z-debug-0.log
```