### PR TITLE
Validate log_file paths to prevent arbitrary file writes

### DIFF
--- a/pre_commit/clientlib.py
+++ b/pre_commit/clientlib.py
@@ -23,6 +23,22 @@ logger = logging.getLogger('pre_commit')
 
 check_string_regex = cfgv.check_and(cfgv.check_string, cfgv.check_regex)
 
+
+def _check_log_file(val: str) -> None:
+    if val == '':
+        return
+    if os.path.isabs(val):
+        raise cfgv.ValidationError(
+            f'log_file must be a relative path, got absolute path: {val!r}',
+        )
+    if os.path.normpath(val).startswith('..'):
+        raise cfgv.ValidationError(
+            f'log_file must not reference a parent directory: {val!r}',
+        )
+
+
+check_log_file = cfgv.check_and(cfgv.check_string, _check_log_file)
+
 HOOK_TYPES = (
     'commit-msg',
     'post-checkout',
@@ -258,7 +274,7 @@ MANIFEST_HOOK_DICT = cfgv.Map(
     cfgv.Optional('pass_filenames', cfgv.check_bool, True),
     cfgv.Optional('description', cfgv.check_string, ''),
     cfgv.Optional('language_version', cfgv.check_string, C.DEFAULT),
-    cfgv.Optional('log_file', cfgv.check_string, ''),
+    cfgv.Optional('log_file', check_log_file, ''),
     cfgv.Optional('require_serial', cfgv.check_bool, False),
     StagesMigration('stages', []),
     cfgv.Optional('verbose', cfgv.check_bool, False),

--- a/tests/clientlib_test.py
+++ b/tests/clientlib_test.py
@@ -7,6 +7,7 @@ import cfgv
 import pytest
 
 import pre_commit.constants as C
+from pre_commit.clientlib import _check_log_file
 from pre_commit.clientlib import check_type_tag
 from pre_commit.clientlib import CONFIG_HOOK_DICT
 from pre_commit.clientlib import CONFIG_REPO_DICT
@@ -605,3 +606,22 @@ def test_manifest_v5_forward_compat(tmp_path):
         f'=====> pre-commit version 5 is required but version {C.VERSION} '
         f'is installed.  Perhaps run `pip install --upgrade pre-commit`.'
     )
+
+
+@pytest.mark.parametrize('value', ('output.log', 'logs/hook.log', ''))
+def test_check_log_file_valid(value):
+    _check_log_file(value)
+
+
+@pytest.mark.parametrize(
+    'value',
+    (
+        '/tmp/evil.log',
+        '/etc/cron.d/malicious',
+        '../../../etc/passwd',
+        '../outside.log',
+    ),
+)
+def test_check_log_file_invalid(value):
+    with pytest.raises(cfgv.ValidationError):
+        _check_log_file(value)


### PR DESCRIPTION
## Summary

`log_file` in hook manifests (`.pre-commit-hooks.yaml`) accepts arbitrary strings and is passed directly to `open(logfile_name, 'ab')` in `output.write_line_b`. A malicious remote hook manifest can set `log_file` to an absolute path (e.g. `/etc/cron.d/malicious`) or use path traversal (`../../../etc/passwd`) to write hook output to arbitrary locations on the host filesystem.

## Fix

Add path validation for `log_file` in `clientlib.py` during manifest schema validation:
- Reject absolute paths
- Reject paths that normalize to a parent directory traversal (e.g. `../foo`)
- Empty string (the default) is still allowed

The validation is applied via `check_log_file` on the `MANIFEST_HOOK_DICT` schema, which also propagates to `CONFIG_HOOK_DICT` and `LOCAL_HOOK_DICT`.

## Test plan

- Added `test_check_log_file_valid` — verifies relative paths like `output.log`, `logs/hook.log`, and empty string pass validation
- Added `test_check_log_file_invalid` — verifies absolute paths and `..` traversal paths are rejected with `cfgv.ValidationError`

Fixes #3655