### PR TITLE
feature: fetch tag pointing to HEAD in shallow clone

### DIFF
--- a/pre_commit/store.py
+++ b/pre_commit/store.py
@@ -203,7 +203,7 @@ class Store:
             git.init_repo(directory, repo)
             env = git.no_git_env()
 
-            def _git_cmd(*args: str, check=True) -> None:
+            def _git_cmd(*args: str, check: bool = True) -> None:
                 cmd_output_b('git', *args, cwd=directory, env=env, check=check)
 
             try:


### PR DESCRIPTION
`pre-commit` shallow clones do not fetch tags, which leads to errors when a repository depends on tag metadata (see golangci/golangci-lint#6347).

This PR adds logic to resolve and fetch the remote tag associated with FETCH_HEAD when present.