### PR TITLE
Optimize Docker image pull

### DIFF
--- a/tests/languages/docker_image_test.py
+++ b/tests/languages/docker_image_test.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from unittest.mock import patch
+
 import pytest
 
 from pre_commit.languages import docker_image
@@ -57,3 +59,35 @@ def test_docker_image_no_color_no_tty(tmp_path):
         color=False,
     )
     assert ret == (0, b'root:x:0:\n')
+
+
+@xfailif_windows  # pragma: win32 no cover
+@patch('pre_commit.lang_base.setup_cmd')
+def test_docker_image_pre_pull_regular_entry(mock_setup, tmp_path):
+    ret = run_language(
+        tmp_path,
+        docker_image,
+        'ubuntu:22.04 echo',
+        args=('hello hello world',),
+    )
+    mock_setup.assert_called_once_with(
+        mock_setup.call_args[0][0],
+        ('docker', 'pull', 'ubuntu:22.04'),
+    )
+    assert ret == (0, b'hello hello world\n')
+
+
+@xfailif_windows  # pragma: win32 no cover
+@patch('pre_commit.lang_base.setup_cmd')
+def test_docker_image_pre_pull_entrypoint_entry(mock_setup, tmp_path):
+    ret = run_language(
+        tmp_path,
+        docker_image,
+        '--entrypoint echo ubuntu:22.04',
+        args=('hello hello world',),
+    )
+    mock_setup.assert_called_once_with(
+        mock_setup.call_args[0][0],
+        ('docker', 'pull', 'ubuntu:22.04'),
+    )
+    assert ret == (0, b'hello hello world\n')


### PR DESCRIPTION
Currently `language: docker_image` will have each partition try to pull the same Docker image individually, which is unnecessarily slow because the image really only needs to be downloaded once.

This PR modifies `language: docker_image` to precache the image before running the entry command.

I tested in this repo with this hook:

```yaml
-   repo: local
    hooks:
    -   id: test
        name: Test
        entry: ubuntu:22.04 echo
        language: docker_image
        types: [text]
```

Before this PR it takes 15 seconds:

```
$ docker rmi ubuntu:22.04 &> /dev/null; pre-commit run test --all-files --verbose
Test.....................................................................Passed
- hook id: test
- duration: 14.97s

Unable to find image 'ubuntu:22.04' locally
22.04: Pulling from library/ubuntu
f85691aa4b90: Pull complete
Digest: sha256:09506232a8004baa32c47d68f1e5c307d648fdd59f5e7eaa42aaf87914100db3
Status: Image is up to date for ubuntu:22.04
pre_commit/hook.py testing/resources/logfile_repo/bin/hook.sh testing/languages tests/languages/lua_test.py pre_commit/lan
guages/python.py pre_commit/languages/dart.py pre_commit/commands/sample_config.py pre_commit/commands/migrate_config.py t
esting/resources/modified_file_returns_zero_repo/.pre-commit-hooks.yaml pre_commit/prefix.py pre_commit/resources/empty_te
mplate_setup.py tests/languages/conda_test.py tests/output_test.py tests/yaml_rewrite_test.py testing/resources/prints_cwd
_repo/.pre-commit-hooks.yaml pre_commit/resources/empty_template_main.go testing/resources/exclude_types_repo/bin/hook.sh
Unable to find image 'ubuntu:22.04' locally
22.04: Pulling from library/ubuntu
f85691aa4b90: Pull complete
Digest: sha256:09506232a8004baa32c47d68f1e5c307d648fdd59f5e7eaa42aaf87914100db3
Status: Downloaded newer image for ubuntu:22.04
tests/prefix_test.py pre_commit/languages/fail.py pre_commit/resources/empty_template_.npmignore tests/languages/__init__.
py tests/commands/init_templatedir_test.py LICENSE tests/parse_shebang_test.py tests/languages/r_test.py pre_commit/comman
ds/install_uninstall.py testing/resources/not_found_exe/.pre-commit-hooks.yaml pre_commit/yaml_rewrite.py tests/color_test
.py pre_commit/resources/__init__.py pre_commit/languages/haskell.py testing/resources/types_repo/bin/hook.sh testing/reso
urces/script_hooks_repo/bin/hook.sh tests/languages/swift_test.py
Unable to find image 'ubuntu:22.04' locally
22.04: Pulling from library/ubuntu
Digest: sha256:09506232a8004baa32c47d68f1e5c307d648fdd59f5e7eaa42aaf87914100db3
Status: Image is up to date for ubuntu:22.04
pre_commit/resources/empty_template_Makefile.PL tests/git_test.py pre_commit/languages/docker_image.py tests/conftest.py p
re_commit/languages/lua.py tests/repository_test.py tests/languages/coursier_test.py tests/commands/try_repo_test.py pre_c
ommit/store.py .github/ISSUE_TEMPLATE/01_feature.yaml pre_commit/languages/ruby.py tests/meta_hooks/check_hooks_apply_test
.py .github/workflows/languages.yaml pre_commit/main.py .gitignore testing/resources/python_hooks_repo/setup.py pre_commit
/util.py
Unable to find image 'ubuntu:22.04' locally
22.04: Pulling from library/ubuntu
f85691aa4b90: Pull complete
Digest: sha256:09506232a8004baa32c47d68f1e5c307d648fdd59f5e7eaa42aaf87914100db3
Status: Downloaded newer image for ubuntu:22.04
tests/meta_hooks/identity_test.py testing/resources/logfile_repo/.pre-commit-hooks.yaml testing/resources/system_hook_with
_spaces_repo/.pre-commit-hooks.yaml tests/logging_handler_test.py pre_commit/resources/empty_template_pre-commit-package-d
ev-1.rockspec .pre-commit-hooks.yaml pre_commit/languages/__init__.py pre_commit/languages/swift.py testing/resources/arg_
per_line_hooks_repo/bin/hook.sh pre_commit/resources/empty_template_environment.yml pre_commit/commands/try_repo.py pre_co
mmit/languages/script.py tests/store_test.py pre_commit/lang_base.py testing/get-coursier.sh setup.py testing/resources/mo
dified_file_returns_zero_repo/bin/hook.sh
Unable to find image 'ubuntu:22.04' locally
22.04: Pulling from library/ubuntu
Digest: sha256:09506232a8004baa32c47d68f1e5c307d648fdd59f5e7eaa42aaf87914100db3
Status: Downloaded newer image for ubuntu:22.04
pre_commit/languages/julia.py tests/languages/rust_test.py tests/envcontext_test.py testing/resources/python3_hooks_repo/s
etup.py tests/languages/julia_test.py pre_commit/languages/pygrep.py tests/languages/golang_test.py testing/resources/excl
ude_types_repo/.pre-commit-hooks.yaml pre_commit/constants.py pre_commit/commands/run.py tox.ini tests/languages/dotnet_te
st.py pre_commit/git.py pre_commit/envcontext.py tests/meta_hooks/__init__.py tests/commands/__init__.py pre_commit/comman
ds/autoupdate.py
Unable to find image 'ubuntu:22.04' locally
22.04: Pulling from library/ubuntu
Digest: sha256:09506232a8004baa32c47d68f1e5c307d648fdd59f5e7eaa42aaf87914100db3
Status: Image is up to date for ubuntu:22.04
testing/resources/types_or_repo/.pre-commit-hooks.yaml testing/__init__.py tests/languages/perl_test.py README.md testing/
resources/python3_hooks_repo/.pre-commit-hooks.yaml pre_commit/resources/empty_template_renv.lock tests/languages/node_tes
t.py .github/ISSUE_TEMPLATE/config.yml testing/zipapp/python pre_commit/logging_handler.py pre_commit/error_handler.py pre
_commit/resources/empty_template_activate.R tests/lang_base_test.py pre_commit/file_lock.py tests/commands/migrate_config_
test.py .github/actions/pre-test/action.yml tests/languages/python_test.py
Unable to find image 'ubuntu:22.04' locally
22.04: Pulling from library/ubuntu
Digest: sha256:09506232a8004baa32c47d68f1e5c307d648fdd59f5e7eaa42aaf87914100db3
Status: Downloaded newer image for ubuntu:22.04
pre_commit/meta_hooks/check_useless_excludes.py pre_commit/resources/empty_template_Cargo.toml pre_commit/parse_shebang.py
 tests/languages/system_test.py pre_commit/meta_hooks/check_hooks_apply.py tests/languages/dart_test.py pre_commit/command
s/init_templatedir.py pre_commit/commands/validate_config.py testing/auto_namedtuple.py tests/commands/hook_impl_test.py t
esting/resources/arbitrary_bytes_repo/hook.sh pre_commit/languages/coursier.py pre_commit/staged_files_only.py pre_commit/
resources/empty_template_package.json testing/resources/stdout_stderr_repo/tty-check-entry tests/commands/run_test.py test
ing/resources/arg_per_line_hooks_repo/.pre-commit-hooks.yaml
Unable to find image 'ubuntu:22.04' locally
22.04: Pulling from library/ubuntu
Digest: sha256:09506232a8004baa32c47d68f1e5c307d648fdd59f5e7eaa42aaf87914100db3
Status: Image is up to date for ubuntu:22.04
tests/meta_hooks/check_useless_excludes_test.py testing/zipapp/make testing/resources/modified_file_returns_zero_repo/bin/
hook2.sh testing/resources/stdout_stderr_repo/.pre-commit-hooks.yaml pre_commit/__main__.py testing/resources/types_repo/.
pre-commit-hooks.yaml testing/resources/modified_file_returns_zero_repo/bin/hook3.sh tests/commands/gc_test.py tests/langu
ages/haskell_test.py pre_commit/resources/empty_template_go.mod testing/resources/failing_hook_repo/bin/hook.sh pre_commit
/commands/validate_manifest.py tests/languages/pygrep_test.py pre_commit/languages/conda.py testing/resources/types_or_rep
o/bin/hook.sh tests/xargs_test.py pre_commit/languages/golang.py
Unable to find image 'ubuntu:22.04' locally
22.04: Pulling from library/ubuntu
Digest: sha256:09506232a8004baa32c47d68f1e5c307d648fdd59f5e7eaa42aaf87914100db3
Status: Downloaded newer image for ubuntu:22.04
tests/commands/sample_config_test.py CHANGELOG.md pre_commit/resources/empty_template_LICENSE.renv tests/languages/ruby_te
st.py testing/util.py testing/resources/arbitrary_bytes_repo/.pre-commit-hooks.yaml setup.cfg pre_commit/languages/dotnet.
py .pre-commit-config.yaml tests/commands/install_uninstall_test.py tests/commands/autoupdate_test.py tests/staged_files_o
nly_test.py testing/zipapp/Dockerfile pre_commit/output.py tests/commands/validate_manifest_test.py tests/__init__.py pre_
commit/clientlib.py
Unable to find image 'ubuntu:22.04' locally
22.04: Pulling from library/ubuntu
Digest: sha256:09506232a8004baa32c47d68f1e5c307d648fdd59f5e7eaa42aaf87914100db3
Status: Image is up to date for ubuntu:22.04
pre_commit/yaml.py testing/fixtures.py pre_commit/commands/__init__.py pre_commit/languages/rust.py .github/ISSUE_TEMPLATE
/00_bug.yaml pre_commit/languages/docker.py testing/resources/script_hooks_repo/.pre-commit-hooks.yaml pre_commit/language
s/node.py testing/resources/stdout_stderr_repo/stdout-stderr-entry pre_commit/languages/r.py pre_commit/all_languages.py .
github/workflows/main.yml tests/clientlib_test.py pre_commit/repository.py pre_commit/__init__.py tests/languages/fail_tes
t.py CONTRIBUTING.md
Unable to find image 'ubuntu:22.04' locally
22.04: Pulling from library/ubuntu
Digest: sha256:09506232a8004baa32c47d68f1e5c307d648fdd59f5e7eaa42aaf87914100db3
Status: Downloaded newer image for ubuntu:22.04
pre_commit/xargs.py pre_commit/meta_hooks/__init__.py tests/languages/docker_test.py testing/resources/python_hooks_repo/f
oo.py testing/get-dart.sh pre_commit/resources/empty_template_pre_commit_placeholder_package.gemspec tests/main_test.py re
quirements-dev.txt pre_commit/color.py pre_commit/resources/hook-tmpl testing/language_helpers.py pre_commit/meta_hooks/id
entity.py pre_commit/commands/gc.py tests/util_test.py testing/resources/failing_hook_repo/.pre-commit-hooks.yaml pre_comm
it/commands/clean.py pre_commit/commands/hook_impl.py
Unable to find image 'ubuntu:22.04' locally
22.04: Pulling from library/ubuntu
Digest: sha256:09506232a8004baa32c47d68f1e5c307d648fdd59f5e7eaa42aaf87914100db3
Status: Image is up to date for ubuntu:22.04
tests/languages/script_test.py testing/make-archives tests/error_handler_test.py pre_commit/errors.py testing/zipapp/entry
 pre_commit/languages/system.py testing/resources/python_hooks_repo/.pre-commit-hooks.yaml tests/languages/docker_image_te
st.py pre_commit/resources/empty_template_pubspec.yaml pre_commit/resources/empty_template_main.rs pre_commit/languages/pe
rl.py tests/commands/validate_config_test.py testing/resources/python3_hooks_repo/py3_hook.py tests/commands/clean_test.py
```

After this PR it takes 4 seconds:

```
$ docker rmi ubuntu:22.04 &> /dev/null; pre-commit run test --all-files --verbo
se
Test.....................................................................Passed
- hook id: test
- duration: 4.3s

pre_commit/hook.py testing/resources/logfile_repo/bin/hook.sh testing/languages tests/languages/lua_test.py pre_commit/lan
guages/python.py pre_commit/languages/dart.py pre_commit/commands/sample_config.py pre_commit/commands/migrate_config.py t
esting/resources/modified_file_returns_zero_repo/.pre-commit-hooks.yaml pre_commit/prefix.py pre_commit/resources/empty_te
mplate_setup.py tests/languages/conda_test.py tests/output_test.py tests/yaml_rewrite_test.py testing/resources/prints_cwd
_repo/.pre-commit-hooks.yaml pre_commit/resources/empty_template_main.go testing/resources/exclude_types_repo/bin/hook.sh
tests/prefix_test.py pre_commit/languages/fail.py pre_commit/resources/empty_template_.npmignore tests/languages/__init__.
py tests/commands/init_templatedir_test.py LICENSE tests/parse_shebang_test.py tests/languages/r_test.py pre_commit/comman
ds/install_uninstall.py testing/resources/not_found_exe/.pre-commit-hooks.yaml pre_commit/yaml_rewrite.py tests/color_test
.py pre_commit/resources/__init__.py pre_commit/languages/haskell.py testing/resources/types_repo/bin/hook.sh testing/reso
urces/script_hooks_repo/bin/hook.sh tests/languages/swift_test.py
pre_commit/resources/empty_template_Makefile.PL tests/git_test.py pre_commit/languages/docker_image.py tests/conftest.py p
re_commit/languages/lua.py tests/repository_test.py tests/languages/coursier_test.py tests/commands/try_repo_test.py pre_c
ommit/store.py .github/ISSUE_TEMPLATE/01_feature.yaml pre_commit/languages/ruby.py tests/meta_hooks/check_hooks_apply_test
.py .github/workflows/languages.yaml pre_commit/main.py .gitignore testing/resources/python_hooks_repo/setup.py pre_commit
/util.py
tests/meta_hooks/identity_test.py testing/resources/logfile_repo/.pre-commit-hooks.yaml testing/resources/system_hook_with
_spaces_repo/.pre-commit-hooks.yaml tests/logging_handler_test.py pre_commit/resources/empty_template_pre-commit-package-d
ev-1.rockspec .pre-commit-hooks.yaml pre_commit/languages/__init__.py pre_commit/languages/swift.py testing/resources/arg_
per_line_hooks_repo/bin/hook.sh pre_commit/resources/empty_template_environment.yml pre_commit/commands/try_repo.py pre_co
mmit/languages/script.py tests/store_test.py pre_commit/lang_base.py testing/get-coursier.sh setup.py testing/resources/mo
dified_file_returns_zero_repo/bin/hook.sh
pre_commit/languages/julia.py tests/languages/rust_test.py tests/envcontext_test.py testing/resources/python3_hooks_repo/s
etup.py tests/languages/julia_test.py pre_commit/languages/pygrep.py tests/languages/golang_test.py testing/resources/excl
ude_types_repo/.pre-commit-hooks.yaml pre_commit/constants.py pre_commit/commands/run.py tox.ini tests/languages/dotnet_te
st.py pre_commit/git.py pre_commit/envcontext.py tests/meta_hooks/__init__.py tests/commands/__init__.py pre_commit/comman
ds/autoupdate.py
testing/resources/types_or_repo/.pre-commit-hooks.yaml testing/__init__.py tests/languages/perl_test.py README.md testing/
resources/python3_hooks_repo/.pre-commit-hooks.yaml pre_commit/resources/empty_template_renv.lock tests/languages/node_tes
t.py .github/ISSUE_TEMPLATE/config.yml testing/zipapp/python pre_commit/logging_handler.py pre_commit/error_handler.py pre
_commit/resources/empty_template_activate.R tests/lang_base_test.py pre_commit/file_lock.py tests/commands/migrate_config_
test.py .github/actions/pre-test/action.yml tests/languages/python_test.py
pre_commit/meta_hooks/check_useless_excludes.py pre_commit/resources/empty_template_Cargo.toml pre_commit/parse_shebang.py
 tests/languages/system_test.py pre_commit/meta_hooks/check_hooks_apply.py tests/languages/dart_test.py pre_commit/command
s/init_templatedir.py pre_commit/commands/validate_config.py testing/auto_namedtuple.py tests/commands/hook_impl_test.py t
esting/resources/arbitrary_bytes_repo/hook.sh pre_commit/languages/coursier.py pre_commit/staged_files_only.py pre_commit/
resources/empty_template_package.json testing/resources/stdout_stderr_repo/tty-check-entry tests/commands/run_test.py test
ing/resources/arg_per_line_hooks_repo/.pre-commit-hooks.yaml
tests/meta_hooks/check_useless_excludes_test.py testing/zipapp/make testing/resources/modified_file_returns_zero_repo/bin/
hook2.sh testing/resources/stdout_stderr_repo/.pre-commit-hooks.yaml pre_commit/__main__.py testing/resources/types_repo/.
pre-commit-hooks.yaml testing/resources/modified_file_returns_zero_repo/bin/hook3.sh tests/commands/gc_test.py tests/langu
ages/haskell_test.py pre_commit/resources/empty_template_go.mod testing/resources/failing_hook_repo/bin/hook.sh pre_commit
/commands/validate_manifest.py tests/languages/pygrep_test.py pre_commit/languages/conda.py testing/resources/types_or_rep
o/bin/hook.sh tests/xargs_test.py pre_commit/languages/golang.py
tests/commands/sample_config_test.py CHANGELOG.md pre_commit/resources/empty_template_LICENSE.renv tests/languages/ruby_te
st.py testing/util.py testing/resources/arbitrary_bytes_repo/.pre-commit-hooks.yaml setup.cfg pre_commit/languages/dotnet.
py .pre-commit-config.yaml tests/commands/install_uninstall_test.py tests/commands/autoupdate_test.py tests/staged_files_o
nly_test.py testing/zipapp/Dockerfile pre_commit/output.py tests/commands/validate_manifest_test.py tests/__init__.py pre_
commit/clientlib.py
pre_commit/yaml.py testing/fixtures.py pre_commit/commands/__init__.py pre_commit/languages/rust.py .github/ISSUE_TEMPLATE
/00_bug.yaml pre_commit/languages/docker.py testing/resources/script_hooks_repo/.pre-commit-hooks.yaml pre_commit/language
s/node.py testing/resources/stdout_stderr_repo/stdout-stderr-entry pre_commit/languages/r.py pre_commit/all_languages.py .
github/workflows/main.yml tests/clientlib_test.py pre_commit/repository.py pre_commit/__init__.py tests/languages/fail_tes
t.py CONTRIBUTING.md
pre_commit/xargs.py pre_commit/meta_hooks/__init__.py tests/languages/docker_test.py testing/resources/python_hooks_repo/f
oo.py testing/get-dart.sh pre_commit/resources/empty_template_pre_commit_placeholder_package.gemspec tests/main_test.py re
quirements-dev.txt pre_commit/color.py pre_commit/resources/hook-tmpl testing/language_helpers.py pre_commit/meta_hooks/id
entity.py pre_commit/commands/gc.py tests/util_test.py testing/resources/failing_hook_repo/.pre-commit-hooks.yaml pre_comm
it/commands/clean.py pre_commit/commands/hook_impl.py
tests/languages/script_test.py testing/make-archives tests/error_handler_test.py pre_commit/errors.py testing/zipapp/entry
 pre_commit/languages/system.py testing/resources/python_hooks_repo/.pre-commit-hooks.yaml tests/languages/docker_image_te
st.py pre_commit/resources/empty_template_pubspec.yaml pre_commit/resources/empty_template_main.rs pre_commit/languages/pe
rl.py tests/commands/validate_config_test.py testing/resources/python3_hooks_repo/py3_hook.py tests/commands/clean_test.py
```

Note the before run's twelve occurrences of "Pulling from library/ubuntu" and the after run's 3.5x speed improvement.