### PR TITLE
Fix ValueError on Windows when config is on different drive than git repo

### DIFF
--- a/pre_commit/main.py
+++ b/pre_commit/main.py
@@ -188,15 +188,27 @@ def _adjust_args_and_chdir(args: argparse.Namespace) -> None:
     toplevel = git.get_root()
     os.chdir(toplevel)
 
-    args.config = os.path.relpath(args.config)
+    try:
+        args.config = os.path.relpath(args.config)
+    except ValueError:
+        pass
     if args.command in {'run', 'try-repo'}:
-        args.files = [os.path.relpath(filename) for filename in args.files]
+        try:
+            args.files = [os.path.relpath(filename) for filename in args.files]
+        except ValueError:
+            pass
         if args.commit_msg_filename is not None:
-            args.commit_msg_filename = os.path.relpath(
-                args.commit_msg_filename,
-            )
+            try:
+                args.commit_msg_filename = os.path.relpath(
+                    args.commit_msg_filename,
+                )
+            except ValueError:
+                pass
     if args.command == 'try-repo' and os.path.exists(args.repo):
-        args.repo = os.path.relpath(args.repo)
+        try:
+            args.repo = os.path.relpath(args.repo)
+        except ValueError:
+            pass
 
 
 def main(argv: Sequence[str] | None = None) -> int:


### PR DESCRIPTION
Fixes #2530

On Windows, `os.path.relpath()` raises `ValueError` when the target path and the current working directory are on different drives (e.g., config on `C:` and repo on `D:`). This wraps all `os.path.relpath()` calls in `_adjust_args_and_chdir` with `try/except ValueError`, falling back to the absolute path when conversion is not possible.

As discussed in the issue, option 2 (try/except) was preferred by @asottile.