### PR TITLE
fix: cargo install uses Cargo.lock for installation

### DIFF
--- a/pre_commit/languages/rust.py
+++ b/pre_commit/languages/rust.py
@@ -155,6 +155,6 @@ def install_environment(
 
         for args in packages_to_install:
             cmd_output_b(
-                'cargo', 'install', '--bins', '--root', envdir, *args,
+                'cargo', 'install', '--locked', '--bins', '--root', envdir, *args,
                 cwd=prefix.prefix_dir,
             )

--- a/pre_commit/languages/rust.py
+++ b/pre_commit/languages/rust.py
@@ -155,6 +155,7 @@ def install_environment(
 
         for args in packages_to_install:
             cmd_output_b(
-                'cargo', 'install', '--locked', '--bins', '--root', envdir, *args,
+                'cargo', 'install', '--locked', '--bins', '--root',
+                envdir, *args,
                 cwd=prefix.prefix_dir,
             )


### PR DESCRIPTION
According to the [cargo documentation](https://doc.rust-lang.org/cargo/commands/cargo-install.html#dealing-with-the-lockfile), cargo does not care about the lockfile by default but will recompute which versions of dependencies to use. This can lead to issues such as https://github.com/EmbarkStudios/cargo-deny/issues/771 where the release of a new upstream dependency breaks an existing unchanged pipeline.

Adding `--locked` to the cargo install to to force Cargo to use the packaged `Cargo.lock` file if it is available which should make rust hooks more reproducible.