### PR TITLE
Make Dart pre-commit hook compatible with the latest Dart SDKs

### DIFF
--- a/pre_commit/resources/empty_template_pubspec.yaml
+++ b/pre_commit/resources/empty_template_pubspec.yaml
@@ -1,4 +1,4 @@
 name: pre_commit_empty_pubspec
 environment:
-  sdk: '>=2.10.0'
+  sdk: '>=2.12.0'
 executables: {}

--- a/testing/get-dart.sh
+++ b/testing/get-dart.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-VERSION=2.13.4
+VERSION=3.8.3
 
 if [ "$OSTYPE" = msys ]; then
     URL="https://storage.googleapis.com/dart-archive/channels/stable/release/${VERSION}/sdk/dartsdk-windows-x64-release.zip"

--- a/testing/get-dart.sh
+++ b/testing/get-dart.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-VERSION=3.8.3
+VERSION=2.19.6
 
 if [ "$OSTYPE" = msys ]; then
     URL="https://storage.googleapis.com/dart-archive/channels/stable/release/${VERSION}/sdk/dartsdk-windows-x64-release.zip"

--- a/tests/languages/dart_test.py
+++ b/tests/languages/dart_test.py
@@ -10,7 +10,7 @@ from testing.language_helpers import run_language
 def test_dart(tmp_path):
     pubspec_yaml = '''\
 environment:
-  sdk: '>=2.10.0 <3.0.0'
+  sdk: '>=2.12.0 <4.0.0'
 
 name: hello_world_dart
 


### PR DESCRIPTION
Dart introduced sound null safety in version 2.12.0, and as of Dart 3, null safety is mandatory. Older Dart SDKs allowed both pre-null safety and null-safe packages, but modern Dart SDKs, where most source code is null-safe, now reject pre-null safety packages.

The current `pubspec.yaml` template with `sdk: '>=2.10.0'` is incompatible with recent Dart SDKs, leading to the following error:

```
An unexpected error has occurred: CalledProcessError: command: ('/path/to/dart-sdk/bin/dart', 'pub', 'get') return code: 65
stdout:
    Resolving dependencies...
stderr:
    The lower bound of "sdk: '>=2.10.0'" must be 2.12.0'
    or higher to enable null safety.

    The current Dart SDK (3.8.3) only supports null safety.

    For details, see https://dart.dev/null-safety
```

To ensure compatibility with the modern Dart ecosystem, this commit updates the minimum Dart SDK version to 2.12.0 or higher, which implicitly supports null safety.
Additionally, `testing/get-dart.sh` has been updated to verify that the pre-commit hook functions correctly with the latest Dart versions.