### PR TITLE
Diagram visualization of pre-commit's codebase

### DIFF
--- a/.codeboarding/Application_Core.md
+++ b/.codeboarding/Application_Core.md
@@ -1,0 +1,225 @@
+```mermaid
+
+graph LR
+
+    Application_Core["Application Core"]
+
+    Command_Modules["Command Modules"]
+
+    Store_Management["Store Management"]
+
+    Client_Utilities["Client Utilities"]
+
+    Git_Operations["Git Operations"]
+
+    Output_Logging["Output & Logging"]
+
+    Error_Handling["Error Handling"]
+
+    Application_Constants["Application Constants"]
+
+    Application_Core -- "Delegates to" --> Command_Modules
+
+    Application_Core -- "Uses" --> Store_Management
+
+    Application_Core -- "Uses" --> Git_Operations
+
+    Application_Core -- "Uses" --> Output_Logging
+
+    Application_Core -- "Uses" --> Error_Handling
+
+    Application_Core -- "Uses" --> Application_Constants
+
+    Command_Modules -- "Uses" --> Store_Management
+
+    Command_Modules -- "Uses" --> Client_Utilities
+
+    Command_Modules -- "Uses" --> Git_Operations
+
+    Command_Modules -- "Uses" --> Output_Logging
+
+    Command_Modules -- "Uses" --> Application_Constants
+
+    Store_Management -- "Uses" --> Git_Operations
+
+    Store_Management -- "Uses" --> Application_Constants
+
+    Client_Utilities -- "Uses" --> Application_Constants
+
+    Client_Utilities -- "Uses" --> Error_Handling
+
+    Git_Operations -- "Uses" --> Error_Handling
+
+    Error_Handling -- "Uses" --> Output_Logging
+
+    click Application_Core href "https://github.com/pre-commit/pre-commit/blob/main/.codeboarding//Application_Core.md" "Details"
+
+```
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Component Details
+
+
+
+The `Application Core` serves as the central orchestrator and command dispatcher for the `pre-commit` command-line interface. It is responsible for parsing command-line arguments, setting up the application's execution environment, and directing control to the appropriate sub-commands for processing. This component acts as the primary control flow manager, ensuring that user requests are correctly interpreted and executed.
+
+
+
+### Application Core
+
+The primary entry point and command dispatcher for the `pre-commit` CLI. It parses command-line arguments, initializes the application environment, and orchestrates the execution of various sub-commands.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/pre-commit/pre-commit/blob/master/pre_commit/main.py#L196-L437" target="_blank" rel="noopener noreferrer">`pre_commit.main` (196:437)</a>
+
+
+
+
+
+### Command Modules
+
+A collection of modules, each implementing a specific `pre-commit` command (e.g., `run`, `install`, `autoupdate`). These modules encapsulate the distinct business logic for individual CLI operations.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `pre_commit.commands` (1:1)
+
+
+
+
+
+### Store Management
+
+Manages the persistent storage and caching of pre-commit repositories and their associated data (e.g., cloned repositories, hook environments), ensuring efficient access and data integrity.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/pre-commit/pre-commit/blob/master/pre_commit/store.py#L1-L1" target="_blank" rel="noopener noreferrer">`pre_commit.store` (1:1)</a>
+
+
+
+
+
+### Client Utilities
+
+Provides shared client-side logic and utilities, including configuration parsing, migration strategies, and general helper functions used across various commands.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/pre-commit/pre-commit/blob/master/pre_commit/clientlib.py#L1-L1" target="_blank" rel="noopener noreferrer">`pre_commit.clientlib` (1:1)</a>
+
+
+
+
+
+### Git Operations
+
+Encapsulates functionalities for interacting with Git repositories, such as checking the Git environment, executing Git commands, and managing repository states.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/pre-commit/pre-commit/blob/master/pre_commit/git.py#L1-L1" target="_blank" rel="noopener noreferrer">`pre_commit.git` (1:1)</a>
+
+
+
+
+
+### Output & Logging
+
+Responsible for managing all console output, including colored text, progress indicators, and logging messages, to provide clear and informative feedback to the user.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/pre-commit/pre-commit/blob/master/pre_commit/output.py#L1-L1" target="_blank" rel="noopener noreferrer">`pre_commit.output` (1:1)</a>
+
+- <a href="https://github.com/pre-commit/pre-commit/blob/master/pre_commit/color.py#L1-L1" target="_blank" rel="noopener noreferrer">`pre_commit.color` (1:1)</a>
+
+- <a href="https://github.com/pre-commit/pre-commit/blob/master/pre_commit/logging_handler.py#L34-L41" target="_blank" rel="noopener noreferrer">`pre_commit.logging_handler` (34:41)</a>
+
+
+
+
+
+### Error Handling
+
+Defines custom exception types and provides a centralized mechanism for handling and reporting errors gracefully, ensuring robust application behavior and a better user experience.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/pre-commit/pre-commit/blob/master/pre_commit/errors.py#L1-L1" target="_blank" rel="noopener noreferrer">`pre_commit.errors` (1:1)</a>
+
+- <a href="https://github.com/pre-commit/pre-commit/blob/master/pre_commit/error_handler.py#L70-L80" target="_blank" rel="noopener noreferrer">`pre_commit.error_handler` (70:80)</a>
+
+
+
+
+
+### Application Constants
+
+Stores immutable constants and configuration values used globally throughout the application, such as version numbers, default paths, and magic strings.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/pre-commit/pre-commit/blob/master/pre_commit/constants.py#L1-L1" target="_blank" rel="noopener noreferrer">`pre_commit.constants` (1:1)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Configuration_Repository_Management.md
+++ b/.codeboarding/Configuration_Repository_Management.md
@@ -1,0 +1,143 @@
+```mermaid
+
+graph LR
+
+    Configuration_Schema_Validation["Configuration Schema & Validation"]
+
+    YAML_Parser["YAML Parser"]
+
+    YAML_Rewriter["YAML Rewriter"]
+
+    Repository_Store["Repository Store"]
+
+    Repository_Management["Repository Management"]
+
+    Configuration_Schema_Validation -- "defines expectations for" --> YAML_Parser
+
+    Configuration_Schema_Validation -- "sends validated data to" --> YAML_Rewriter
+
+    YAML_Parser -- "parses for" --> Configuration_Schema_Validation
+
+    YAML_Parser -- "provides structure to" --> YAML_Rewriter
+
+    YAML_Rewriter -- "uses" --> YAML_Parser
+
+    Repository_Store -- "provides path to" --> Repository_Management
+
+    Repository_Store -- "manages lifecycle of repositories for" --> Repository_Management
+
+    Repository_Management -- "requests and stores repositories in" --> Repository_Store
+
+    Repository_Management -- "provides manifest data to" --> Configuration_Schema_Validation
+
+    click Repository_Management href "https://github.com/pre-commit/pre-commit/blob/main/.codeboarding//Repository_Management.md" "Details"
+
+```
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Component Details
+
+
+
+This component is central to how `pre-commit` manages its operational parameters and the external code repositories it interacts with. It ensures that the application's behavior is consistent, validated, and efficiently handles the lifecycle of cached repositories.
+
+
+
+### Configuration Schema & Validation
+
+Defines and validates the structure and content of the `.pre-commit-config.yaml` and `manifest.yaml` files. It includes checks for hook definitions, language types, and pre-commit version compatibility. It also handles the migration of deprecated stage names.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/pre-commit/pre-commit/blob/master/pre_commit/clientlib.py#L1-L1" target="_blank" rel="noopener noreferrer">`pre_commit.clientlib` (1:1)</a>
+
+
+
+
+
+### YAML Parser
+
+Provides robust functionality for loading and dumping YAML data, specifically tailored for `pre-commit`'s configuration files. It handles various YAML-related operations, including safe loading and error handling during parsing.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/pre-commit/pre-commit/blob/master/pre_commit/yaml.py#L1-L1" target="_blank" rel="noopener noreferrer">`pre_commit.yaml` (1:1)</a>
+
+
+
+
+
+### YAML Rewriter
+
+Facilitates in-place modifications and updates to YAML files, particularly the `.pre-commit-config.yaml`. This is essential for operations like `autoupdate` or `migrate-config`, allowing `pre-commit` to programmatically adjust the user's configuration while preserving comments and formatting.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/pre-commit/pre-commit/blob/master/pre_commit/yaml_rewrite.py#L1-L1" target="_blank" rel="noopener noreferrer">`pre_commit.yaml_rewrite` (1:1)</a>
+
+
+
+
+
+### Repository Store
+
+Manages the local cache of pre-commit repositories. This includes operations for initializing, cloning, and retrieving repositories, as well as garbage collection to manage disk space. It acts as a persistent storage mechanism for the cloned repositories.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/pre-commit/pre-commit/blob/master/pre_commit/store.py#L1-L1" target="_blank" rel="noopener noreferrer">`pre_commit.store` (1:1)</a>
+
+
+
+
+
+### Repository Management
+
+Encapsulates the logic for interacting with individual pre-commit repositories. This includes cloning, checking out specific revisions, and managing the repository's internal state and manifest. It bridges the gap between the abstract concept of a repository and its physical representation on disk.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/pre-commit/pre-commit/blob/master/pre_commit/repository.py#L1-L1" target="_blank" rel="noopener noreferrer">`pre_commit.repository` (1:1)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Git_Integration_Layer.md
+++ b/.codeboarding/Git_Integration_Layer.md
@@ -1,0 +1,167 @@
+```mermaid
+
+graph LR
+
+    Git_Command_Execution_Core["Git Command Execution Core"]
+
+    Git_Repository_Metadata_Provider["Git Repository Metadata Provider"]
+
+    Git_File_Change_Tracker["Git File Change Tracker"]
+
+    Git_Environment_Sanitizer["Git Environment Sanitizer"]
+
+    Git_Repository_Initializer["Git Repository Initializer"]
+
+    Staged_Files_Isolation_Context["Staged Files Isolation Context"]
+
+    Git_Repository_Metadata_Provider -- "uses" --> Git_Command_Execution_Core
+
+    Git_File_Change_Tracker -- "uses" --> Git_Command_Execution_Core
+
+    Git_File_Change_Tracker -- "uses" --> Git_Repository_Metadata_Provider
+
+    Git_Repository_Initializer -- "uses" --> Git_Command_Execution_Core
+
+    Git_Repository_Initializer -- "uses" --> Git_Environment_Sanitizer
+
+    Staged_Files_Isolation_Context -- "uses" --> Git_Command_Execution_Core
+
+    Staged_Files_Isolation_Context -- "uses" --> Git_File_Change_Tracker
+
+```
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Component Details
+
+
+
+The `Git Integration Layer` in `pre-commit` provides a robust and high-level interface for interacting with the Git version control system. It is designed to abstract away the complexities of direct Git command-line interactions, offering a set of focused components that handle various aspects of Git operations, from repository information retrieval to managing the Git index for hook execution. This layer is fundamental to `pre-commit`'s ability to reliably execute hooks against the correct set of files and maintain repository integrity.
+
+
+
+### Git Command Execution Core
+
+This is the foundational component responsible for executing all Git commands and handling their output. It abstracts away the direct interaction with the `git` executable, providing a reliable and consistent way for other components to run Git operations. It's fundamental because all Git-related functionalities within `pre-commit` ultimately rely on executing these underlying Git commands.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/pre-commit/pre-commit/blob/master/pre_commit/git.py#L1-L1" target="_blank" rel="noopener noreferrer">`pre_commit.git:cmd_output` (1:1)</a>
+
+- <a href="https://github.com/pre-commit/pre-commit/blob/master/pre_commit/git.py#L1-L1" target="_blank" rel="noopener noreferrer">`pre_commit.git:cmd_output_b` (1:1)</a>
+
+
+
+
+
+### Git Repository Metadata Provider
+
+This component provides essential information about the Git repository's structure and state. It includes functions like `get_root` to determine the repository's top-level directory, `get_git_dir` to locate the `.git` directory, and `is_in_merge_conflict` to check for ongoing merge conflicts. This component is fundamental for navigating the repository and understanding its current operational context.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/pre-commit/pre-commit/blob/master/pre_commit/git.py#L50-L72" target="_blank" rel="noopener noreferrer">`pre_commit.git:get_root` (50:72)</a>
+
+- <a href="https://github.com/pre-commit/pre-commit/blob/master/pre_commit/git.py#L75-L82" target="_blank" rel="noopener noreferrer">`pre_commit.git:get_git_dir` (75:82)</a>
+
+- <a href="https://github.com/pre-commit/pre-commit/blob/master/pre_commit/git.py#L95-L100" target="_blank" rel="noopener noreferrer">`pre_commit.git:is_in_merge_conflict` (95:100)</a>
+
+
+
+
+
+### Git File Change Tracker
+
+This component is dedicated to identifying and listing files based on their status within the Git repository. It offers functionalities suchs as `get_staged_files` to retrieve files currently in the staging area, `get_all_files` for all tracked files, and `get_changed_files` to list differences between revisions. This is crucial for `pre-commit` hooks to accurately determine which files they need to process.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/pre-commit/pre-commit/blob/master/pre_commit/git.py#L134-L142" target="_blank" rel="noopener noreferrer">`pre_commit.git:get_staged_files` (134:142)</a>
+
+- <a href="https://github.com/pre-commit/pre-commit/blob/master/pre_commit/git.py#L153-L154" target="_blank" rel="noopener noreferrer">`pre_commit.git:get_all_files` (153:154)</a>
+
+- <a href="https://github.com/pre-commit/pre-commit/blob/master/pre_commit/git.py#L157-L166" target="_blank" rel="noopener noreferrer">`pre_commit.git:get_changed_files` (157:166)</a>
+
+
+
+
+
+### Git Environment Sanitizer
+
+Represented by the `no_git_env` function, this component is responsible for cleaning and sanitizing the environment variables before executing Git commands or hooks. It filters out potentially problematic `GIT_` prefixed environment variables that could interfere with Git's behavior, ensuring a consistent and isolated execution context. This is fundamental for the robustness and predictability of `pre-commit`'s operations.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/pre-commit/pre-commit/blob/master/pre_commit/git.py#L26-L47" target="_blank" rel="noopener noreferrer">`pre_commit.git:no_git_env` (26:47)</a>
+
+
+
+
+
+### Git Repository Initializer
+
+This component, primarily through the `init_repo` function, handles the creation and initial setup of new Git repositories, including adding remote origins. It's fundamental for internal testing, bootstrapping new `pre-commit` configurations, or setting up temporary repositories.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/pre-commit/pre-commit/blob/master/pre_commit/git.py#L184-L192" target="_blank" rel="noopener noreferrer">`pre_commit.git:init_repo` (184:192)</a>
+
+
+
+
+
+### Staged Files Isolation Context
+
+This component, embodied by the `staged_files_only` context manager, is critical for `pre-commit`'s core behavior. It temporarily modifies the Git working directory and index to ensure that pre-commit hooks only operate on files that are actually staged for the current commit. This prevents hooks from running on irrelevant unstaged modifications and maintains the integrity of the commit process. It's fundamental for the correctness and efficiency of hook execution.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/pre-commit/pre-commit/blob/master/pre_commit/staged_files_only.py#L107-L112" target="_blank" rel="noopener noreferrer">`pre_commit.staged_files_only:staged_files_only` (107:112)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Hook_Environment_Provisioning.md
+++ b/.codeboarding/Hook_Environment_Provisioning.md
@@ -1,0 +1,187 @@
+```mermaid
+
+graph LR
+
+    Language_Provisioning_Modules["Language Provisioning Modules"]
+
+    Language_Base_Utilities["Language Base Utilities"]
+
+    Environment_Context_Management["Environment Context Management"]
+
+    Shebang_Parsing["Shebang Parsing"]
+
+    Prefix_Management["Prefix Management"]
+
+    General_Utilities["General Utilities"]
+
+    Constants["Constants"]
+
+    Language_Provisioning_Modules -- "uses" --> Language_Base_Utilities
+
+    Language_Provisioning_Modules -- "uses" --> Environment_Context_Management
+
+    Language_Provisioning_Modules -- "uses" --> Prefix_Management
+
+    Language_Base_Utilities -- "uses" --> Shebang_Parsing
+
+    Language_Base_Utilities -- "uses" --> General_Utilities
+
+    Language_Base_Utilities -- "uses" --> Constants
+
+    Environment_Context_Management -- "uses" --> General_Utilities
+
+    Shebang_Parsing -- "uses" --> General_Utilities
+
+    Prefix_Management -- "uses" --> Constants
+
+    General_Utilities -- "uses" --> Constants
+
+```
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Component Details
+
+
+
+The Hook Environment Provisioning subsystem is crucial for `pre-commit`'s ability to run hooks reliably and in isolation across various programming languages. It ensures that each hook operates within a clean, self-contained environment, preventing conflicts and ensuring consistent execution regardless of the user's local system setup.
+
+
+
+### Language Provisioning Modules
+
+These are the individual modules (e.g., `python.py`, `node.py`, `docker.py`) responsible for the concrete implementation of environment setup, dependency installation, and execution context preparation for hooks written in their respective languages. They orchestrate the use of other core provisioning components to achieve language-specific isolation.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/pre-commit/pre-commit/blob/master/pre_commit/languages/python.py#L1-L1" target="_blank" rel="noopener noreferrer">`pre_commit.languages.python` (1:1)</a>
+
+- <a href="https://github.com/pre-commit/pre-commit/blob/master/pre_commit/languages/node.py#L1-L1" target="_blank" rel="noopener noreferrer">`pre_commit.languages.node` (1:1)</a>
+
+- <a href="https://github.com/pre-commit/pre-commit/blob/master/pre_commit/languages/docker.py#L1-L1" target="_blank" rel="noopener noreferrer">`pre_commit.languages.docker` (1:1)</a>
+
+
+
+
+
+### Language Base Utilities
+
+Provides foundational, language-agnostic utilities and base functions commonly used by the language-specific modules. This includes functions for managing environment directories, setting up commands, and interacting with the file system, ensuring a consistent approach to environment management across different languages. It defines the common interface and shared logic for language provisioning.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/pre-commit/pre-commit/blob/master/pre_commit/lang_base.py#L1-L1" target="_blank" rel="noopener noreferrer">`pre_commit.lang_base` (1:1)</a>
+
+
+
+
+
+### Environment Context Management
+
+This module is solely responsible for managing and manipulating environment variables. It sets up the correct execution context for language-specific tools and hooks by ensuring that necessary environment variables (e.g., `PATH` modifications) are correctly configured to locate executables and dependencies within the isolated environment.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/pre-commit/pre-commit/blob/master/pre_commit/envcontext.py#L32-L61" target="_blank" rel="noopener noreferrer">`pre_commit.envcontext` (32:61)</a>
+
+
+
+
+
+### Shebang Parsing
+
+This module handles the parsing of shebang lines (e.g., `#!/usr/bin/env python`) in scripts and finding the corresponding executables. It is essential for determining which interpreter should be used to run a script-based hook within its provisioned environment.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/pre-commit/pre-commit/blob/master/pre_commit/parse_shebang.py#L1-L1" target="_blank" rel="noopener noreferrer">`pre_commit.parse_shebang` (1:1)</a>
+
+
+
+
+
+### Prefix Management
+
+This module manages the base directories and installation prefixes where language-specific virtual environments, tools, and dependencies are installed. It is crucial for maintaining the isolation of different hook environments and ensuring that each hook operates within its designated, clean context.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/pre-commit/pre-commit/blob/master/pre_commit/prefix.py#L1-L1" target="_blank" rel="noopener noreferrer">`pre_commit.prefix` (1:1)</a>
+
+
+
+
+
+### General Utilities
+
+A collection of general-purpose utility functions heavily relied upon by the environment provisioning components. This includes functions for robust command execution (`cmd_output`), file system operations (`rmtree`, `make_executable`), and platform-specific adjustments, all of which are essential for setting up and cleaning isolated environments.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/pre-commit/pre-commit/blob/master/pre_commit/util.py#L1-L1" target="_blank" rel="noopener noreferrer">`pre_commit.util` (1:1)</a>
+
+
+
+
+
+### Constants
+
+This module defines various system-wide constants, such as default paths, version numbers, and configuration values, that are critical for the consistent and correct setup of isolated environments across different languages and platforms.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/pre-commit/pre-commit/blob/master/pre_commit/constants.py#L1-L1" target="_blank" rel="noopener noreferrer">`pre_commit.constants` (1:1)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/on_boarding.md
+++ b/.codeboarding/on_boarding.md
@@ -1,0 +1,191 @@
+```mermaid
+
+graph LR
+
+    Application_Core["Application Core"]
+
+    Configuration_Repository_Management["Configuration & Repository Management"]
+
+    Git_Integration_Layer["Git Integration Layer"]
+
+    Hook_Environment_Provisioning["Hook Environment Provisioning"]
+
+    System_Utilities_Feedback["System Utilities & Feedback"]
+
+    Application_Core -- "Initializes" --> System_Utilities_Feedback
+
+    Application_Core -- "Orchestrates" --> Configuration_Repository_Management
+
+    Application_Core -- "Interacts with" --> Git_Integration_Layer
+
+    Application_Core -- "Dispatches to" --> Hook_Environment_Provisioning
+
+    Configuration_Repository_Management -- "Provides Data to" --> Application_Core
+
+    Configuration_Repository_Management -- "Relies on" --> Git_Integration_Layer
+
+    Configuration_Repository_Management -- "Uses" --> System_Utilities_Feedback
+
+    Application_Core -- "Accesses" --> Git_Integration_Layer
+
+    Configuration_Repository_Management -- "Accesses" --> Git_Integration_Layer
+
+    Git_Integration_Layer -- "Relies on" --> System_Utilities_Feedback
+
+    Application_Core -- "Invokes" --> Hook_Environment_Provisioning
+
+    Hook_Environment_Provisioning -- "Relies on" --> System_Utilities_Feedback
+
+    Application_Core -- "Uses" --> System_Utilities_Feedback
+
+    Configuration_Repository_Management -- "Uses" --> System_Utilities_Feedback
+
+    Git_Integration_Layer -- "Uses" --> System_Utilities_Feedback
+
+    Hook_Environment_Provisioning -- "Uses" --> System_Utilities_Feedback
+
+    click Application_Core href "https://github.com/pre-commit/pre-commit/blob/main/.codeboarding//Application_Core.md" "Details"
+
+    click Configuration_Repository_Management href "https://github.com/pre-commit/pre-commit/blob/main/.codeboarding//Configuration_Repository_Management.md" "Details"
+
+    click Git_Integration_Layer href "https://github.com/pre-commit/pre-commit/blob/main/.codeboarding//Git_Integration_Layer.md" "Details"
+
+    click Hook_Environment_Provisioning href "https://github.com/pre-commit/pre-commit/blob/main/.codeboarding//Hook_Environment_Provisioning.md" "Details"
+
+```
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Component Details
+
+
+
+The `pre-commit` architecture can be effectively decomposed into five fundamental components, each with distinct responsibilities and clear interactions, ensuring modularity, maintainability, and robust operation.
+
+
+
+### Application Core
+
+The central orchestrator and command dispatcher for the `pre-commit` command-line interface. It handles argument parsing, sets up the application environment, and directs control to specific sub-commands for execution, acting as the primary control flow manager.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/pre-commit/pre-commit/blob/master/pre_commit/main.py#L196-L437" target="_blank" rel="noopener noreferrer">`pre_commit.main` (196:437)</a>
+
+- `pre_commit.commands` (1:1)
+
+
+
+
+
+### Configuration & Repository Management
+
+Manages the application's configuration by parsing, validating, and potentially rewriting the `.pre-commit-config.yaml` file. It also handles the local cache of pre-commit repositories, including cloning, metadata storage, and lifecycle management (e.g., garbage collection).
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/pre-commit/pre-commit/blob/master/pre_commit/clientlib.py#L1-L1" target="_blank" rel="noopener noreferrer">`pre_commit.clientlib` (1:1)</a>
+
+- <a href="https://github.com/pre-commit/pre-commit/blob/master/pre_commit/yaml.py#L1-L1" target="_blank" rel="noopener noreferrer">`pre_commit.yaml` (1:1)</a>
+
+- <a href="https://github.com/pre-commit/pre-commit/blob/master/pre_commit/yaml_rewrite.py#L1-L1" target="_blank" rel="noopener noreferrer">`pre_commit.yaml_rewrite` (1:1)</a>
+
+- <a href="https://github.com/pre-commit/pre-commit/blob/master/pre_commit/store.py#L1-L1" target="_blank" rel="noopener noreferrer">`pre_commit.store` (1:1)</a>
+
+
+
+
+
+### Git Integration Layer
+
+Provides a high-level interface for interacting with the Git version control system. This includes retrieving repository information (root, git dir), listing files (staged, changed, all), checking for merge conflicts, and managing the Git index to ensure hooks run against the correct set of files.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/pre-commit/pre-commit/blob/master/pre_commit/git.py#L1-L1" target="_blank" rel="noopener noreferrer">`pre_commit.git` (1:1)</a>
+
+- <a href="https://github.com/pre-commit/pre-commit/blob/master/pre_commit/staged_files_only.py#L107-L112" target="_blank" rel="noopener noreferrer">`pre_commit.staged_files_only` (107:112)</a>
+
+
+
+
+
+### Hook Environment Provisioning
+
+Responsible for setting up and managing isolated execution environments for different programming languages (e.g., Python, Node.js, Ruby, Go, Docker). It handles environment variable manipulation and executable path resolution to ensure hooks run correctly and in isolation, regardless of the user's system setup.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `pre_commit.languages` (1:1)
+
+- <a href="https://github.com/pre-commit/pre-commit/blob/master/pre_commit/lang_base.py#L1-L1" target="_blank" rel="noopener noreferrer">`pre_commit.lang_base` (1:1)</a>
+
+- <a href="https://github.com/pre-commit/pre-commit/blob/master/pre_commit/envcontext.py#L32-L61" target="_blank" rel="noopener noreferrer">`pre_commit.envcontext` (32:61)</a>
+
+- <a href="https://github.com/pre-commit/pre-commit/blob/master/pre_commit/parse_shebang.py#L1-L1" target="_blank" rel="noopener noreferrer">`pre_commit.parse_shebang` (1:1)</a>
+
+
+
+
+
+### System Utilities & Feedback
+
+A foundational component providing general-purpose helper functions for common operations (e.g., executing shell commands, file system manipulations, argument partitioning). It also manages all console output, integrates with Python's logging system, and provides a centralized mechanism for catching, logging, and ensuring the application exits with an appropriate status code.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/pre-commit/pre-commit/blob/master/pre_commit/util.py#L1-L1" target="_blank" rel="noopener noreferrer">`pre_commit.util` (1:1)</a>
+
+- <a href="https://github.com/pre-commit/pre-commit/blob/master/pre_commit/xargs.py#L130-L183" target="_blank" rel="noopener noreferrer">`pre_commit.xargs` (130:183)</a>
+
+- <a href="https://github.com/pre-commit/pre-commit/blob/master/pre_commit/output.py#L1-L1" target="_blank" rel="noopener noreferrer">`pre_commit.output` (1:1)</a>
+
+- <a href="https://github.com/pre-commit/pre-commit/blob/master/pre_commit/logging_handler.py#L34-L41" target="_blank" rel="noopener noreferrer">`pre_commit.logging_handler` (34:41)</a>
+
+- <a href="https://github.com/pre-commit/pre-commit/blob/master/pre_commit/color.py#L1-L1" target="_blank" rel="noopener noreferrer">`pre_commit.color` (1:1)</a>
+
+- <a href="https://github.com/pre-commit/pre-commit/blob/master/pre_commit/error_handler.py#L70-L80" target="_blank" rel="noopener noreferrer">`pre_commit.error_handler` (70:80)</a>
+
+- <a href="https://github.com/pre-commit/pre-commit/blob/master/pre_commit/errors.py#L1-L1" target="_blank" rel="noopener noreferrer">`pre_commit.errors` (1:1)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)


### PR DESCRIPTION
This PR adds a Diagram visualization of the pre-commit's codebase. You can see how it will render here:
https://github.com/CodeBoarding/GeneratedOnBoardings/blob/main/pre-commit/on_boarding.md

The diagram is designed to give high-level understanding of the full codebase. Then when a new contributor wants to join they usually start small - modifying just one sub-module. Having the diagram they can identify where the logic of what they want to improve is, then go one level deeper and again navigate the component of interest. Now they can start working as each component is linked with relevant source code files and the new person can edit them by roughly understanding how they fit in the bigger picture. Would love to hear what is your opinion on the matter!

I'd usually open a discussion first, but you don't have them enabled for this repo so I decided to go ahead and open a PR.

Any feedback is more than welcome!

Full transparency: we’re exploring this idea as a potential startup, but we’re still early and figuring out what’s actually useful to developers.

We’ve also released a free GitHub Action that keeps the diagrams automatically updated as the code changes, so there's no ongoing maintenance burden.