### PR TITLE
fix: handle ValueError when config path is on a different drive (Windows)

### DIFF
--- a/pre_commit/main.py
+++ b/pre_commit/main.py
@@ -188,7 +188,11 @@ def _adjust_args_and_chdir(args: argparse.Namespace) -> None:
     toplevel = git.get_root()
     os.chdir(toplevel)
 
-    args.config = os.path.relpath(args.config)
+    try:
+        args.config = os.path.relpath(args.config)
+    except ValueError:
+        # on Windows, relpath fails when paths are on different drives
+        pass
     if args.command in {'run', 'try-repo'}:
         args.files = [os.path.relpath(filename) for filename in args.files]
         if args.commit_msg_filename is not None:


### PR DESCRIPTION
When `--config` points to a file on a different Windows drive than the
git repository (e.g. config at `C:\Users\...\.pre-commit-config.yaml`,
repo on `D:\`), `os.path.relpath` raises `ValueError: path is on mount
"C:", start on mount "D:"`.

Wrap the `relpath` call in a try/except so we fall back to using the
absolute path, which was already resolved earlier via `os.path.abspath`.
The absolute path works fine as a fallback.

**Before:** crash with unhandled ValueError
**After:** runs normally using absolute config path

Fixes #2530