### PR TITLE
improve julia language support

### DIFF
--- a/.github/workflows/languages.yaml
+++ b/.github/workflows/languages.yaml
@@ -67,7 +67,10 @@ jobs:
       if: matrix.language == 'haskell'
     - uses: r-lib/actions/setup-r@v2
       if: matrix.os == 'ubuntu-latest' && matrix.language == 'r'
-
+    - uses: julia-actions/install-juliaup@v2
+      if: matrix.language == 'julia'
+    - run: juliaup add 1.10.10
+      if: matrix.language == 'julia'
     - name: install deps
       run: python -mpip install -e . -r requirements-dev.txt
     - name: run tests

--- a/.github/workflows/languages.yaml
+++ b/.github/workflows/languages.yaml
@@ -69,6 +69,8 @@ jobs:
       if: matrix.os == 'ubuntu-latest' && matrix.language == 'r'
     - uses: julia-actions/install-juliaup@v2
       if: matrix.language == 'julia'
+      with:
+        channel: 'release'
     - run: juliaup add 1.10.10
       if: matrix.language == 'julia'
     - name: install deps

--- a/pre_commit/languages/julia.py
+++ b/pre_commit/languages/julia.py
@@ -5,14 +5,11 @@ import os
 import shutil
 from collections.abc import Generator
 from collections.abc import Sequence
-from typing import Union
 
 from pre_commit import lang_base
-from pre_commit.envcontext import _Unset
 from pre_commit.envcontext import envcontext
 from pre_commit.envcontext import PatchesT
 from pre_commit.envcontext import UNSET
-from pre_commit.envcontext import Var
 from pre_commit.prefix import Prefix
 from pre_commit.util import cmd_output_b
 
@@ -49,17 +46,17 @@ def run_hook(
     )
 
 
-PatchEntry = tuple[str, Union[str, _Unset, tuple[Union[str, Var], ...]]]
-
-
 def get_env_patch(target_dir: str, version: str) -> PatchesT:
-    patches: list[PatchEntry] = [
+    patches = (
         ('JULIA_LOAD_PATH', target_dir),
         ('JULIA_PROJECT', UNSET),
-    ]
-    if version not in ('system', 'default'):
-        patches.append(('JULIAUP_CHANNEL', version))
-    return tuple(patches)
+        # Only set JULIAUP_CHANNEL if we don't want use the system's default
+        *(
+            (('JULIAUP_CHANNEL', version),)
+            if version not in ('system', 'default') else ()
+        ),
+    )
+    return patches
 
 
 @contextlib.contextmanager

--- a/pre_commit/languages/julia.py
+++ b/pre_commit/languages/julia.py
@@ -49,6 +49,7 @@ def run_hook(
 def get_env_patch(target_dir: str, version: str) -> PatchesT:
     patches = (
         ('JULIA_LOAD_PATH', target_dir),
+        # May be set, remove it to not interfere with LOAD_PATH
         ('JULIA_PROJECT', UNSET),
         # Only set JULIAUP_CHANNEL if we don't want use the system's default
         *(

--- a/pre_commit/languages/julia.py
+++ b/pre_commit/languages/julia.py
@@ -106,7 +106,10 @@ def install_environment(
         # copy `src` files if they exist
         src_dir = prefix.path('src')
         if os.path.isdir(src_dir):
-            shutil.copytree(src_dir, os.path.join(envdir, 'src'))
+            shutil.copytree(
+                src_dir, os.path.join(envdir, 'src'),
+                dirs_exist_ok=True,
+            )
 
         # Julia code to instantiate the hook environment
         julia_code = """

--- a/pre_commit/languages/julia.py
+++ b/pre_commit/languages/julia.py
@@ -45,20 +45,23 @@ def run_hook(
         color=color,
     )
 
+
 def get_env_patch(target_dir: str, version: str) -> PatchesT:
     patches = [
         ('JULIA_LOAD_PATH', target_dir),
         ('JULIA_PROJECT', UNSET),
     ]
-    if version not in ("system", "default"):
+    if version not in ('system', 'default'):
         patches.append(('JULIAUP_CHANNEL', version))
     return tuple(patches)
+
 
 @contextlib.contextmanager
 def in_env(prefix: Prefix, version: str) -> Generator[None]:
     envdir = lang_base.environment_dir(prefix, ENVIRONMENT_DIR, version)
     with envcontext(get_env_patch(envdir, version)):
         yield
+
 
 def install_environment(
         prefix: Prefix,
@@ -95,7 +98,7 @@ def install_environment(
             break
 
         # copy `src` files if they exist
-        src_dir = prefix.path("src")
+        src_dir = prefix.path('src')
         if os.path.isdir(src_dir):
             shutil.copytree(src_dir, os.path.join(envdir, 'src'))
 

--- a/pre_commit/languages/julia.py
+++ b/pre_commit/languages/julia.py
@@ -5,11 +5,14 @@ import os
 import shutil
 from collections.abc import Generator
 from collections.abc import Sequence
+from typing import Union
 
 from pre_commit import lang_base
+from pre_commit.envcontext import _Unset
 from pre_commit.envcontext import envcontext
 from pre_commit.envcontext import PatchesT
 from pre_commit.envcontext import UNSET
+from pre_commit.envcontext import Var
 from pre_commit.prefix import Prefix
 from pre_commit.util import cmd_output_b
 
@@ -46,8 +49,11 @@ def run_hook(
     )
 
 
+PatchEntry = tuple[str, Union[str, _Unset, tuple[Union[str, Var], ...]]]
+
+
 def get_env_patch(target_dir: str, version: str) -> PatchesT:
-    patches = [
+    patches: list[PatchEntry] = [
         ('JULIA_LOAD_PATH', target_dir),
         ('JULIA_PROJECT', UNSET),
     ]
@@ -130,6 +136,6 @@ def install_environment(
         end
         """
         cmd_output_b(
-            'julia', '--startup-file=no', '-e', julia_code, '--', envdir, *additional_dependencies,
-            cwd=prefix.prefix_dir,
+            'julia', '--startup-file=no', '-e', julia_code, '--', envdir,
+            *additional_dependencies, cwd=prefix.prefix_dir,
         )

--- a/tests/languages/julia_test.py
+++ b/tests/languages/julia_test.py
@@ -95,3 +95,41 @@ def test_julia_repo_local(tmp_path):
             env_dir, julia, 'local.jl --local-arg1 --local-arg2',
             deps=deps, is_local=True,
         ) == expected
+
+
+def _make_src_hook(tmp_path, pkg_code, script_code):
+    # here we have a package with a src dir and a script dir
+    src_dir = tmp_path.joinpath('src')
+    src_dir.mkdir()
+    src_dir.joinpath('ExamplePkg.jl').write_text(pkg_code)
+
+    script_dir = tmp_path.joinpath('scripts')
+    script_dir.mkdir()
+    script_dir.joinpath('main.jl').write_text(script_code)
+
+    tmp_path.joinpath('Project.toml').write_text(
+        'name = "ExamplePkg"\n'
+        'uuid = "df230c44-b485-4b6a-bafb-763c50abe554"\n'
+        '[deps]\n'
+        'Example = "7876af07-990d-54b4-ab0e-23690620f79a"\n',
+    )
+
+
+def test_julia_hook_src(tmp_path):
+    pkg_code = """
+    module ExamplePkg
+    using Example
+    export main
+    function main()
+        println("Hello, world!")
+    end
+    end
+    """
+
+    script_code = """
+    using ExamplePkg
+    main()
+    """
+    _make_src_hook(tmp_path, pkg_code, script_code)
+    expected = (0, b'Hello, world!\n')
+    assert run_language(tmp_path, julia, 'scripts/main.jl') == expected

--- a/tests/languages/julia_test.py
+++ b/tests/languages/julia_test.py
@@ -28,6 +28,22 @@ def test_julia_hook(tmp_path):
     assert run_language(tmp_path, julia, 'src/main.jl') == expected
 
 
+def test_julia_hook_version(tmp_path):
+    code = """
+    using Example
+    function main()
+        println("Hello, Julia $(VERSION)!")
+    end
+    main()
+    """
+    _make_hook(tmp_path, code)
+    expected = (0, b'Hello, Julia 1.10.10!\n')
+    assert run_language(
+        tmp_path, julia, 'src/main.jl',
+        version='1.10.10',
+    ) == expected
+
+
 def test_julia_hook_manifest(tmp_path):
     code = """
     using Example


### PR DESCRIPTION
This PR fixes three issues I ran into when trying to use pre-commit's native Julia language support for ExplicitImports.jl (https://github.com/JuliaTesting/ExplicitImports.jl/issues/100) in Pkg (https://github.com/JuliaLang/Pkg.jl/pull/4326):

1. Adds `--startup-file=no` to both invocations of Julia (install & run). The startup file is a Julia script that users can configure to run commands before the start of their Julia session. It is typically used to load developer packages like Revise and not used "in-production". Here when we run our pre-commit hooks we do not want to run the user's startup file which could have dependencies the current environment does not have.
2. Copies `src` files in addition to Project/Manifest. This allows pre-commit hooks to live inside a package (like https://github.com/JuliaTesting/ExplicitImports.jl/blob/main/.pre-commit-hooks.yaml) instead of being in a separate repo (like https://github.com/fredrikekre/runic-pre-commit).
3. Adds basic support for customizing the Julia version by setting the `JULIAUP_CHANNEL` environmental variable. This support is limited in a couple ways:
    - We don't check that the user is using juliaup. They could have installed julia some other way in which case the `JULIAUP_CHANNEL` does not do anything and setting the `language_version` will not have any effect. That however is the status quo (currently setting the `language_version` does not have any effect) and many users use juliaup, so I think we could just document that `language_version` support requires your `julia` to be from juliaup.
    - If the user passes a channel which is not installed, they will get a juliaup error that the channel can not be found. If we were confident they were using juliaup we could install it on their behalf instead, but I'm not sure this is necessary.

With these changes, https://github.com/JuliaLang/Pkg.jl/pull/4329 can run successfully.