### PR TITLE
fix: uninstall without -t removes all pre-commit managed hooks

### DIFF
--- a/pre_commit/commands/install_uninstall.py
+++ b/pre_commit/commands/install_uninstall.py
@@ -8,6 +8,7 @@ import sys
 
 from pre_commit import git
 from pre_commit import output
+from pre_commit.clientlib import HOOK_TYPES
 from pre_commit.clientlib import InvalidConfigError
 from pre_commit.clientlib import load_config
 from pre_commit.repository import all_hooks
@@ -162,6 +163,10 @@ def _uninstall_hook_script(hook_type: str) -> None:
 
 
 def uninstall(config_file: str, hook_types: list[str] | None) -> int:
-    for hook_type in _hook_types(config_file, hook_types):
+    if hook_types is not None:
+        actual_hook_types = hook_types
+    else:
+        actual_hook_types = list(HOOK_TYPES)
+    for hook_type in actual_hook_types:
         _uninstall_hook_script(hook_type)
     return 0

--- a/tests/commands/install_uninstall_test.py
+++ b/tests/commands/install_uninstall_test.py
@@ -1102,3 +1102,26 @@ def test_install_uninstall_default_hook_types(in_git_dir, store):
     assert not uninstall(C.CONFIG_FILE, hook_types=None)
     assert not in_git_dir.join('.git/hooks/pre-commit').exists()
     assert not in_git_dir.join('.git/hooks/pre-push').exists()
+
+
+def test_uninstall_without_t_removes_all_hooks(in_git_dir, store):
+    install(C.CONFIG_FILE, store, hook_types=['pre-commit'])
+    install(C.CONFIG_FILE, store, hook_types=['pre-push'])
+    assert in_git_dir.join('.git/hooks/pre-commit').exists()
+    assert in_git_dir.join('.git/hooks/pre-push').exists()
+
+    assert not uninstall(C.CONFIG_FILE, hook_types=None)
+    assert not in_git_dir.join('.git/hooks/pre-commit').exists()
+    assert not in_git_dir.join('.git/hooks/pre-push').exists()
+
+
+def test_uninstall_without_t_ignores_non_precommit_hooks(in_git_dir, store):
+    install(C.CONFIG_FILE, store, hook_types=['pre-commit'])
+    # write a non-pre-commit hook
+    in_git_dir.join('.git/hooks/pre-push').write('#!/bin/sh\necho custom\n')
+    assert in_git_dir.join('.git/hooks/pre-push').exists()
+
+    assert not uninstall(C.CONFIG_FILE, hook_types=None)
+    assert not in_git_dir.join('.git/hooks/pre-commit').exists()
+    # non-pre-commit hook should be preserved
+    assert in_git_dir.join('.git/hooks/pre-push').exists()


### PR DESCRIPTION
## Summary

Closes #364

Thanks for maintaining this project for so long. I saw the "patches welcome" comment on #364 back in 2018 — is this kind of change still acceptable?

 `pre-commit uninstall` without `-t` only removed hooks based on `default_install_hook_types` from the config. This meant hooks installed with e.g. `-t pre-push` would silently remain unless explicitly uninstalled with `-t pre-push`.

This change makes `uninstall` without `-t` scan all known `HOOK_TYPES` and remove any managed by pre-commit (checked via `is_our_script`). Non-pre-commit hooks are left untouched.

- **`-t` specified**: behavior unchanged
- **`-t` not specified**: removes all pre-commit managed hooks
- **`install`**: behavior unchanged (still respects `default_install_hook_types`)

## Test plan

- [x] Existing uninstall tests pass
- [x] `test_uninstall_without_t_removes_all_hooks` — installs multiple hook types, uninstalls without `-t`, all removed
- [x] `test_uninstall_without_t_ignores_non_precommit_hooks` — custom hooks are preserved
