### PR TITLE
fix: handle SHA-256 zero OID in pre-push hook

### DIFF
--- a/pre_commit/commands/hook_impl.py
+++ b/pre_commit/commands/hook_impl.py
@@ -34,7 +34,6 @@ def _get_object_format(remote_url: str) -> str:
     return 'sha1'
 
 
-
 def _run_legacy(
         hook_type: str,
         hook_dir: str | None,

--- a/pre_commit/commands/hook_impl.py
+++ b/pre_commit/commands/hook_impl.py
@@ -12,6 +12,27 @@ from pre_commit.parse_shebang import normalize_cmd
 from pre_commit.store import Store
 
 Z40 = '0' * 40
+ZERO_SHA_256 = '0' * 64  # SHA-256 zero OID
+
+
+def _get_object_format(remote_url: str) -> str:
+    """Detect git object format (sha1 or sha256) from the remote HEAD ref."""
+    try:
+        result = subprocess.run(
+            ['git', 'ls-remote', '--symref', remote_url, 'HEAD'],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        for line in result.stdout.splitlines():
+            if 'object-format=' in line:
+                for part in line.split():
+                    if part.startswith('object-format='):
+                        return part.split('=')[1].rstrip(',')
+    except (subprocess.TimeoutExpired, OSError):
+        pass
+    return 'sha1'
+
 
 
 def _run_legacy(
@@ -125,12 +146,16 @@ def _pre_push_ns(
     remote_name = args[0]
     remote_url = args[1]
 
+    # Detect the object format of the remote to use the correct zero OID
+    obj_fmt = _get_object_format(remote_url)
+    zero_sha = ZERO_SHA_256 if obj_fmt == 'sha256' else Z40
+
     for line in stdin.decode().splitlines():
         parts = line.rsplit(maxsplit=3)
         local_branch, local_sha, remote_branch, remote_sha = parts
-        if local_sha == Z40:
+        if local_sha == zero_sha:
             continue
-        elif remote_sha != Z40 and _rev_exists(remote_sha):
+        elif remote_sha != zero_sha and _rev_exists(remote_sha):
             return _ns(
                 'pre-push', color,
                 from_ref=remote_sha, to_ref=local_sha,


### PR DESCRIPTION
## Summary

Fix for issue #3664: Z40 hardcoding breaks `git push --delete` on SHA-256 repos.

### Problem

In repositories initialized with `--object-format=sha256`, git's pre-push hook protocol emits 64-character zero OIDs rather than the SHA-1 40-character `Z40`. This caused equality checks `local_sha == Z40` and `remote_sha != Z40` to never match, resulting in:

```
fatal: Invalid revision range ...000000...(x64)
fatal: Invalid symmetric difference expression ...000000...(x64)
```

Branch deletion (`git push origin --delete <branch>`) was refused on every sha256 repo.

### Solution

1. Added `ZERO_SHA_256 = '0' * 64` constant
2. Added `_get_object_format(remote_url)` function that detects SHA-256 via `git ls-remote --symref` reading the `object-format=` from HEAD symref
3. Modified `_pre_push_ns` to detect the remote's object format and use the appropriate zero SHA

### References

- Issue: pre-commit/pre-commit#3664