### PR TITLE
Add checks for potentially dangerous trailing characters in files and excludes fields

### DIFF
--- a/pre_commit/clientlib.py
+++ b/pre_commit/clientlib.py
@@ -282,35 +282,35 @@ class OptionalSensibleRegexAtHook(cfgv.OptionalNoDefault):
                 )
 
 
-
 class PotentiallyDangerousTrailingCharactersAtHook(cfgv.OptionalNoDefault):
     def _pre_process(self, value: str) -> str:
         """Normalize the field value by removing tabs, newlines, spaces, and trailing )/."""
-        spaces_regex_pattern = r"\s+"
-        trailing_bracket_and_slash_pattern = r"\)/$"
+        spaces_regex_pattern = r'\s+'
+        trailing_bracket_and_slash_pattern = r'\)/$'
         combined_pattern = f"{spaces_regex_pattern}|{trailing_bracket_and_slash_pattern}"
-        return re.sub(combined_pattern, "", value.replace("\t", "").replace("\n", "").strip())
+        return re.sub(combined_pattern, '', value.replace('\t', '').replace('\n', '').strip())
 
     def check(self, dct: dict[str, Any]) -> None:
         super().check(dct)
-        pipe_trailing_pattern = r"\|(\)|\/)?$"
-        slash_trailing_pattern = r"\/(\)|\/)?$"
+        pipe_trailing_pattern = r'\|(\)|\/)?$'
+        slash_trailing_pattern = r'\/(\)|\/)?$'
 
-        pre_processed_field = self._pre_process(dct.get(self.key, ""))
+        pre_processed_field = self._pre_process(dct.get(self.key, ''))
 
         if re.search(pipe_trailing_pattern, pre_processed_field):
             logger.error(
                 f"Potentially dangerous trailing pipe pattern detected in {self.key!r} field of the hook: {dct.get('id')!r}"
-                "This can uninteded behaviour such as the files option being rendered empty"
-                "It is recommended to remove the trailing character prompted"
+                'This can uninteded behaviour such as the files option being rendered empty'
+                'It is recommended to remove the trailing character prompted',
             )
 
         if re.search(slash_trailing_pattern, pre_processed_field):
             logger.error(
                 f"Potentially dangerous trailing slash pattern detected in {self.key!r} field of the hook: {dct.get('id')!r}"
                 f"This can uninteded behaviour such as the files option being rendered empty"
-                f"It is recommended to remove the trailing character prompted"
+                f"It is recommended to remove the trailing character prompted",
             )
+
 
 class OptionalSensibleRegexAtTop(cfgv.OptionalNoDefault):
     def check(self, dct: dict[str, Any]) -> None:

--- a/tests/clientlib_test.py
+++ b/tests/clientlib_test.py
@@ -240,63 +240,62 @@ def test_validate_optional_sensible_regex_at_hook(caplog, regex, warning):
     assert caplog.record_tuples == [('pre_commit', logging.WARNING, warning)]
 
 
-
 @pytest.mark.parametrize(
     ('regex', 'warning'),
     (
         (
-            "(?x)^(\n^some-dir/some-sub-dir|\n)/",
+            '(?x)^(\n^some-dir/some-sub-dir|\n)/',
             "Potentially dangerous trailing pipe pattern detected in 'files' field of the hook: 'flake8'"
-            "This can uninteded behaviour such as the files option being rendered empty"
-            "It is recommended to remove the trailing character prompted"
+            'This can uninteded behaviour such as the files option being rendered empty'
+            'It is recommended to remove the trailing character prompted',
         ),
         (
-            "^some/path1|",
+            '^some/path1|',
             "Potentially dangerous trailing pipe pattern detected in 'files' field of the hook: 'flake8'"
-            "This can uninteded behaviour such as the files option being rendered empty"
-            "It is recommended to remove the trailing character prompted"
+            'This can uninteded behaviour such as the files option being rendered empty'
+            'It is recommended to remove the trailing character prompted',
         ),
         (
-            "(?x)^(\n" "^some/path1|\n" "^some/path2|\n" ")",
+            '(?x)^(\n' '^some/path1|\n' '^some/path2|\n' ')',
             "Potentially dangerous trailing pipe pattern detected in 'files' field of the hook: 'flake8'"
-            "This can uninteded behaviour such as the files option being rendered empty"
-            "It is recommended to remove the trailing character prompted"
+            'This can uninteded behaviour such as the files option being rendered empty'
+            'It is recommended to remove the trailing character prompted',
         ),
         (
-            "^some/path2/",
+            '^some/path2/',
             "Potentially dangerous trailing slash pattern detected in 'files' field of the hook: 'flake8'"
-            "This can uninteded behaviour such as the files option being rendered empty"
-            "It is recommended to remove the trailing character prompted"
+            'This can uninteded behaviour such as the files option being rendered empty'
+            'It is recommended to remove the trailing character prompted',
         ),
         (
-            "(?x)^(^some-dir/)/",
+            '(?x)^(^some-dir/)/',
             "Potentially dangerous trailing slash pattern detected in 'files' field of the hook: 'flake8'"
-            "This can uninteded behaviour such as the files option being rendered empty"
-            "It is recommended to remove the trailing character prompted"
+            'This can uninteded behaviour such as the files option being rendered empty'
+            'It is recommended to remove the trailing character prompted',
         ),
         (
-            "(?x)^(\n^some-dir|)/",
+            '(?x)^(\n^some-dir|)/',
             "Potentially dangerous trailing pipe pattern detected in 'files' field of the hook: 'flake8'"
-            "This can uninteded behaviour such as the files option being rendered empty"
-            "It is recommended to remove the trailing character prompted"
+            'This can uninteded behaviour such as the files option being rendered empty'
+            'It is recommended to remove the trailing character prompted',
         ),
         (
-            "(?x)^(\n^some-dir/\n)/",
+            '(?x)^(\n^some-dir/\n)/',
             "Potentially dangerous trailing slash pattern detected in 'files' field of the hook: 'flake8'"
-            "This can uninteded behaviour such as the files option being rendered empty"
-            "It is recommended to remove the trailing character prompted"
+            'This can uninteded behaviour such as the files option being rendered empty'
+            'It is recommended to remove the trailing character prompted',
         ),
         (
-            "(?x)^(\n^some-dir/\n\t\t\t\t)/",
+            '(?x)^(\n^some-dir/\n\t\t\t\t)/',
             "Potentially dangerous trailing slash pattern detected in 'files' field of the hook: 'flake8'"
-            "This can uninteded behaviour such as the files option being rendered empty"
-            "It is recommended to remove the trailing character prompted"
+            'This can uninteded behaviour such as the files option being rendered empty'
+            'It is recommended to remove the trailing character prompted',
         ),
         (
-            "(?x)^(\n^some-dir/\n           )/",
+            '(?x)^(\n^some-dir/\n           )/',
             "Potentially dangerous trailing slash pattern detected in 'files' field of the hook: 'flake8'"
-            "This can uninteded behaviour such as the files option being rendered empty"
-            "It is recommended to remove the trailing character prompted"
+            'This can uninteded behaviour such as the files option being rendered empty'
+            'It is recommended to remove the trailing character prompted',
         ),
     ),
 )


### PR DESCRIPTION
Characters such as `| /` can have unintended and potentially dangerous effects when used in trailing position of the files and exclude fields of pre-commit hooks.

This PR adds tests to display an ERROR when user adds these characters in some specific ways in files and exclude fields.

Fixes #3523