### PR TITLE
Julia: copy src files

### DIFF
--- a/pre_commit/languages/julia.py
+++ b/pre_commit/languages/julia.py
@@ -99,6 +99,14 @@ def install_environment(
             shutil.copy(manifest_file, envdir)
             break
 
+        # copy `src` files if they exist
+        src_dir = prefix.path('src')
+        if os.path.isdir(src_dir):
+            shutil.copytree(
+                src_dir, os.path.join(envdir, 'src'),
+                dirs_exist_ok=True,
+            )
+
         # Julia code to instantiate the hook environment
         julia_code = """
         @assert length(ARGS) > 0


### PR DESCRIPTION
Copies src files in addition to Project/Manifest. This allows pre-commit hooks to live inside a package (like https://github.com/JuliaTesting/ExplicitImports.jl/blob/main/.pre-commit-hooks.yaml) instead of being in a separate repo (like https://github.com/fredrikekre/runic-pre-commit).

Split out from #3494 