### PR TITLE
fix: handle ValueError from relpath on Windows cross-drive paths

### DIFF
--- a/pre_commit/main.py
+++ b/pre_commit/main.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import contextlib
 import logging
 import os
 import sys
@@ -172,6 +173,14 @@ def _add_run_options(parser: argparse.ArgumentParser) -> None:
     )
 
 
+def _try_relpath(path: str) -> str:
+    # on windows, different drives raises ValueError
+    try:
+        return os.path.relpath(path)
+    except ValueError:
+        return path
+
+
 def _adjust_args_and_chdir(args: argparse.Namespace) -> None:
     # `--config` was specified relative to the non-root working directory
     if os.path.exists(args.config):
@@ -188,15 +197,23 @@ def _adjust_args_and_chdir(args: argparse.Namespace) -> None:
     toplevel = git.get_root()
     os.chdir(toplevel)
 
-    args.config = os.path.relpath(args.config)
+    with contextlib.suppress(ValueError):
+        # on windows, different drives raises ValueError
+        args.config = os.path.relpath(args.config)
     if args.command in {'run', 'try-repo'}:
-        args.files = [os.path.relpath(filename) for filename in args.files]
+        args.files = [
+            _try_relpath(filename) for filename in args.files
+        ]
         if args.commit_msg_filename is not None:
-            args.commit_msg_filename = os.path.relpath(
-                args.commit_msg_filename,
-            )
+            with contextlib.suppress(ValueError):
+                # on windows, different drives raises ValueError
+                args.commit_msg_filename = os.path.relpath(
+                    args.commit_msg_filename,
+                )
     if args.command == 'try-repo' and os.path.exists(args.repo):
-        args.repo = os.path.relpath(args.repo)
+        with contextlib.suppress(ValueError):
+            # on windows, different drives raises ValueError
+            args.repo = os.path.relpath(args.repo)
 
 
 def main(argv: Sequence[str] | None = None) -> int:

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -78,6 +78,20 @@ def test_adjust_args_and_chdir_non_relative_config(in_git_dir):
         assert args.config == C.CONFIG_FILE
 
 
+def test_adjust_args_and_chdir_relpath_valueerror_cross_drive(in_git_dir):
+    # regression test for https://github.com/pre-commit/pre-commit/issues/2530
+    # on windows, different drives raises ValueError from relpath
+    with in_git_dir.join('foo').ensure_dir().as_cwd():
+        # use an absolute config path (simulates config on different drive)
+        args = _args(config=str(in_git_dir.join(C.CONFIG_FILE)))
+        with mock.patch.object(os.path, 'relpath', side_effect=ValueError):
+            # should not raise, should keep absolute path
+            main._adjust_args_and_chdir(args)
+        assert os.getcwd() == in_git_dir
+        # config should still be an absolute path (not relative)
+        assert os.path.isabs(args.config)
+
+
 def test_adjust_args_try_repo_repo_relative(in_git_dir):
     with in_git_dir.join('foo').ensure_dir().as_cwd():
         args = _args(command='try-repo', repo='../foo', files=[])


### PR DESCRIPTION
## Description

When the config file (or other paths) is on a different Windows drive than the git repository, `os.path.relpath` raises a `ValueError` because it cannot compute a relative path between paths on different drives.

This change wraps all `relpath` calls in `_adjust_args_and_chdir` with `ValueError` suppression, keeping the absolute path when `relpath` fails.

Fixes pre-commit/pre-commit#2530

## Testing

Added a regression test `test_adjust_args_and_chdir_relpath_valueerror_cross_drive` that simulates the cross-drive `ValueError` scenario.

All existing tests pass (29 passed, 1 skipped on Linux).