### PR TITLE
use git cat-file -e instead of git rev-list in _rev_exists

### DIFF
--- a/pre_commit/commands/hook_impl.py
+++ b/pre_commit/commands/hook_impl.py
@@ -111,7 +111,7 @@ def _ns(
 
 
 def _rev_exists(rev: str) -> bool:
-    return not subprocess.call(('git', 'rev-list', '--quiet', rev))
+    return subprocess.call(('git', 'cat-file', '-e', rev)) == 0
 
 
 def _pre_push_ns(

--- a/pre_commit/commands/hook_impl.py
+++ b/pre_commit/commands/hook_impl.py
@@ -111,12 +111,10 @@ def _ns(
 
 
 def _rev_exists(rev: str) -> bool:
-    return not (
-        not subprocess.call(
-            ('git', 'cat-file', '-e', rev),
-            stderr=subprocess.DEVNULL,
-        )
-    )
+    return not bool(subprocess.call(
+        ('git', 'cat-file', '-e', rev),
+        stderr=subprocess.DEVNULL,
+    ))
 
 
 def _pre_push_ns(

--- a/pre_commit/commands/hook_impl.py
+++ b/pre_commit/commands/hook_impl.py
@@ -111,7 +111,7 @@ def _ns(
 
 
 def _rev_exists(rev: str) -> bool:
-    return subprocess.call(('git', 'cat-file', '-e', rev)) == 0
+    return subprocess.call(('git', 'cat-file', '-e', rev))
 
 
 def _pre_push_ns(

--- a/pre_commit/commands/hook_impl.py
+++ b/pre_commit/commands/hook_impl.py
@@ -111,10 +111,10 @@ def _ns(
 
 
 def _rev_exists(rev: str) -> bool:
-    return not not subprocess.call(
+    return not (not subprocess.call(
         ('git', 'cat-file', '-e', rev),
         stderr=subprocess.DEVNULL,
-    )
+    ))
 
 
 def _pre_push_ns(

--- a/pre_commit/commands/hook_impl.py
+++ b/pre_commit/commands/hook_impl.py
@@ -111,7 +111,7 @@ def _ns(
 
 
 def _rev_exists(rev: str) -> bool:
-    return subprocess.call(('git', 'cat-file', '-e', rev)) == 0
+    return subprocess.call(('git', 'cat-file', '-e', rev), stderr=subprocess.DEVNULL) == 0
 
 
 def _pre_push_ns(

--- a/pre_commit/commands/hook_impl.py
+++ b/pre_commit/commands/hook_impl.py
@@ -111,7 +111,10 @@ def _ns(
 
 
 def _rev_exists(rev: str) -> bool:
-    return subprocess.call(('git', 'cat-file', '-e', rev), stderr=subprocess.DEVNULL) == 0
+    return subprocess.call(
+        ('git', 'cat-file', '-e', rev),
+        stderr=subprocess.DEVNULL,
+    ) == 0
 
 
 def _pre_push_ns(

--- a/pre_commit/commands/hook_impl.py
+++ b/pre_commit/commands/hook_impl.py
@@ -111,10 +111,12 @@ def _ns(
 
 
 def _rev_exists(rev: str) -> bool:
-    return not bool(subprocess.call(
-        ('git', 'cat-file', '-e', rev),
-        stderr=subprocess.DEVNULL,
-    ))
+    return not bool(
+        subprocess.call(
+            ('git', 'cat-file', '-e', rev),
+            stderr=subprocess.DEVNULL,
+        ),
+    )
 
 
 def _pre_push_ns(

--- a/pre_commit/commands/hook_impl.py
+++ b/pre_commit/commands/hook_impl.py
@@ -111,7 +111,7 @@ def _ns(
 
 
 def _rev_exists(rev: str) -> bool:
-    return subprocess.call(('git', 'cat-file', '-e', rev))
+    return subprocess.call(('git', 'cat-file', '-e', rev)) == 0
 
 
 def _pre_push_ns(

--- a/pre_commit/commands/hook_impl.py
+++ b/pre_commit/commands/hook_impl.py
@@ -111,11 +111,9 @@ def _ns(
 
 
 def _rev_exists(rev: str) -> bool:
-    return not bool(
-        subprocess.call(
-            ('git', 'cat-file', '-e', rev),
-            stderr=subprocess.DEVNULL,
-        ),
+    return not subprocess.call(
+        ('git', 'cat-file', '-e', rev),
+        stderr=subprocess.DEVNULL,
     )
 
 

--- a/pre_commit/commands/hook_impl.py
+++ b/pre_commit/commands/hook_impl.py
@@ -111,10 +111,10 @@ def _ns(
 
 
 def _rev_exists(rev: str) -> bool:
-    return subprocess.call(
+    return not not subprocess.call(
         ('git', 'cat-file', '-e', rev),
         stderr=subprocess.DEVNULL,
-    ) == 0
+    )
 
 
 def _pre_push_ns(

--- a/pre_commit/commands/hook_impl.py
+++ b/pre_commit/commands/hook_impl.py
@@ -111,10 +111,12 @@ def _ns(
 
 
 def _rev_exists(rev: str) -> bool:
-    return not (not subprocess.call(
-        ('git', 'cat-file', '-e', rev),
-        stderr=subprocess.DEVNULL,
-    ))
+    return not (
+        not subprocess.call(
+            ('git', 'cat-file', '-e', rev),
+            stderr=subprocess.DEVNULL,
+        )
+    )
 
 
 def _pre_push_ns(


### PR DESCRIPTION
fixes #3604

https://git-scm.com/docs/git-cat-file

```
-e
Exit with zero status if <object> exists and is a valid object. If <object> is of an invalid format, exit with non-zero status and emit an error on stderr.

```