### PR TITLE
make --hook-dir optional for hook-impl

### DIFF
--- a/pre_commit/commands/hook_impl.py
+++ b/pre_commit/commands/hook_impl.py
@@ -16,7 +16,7 @@ Z40 = '0' * 40
 
 def _run_legacy(
         hook_type: str,
-        hook_dir: str,
+        hook_dir: str | None,
         args: Sequence[str],
 ) -> tuple[int, bytes]:
     if os.environ.get('PRE_COMMIT_RUNNING_LEGACY'):
@@ -32,6 +32,9 @@ def _run_legacy(
         stdin = sys.stdin.buffer.read()
     else:
         stdin = b''
+
+    if hook_dir is None:  # git 2.54+ hooks
+        return 0, stdin
 
     # not running in legacy mode
     legacy_hook = os.path.join(hook_dir, f'{hook_type}.legacy')
@@ -259,7 +262,7 @@ def hook_impl(
         config: str,
         color: bool,
         hook_type: str,
-        hook_dir: str,
+        hook_dir: str | None,
         skip_on_missing_config: bool,
         args: Sequence[str],
 ) -> int:

--- a/tests/commands/hook_impl_test.py
+++ b/tests/commands/hook_impl_test.py
@@ -63,6 +63,11 @@ def test_run_legacy_does_not_exist(tmpdir):
     assert (retv, stdin) == (0, b'')
 
 
+def test_run_legacy_git_2_54():
+    retv, stdin = hook_impl._run_legacy('pre-commit', None, ())
+    assert (retv, stdin) == (0, b'')
+
+
 def test_run_legacy_executes_legacy_script(tmpdir, capfd):
     hook = tmpdir.join('pre-commit.legacy')
     hook.write('#!/usr/bin/env bash\necho hi "$@"\nexit 1\n')


### PR DESCRIPTION
for git 2.54+ hooks it does not make sense to run legacy hooks (they will be run anyway at the original path and/or multiple commands can be configured for a single hook)

in that case we skip running them via hook-impl by not passing --hook-dir at all