### PR TITLE
Remove a full stop in "Initializing environment" message

### DIFF
--- a/pre_commit/store.py
+++ b/pre_commit/store.py
@@ -157,7 +157,7 @@ class Store:
             if result:  # pragma: no cover (race)
                 return result
 
-            logger.info(f'Initializing environment for {repo}.')
+            logger.info(f'Initializing environment for {repo}')
 
             directory = tempfile.mkdtemp(prefix='repo', dir=self.directory)
             with clean_path_on_failure(directory):


### PR DESCRIPTION
This way links will work properly in GitHub UI / terminal, as dot won't be part of the link.