### PR TITLE
perf: use git cat-file -e instead of git rev-list in _rev_exists

### DIFF
--- a/pre_commit/commands/hook_impl.py
+++ b/pre_commit/commands/hook_impl.py
@@ -111,7 +111,7 @@ def _ns(
 
 
 def _rev_exists(rev: str) -> bool:
-    return not subprocess.call(('git', 'rev-list', '--quiet', rev))
+    return subprocess.call(('git', 'cat-file', '-e', rev)) == 0
 
 
 def _pre_push_ns(

--- a/tests/commands/hook_impl_test.py
+++ b/tests/commands/hook_impl_test.py
@@ -91,6 +91,22 @@ def test_run_legacy_recursive(tmpdir):
             call()
 
 
+def test_rev_exists_with_existing_rev(tempdir_factory):
+    src = git_dir(tempdir_factory)
+    git_commit(cwd=src)
+    head = git.head_rev(src)
+    with cwd(src):
+        assert hook_impl._rev_exists(head) is True
+
+
+def test_rev_exists_with_nonexistent_rev(tempdir_factory):
+    src = git_dir(tempdir_factory)
+    git_commit(cwd=src)
+    with cwd(src):
+        fake_sha = 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef'
+        assert hook_impl._rev_exists(fake_sha) is False
+
+
 @pytest.mark.parametrize(
     ('hook_type', 'args'),
     (


### PR DESCRIPTION
Replace `git rev-list --quiet` with `git cat-file -e` for checking if a revision exists. This changes the operation from O(commits) to O(1).

Benchmarks (repo with ~1M commits, 5 runs each):

* git rev-list --quiet: 5159-5191ms
* git cat-file -e: 2-4ms

Both commands have the same semantics: return success if the revision exists in the local repo, failure otherwise.