### PR TITLE
Add configurable log level via PRECOMMIT_LOGLEVEL (#3529)

### DIFF
--- a/pre_commit/logging_handler.py
+++ b/pre_commit/logging_handler.py
@@ -31,19 +31,21 @@ class LoggingHandler(logging.Handler):
         )
         output.write_line(f'{level_msg} {record.getMessage()}')
 
+
 def _set_log_level(logger: logging.Logger) -> None:
     """Set the logger level via PRECOMMIT_LOGLEVEL env var. Default is INFO."""
-    raw_level: str = os.environ.get("PRECOMMIT_LOGLEVEL", "INFO")
+    raw_level: str = os.environ.get('PRECOMMIT_LOGLEVEL', 'INFO')
     try:
         logger.setLevel(int(raw_level))  # user can provide an integer
     except ValueError:
         level = logging.getLevelName(raw_level)  # user can provide a name
-        if isinstance(level, str) and level.startswith("Level "):
+        if isinstance(level, str) and level.startswith('Level '):
             logger.setLevel(logging.INFO)
             msg = f"Unknown PRECOMMIT_LOGLEVEL: {raw_level!r}"
             logger.warning(msg)
         else:
             logger.setLevel(level)
+
 
 @contextlib.contextmanager
 def logging_handler(use_color: bool) -> Generator[None]:


### PR DESCRIPTION
This PR makes the pre-commit logging output level configurable via a `PRECOMMIT_LOGLEVEL` env var.

Although this is generally useful, it also provides the world of vscode users a workaround for using pre-commit reliably inside the IDE (see #3529 for details, which has keywords to let others locate it).