### PR TITLE
implemented --tool flag to allow arbirary arguments to be passed

### DIFF
--- a/pre_commit/main.py
+++ b/pre_commit/main.py
@@ -311,6 +311,11 @@ def main(argv: Sequence[str] | None = None) -> int:
     run_parser = _add_cmd('run', help='Run hooks.')
     _add_config_option(run_parser)
     _add_run_options(run_parser)
+    run_parser.add_argument(
+        '--tool', action='store_true',
+        help='Run as a tool: ignores config args, implies --all-files. '
+             'Pass tool args after --.',
+    )
 
     _add_cmd('sample-config', help=f'Produce a sample {C.CONFIG_FILE} file')
 
@@ -367,7 +372,20 @@ def main(argv: Sequence[str] | None = None) -> int:
     # argparse doesn't really provide a way to use a `default` subparser
     if len(argv) == 0:
         argv = ['run']
+
+    # split off extra args after `--` for --tool mode (run command only)
+    extra_args: list[str] = []
+    argv = list(argv)
+    if argv and argv[0] == 'run':
+        try:
+            sep_idx = argv.index('--')
+            extra_args = argv[sep_idx + 1:]
+            argv = argv[:sep_idx]
+        except ValueError:
+            pass
+
     args = parser.parse_args(argv)
+    args.extra_args = extra_args
 
     if args.command == 'help' and args.help_cmd:
         parser.parse_args([args.help_cmd, '--help'])


### PR DESCRIPTION
We are using pre-commit as part of our python CI pipeline and often find we would like to use the really nice dependency management of pre-commit to include tools in various projects and invoke them in the terminal with arbitrary arguments.

Most of our tools are performing pure validation in the CI (we have a `--validate` flag we use with pre-commit) , but these tools expose other features useful to the developer.

Currently pre-commit only allows usage of the hook as a 'tool' in the terminal with 

`pre-commit run example-hook`


If we wanted different arguments passed to different invocations this requires defining each permutation as a separate entry in the `.pre-commit.config.yaml` with specific predefined arguments in `args:[...]`, which does not support using the hook as a tool with dynamic arguments.

Without having to have yet another solution to use our hooks as tools in the terminal, given pre-commit already provides 99% of the functionality we have added a `--tool` flag to our internal build of pre-commit.

`--tool` implies `allow_all_files=true` (this is a choice for our use cases but would work either way) and requires the hook is exposed for `stages:["manual"]`.

A hook can be invoked as a tool with any arbitrary arguments using:

`pre-commit run example-hook --tool -- --arg1 --arg2=4 ...`


