### PR TITLE
Add `--hook-args` option to `try-repo`

### DIFF
--- a/pre_commit/commands/try_repo.py
+++ b/pre_commit/commands/try_repo.py
@@ -4,6 +4,7 @@ import argparse
 import logging
 import os.path
 import tempfile
+import warnings
 
 import pre_commit.constants as C
 from pre_commit import git
@@ -54,8 +55,15 @@ def try_repo(args: argparse.Namespace) -> int:
 
         store = Store(tempdir)
         if args.hook:
-            hooks = [{'id': args.hook}]
+            hook = {'id': args.hook}
+            if args.hook_args is not None:
+                hook['args'] = args.hook_args
+            hooks = [hook]
         else:
+            if args.hook_args is not None:
+                warnings.warn(
+                    "Unused flag '--hook-args' as 'hook' is not specified.",
+                )
             repo_path = store.clone(repo, ref)
             manifest = load_manifest(os.path.join(repo_path, C.MANIFEST_FILE))
             manifest = sorted(manifest, key=lambda hook: hook['id'])

--- a/pre_commit/main.py
+++ b/pre_commit/main.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import logging
 import os
+import shlex
 import sys
 from collections.abc import Sequence
 
@@ -171,6 +172,14 @@ def _add_run_options(parser: argparse.ArgumentParser) -> None:
     )
 
 
+def _add_hook_flags_option(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        '--hook-args',
+        type=shlex.split,
+        help='Raw string with flags to pass into the hook (if specified).',
+    )
+
+
 def _adjust_args_and_chdir(args: argparse.Namespace) -> None:
     # `--config` was specified relative to the non-root working directory
     if os.path.exists(args.config):
@@ -324,6 +333,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         ),
     )
     _add_run_options(try_repo_parser)
+    _add_hook_flags_option(try_repo_parser)
 
     uninstall_parser = _add_cmd(
         'uninstall', help='Uninstall the pre-commit script.',


### PR DESCRIPTION
Hi @asottile, thanks for the great work developing `pre-commit`. It is super useful for a lot of projects.

This is an incredibly common feature request. This PR fixes #850, #1905, #2021, #2522 and #3457.

This pull request adds a `--hook-args` option to `try-repo`. It allows you to pass command-line arguments as a string that are forwarded when a single hook is tried.

TODO: 
- [ ] [This warning](https://github.com/George-Ogden/pre-commit/blob/try-repo-args/pre_commit/commands/try_repo.py#L64-L66) is currently a placeholder
- [ ] This change is not documented yet, other than the automatic `argparse` help message.
- [ ] [`--hook-args`](https://github.com/George-Ogden/pre-commit/blob/try-repo-args/pre_commit/main.py#L178) is currently passed in as a string, then formatted with `shlex.split`. An alternative is to set `nargs=argparse.REMAINDER`?