### PR TITLE
Cap hook output at terminal width to prevent wrapping

### DIFF
--- a/pre_commit/commands/run.py
+++ b/pre_commit/commands/run.py
@@ -6,6 +6,7 @@ import functools
 import logging
 import os
 import re
+import shutil
 import subprocess
 import time
 import unicodedata
@@ -247,7 +248,15 @@ def _compute_cols(hooks: Sequence[Hook]) -> int:
         name_len = 0
 
     cols = name_len + 3 + len(NO_FILES) + 1 + len(SKIPPED)
-    return max(cols, 80)
+    cols = max(cols, 80)
+
+    # Cap at terminal width to prevent wrapping
+    try:
+        term_width = shutil.get_terminal_size().columns
+    except OSError:
+        term_width = 80
+
+    return min(cols, term_width)
 
 
 def _all_filenames(args: argparse.Namespace) -> Iterable[str]:


### PR DESCRIPTION
Previously, _compute_cols() would calculate the ideal column width based on hook names and message lengths, with a minimum of 80 columns. However, it didn't consider the actual terminal width, causing the "Passed/Failed" status to wrap to the next line on narrower terminals.

This change:
- Adds terminal width detection using shutil.get_terminal_size()
- Caps the column width at the terminal width to prevent wrapping
- Maintains the minimum of 80 columns when terminal is wide enough
- Falls back to 80 columns if terminal size cannot be determined

## Before

<img width="500" src="https://github.com/user-attachments/assets/652e841f-8e26-494d-bd4f-d2a0da7878f5" />

## After

<img width="500" src="https://github.com/user-attachments/assets/3922c29d-adb8-47d1-9c26-c6a85de8bf1c" />
