### PR TITLE
Julia: support `language_version`

### DIFF
--- a/.github/workflows/languages.yaml
+++ b/.github/workflows/languages.yaml
@@ -67,7 +67,12 @@ jobs:
       if: matrix.language == 'haskell'
     - uses: r-lib/actions/setup-r@v2
       if: matrix.os == 'ubuntu-latest' && matrix.language == 'r'
-
+    - uses: julia-actions/install-juliaup@v2
+      if: matrix.language == 'julia'
+      with:
+        channel: 'release'
+    - run: juliaup add 1.10.10
+      if: matrix.language == 'julia'
     - name: install deps
       run: python -mpip install -e . -r requirements-dev.txt
     - name: run tests

--- a/pre_commit/languages/julia.py
+++ b/pre_commit/languages/julia.py
@@ -49,8 +49,13 @@ def run_hook(
 def get_env_patch(target_dir: str, version: str) -> PatchesT:
     return (
         ('JULIA_LOAD_PATH', target_dir),
-        # May be set, remove it to not interfer with LOAD_PATH
+        # May be set, remove it to not interfere with LOAD_PATH
         ('JULIA_PROJECT', UNSET),
+        # Only set JULIAUP_CHANNEL if we don't want use the system's default
+        *(
+            (('JULIAUP_CHANNEL', version),)
+            if version not in ('system', 'default') else ()
+        ),
     )
 
 

--- a/tests/languages/julia_test.py
+++ b/tests/languages/julia_test.py
@@ -28,6 +28,22 @@ def test_julia_hook(tmp_path):
     assert run_language(tmp_path, julia, 'src/main.jl') == expected
 
 
+def test_julia_hook_version(tmp_path):
+    code = """
+    using Example
+    function main()
+        println("Hello, Julia $(VERSION)!")
+    end
+    main()
+    """
+    _make_hook(tmp_path, code)
+    expected = (0, b'Hello, Julia 1.10.10!\n')
+    assert run_language(
+        tmp_path, julia, 'src/main.jl',
+        version='1.10.10',
+    ) == expected
+
+
 def test_julia_hook_manifest(tmp_path):
     code = """
     using Example


### PR DESCRIPTION
Adds basic support for customizing the Julia version by setting the JULIAUP_CHANNEL environmental variable. This support is limited in a couple ways:

- We don't check that the user is using juliaup. They could have installed julia some other way in which case the JULIAUP_CHANNEL does not do anything and setting the language_version will not have any effect. That however is the status quo (currently setting the language_version does not have any effect) and many users use juliaup, so I think we could just document that language_version support requires your julia to be from juliaup.
- If the user passes a channel which is not installed, they will get a juliaup error that the channel can not be found. If we were confident they were using juliaup we could install it on their behalf instead, but I'm not sure this is necessary.

split out from #3494 