### PR TITLE
fix: handle SHA-256 zero OID in pre-push hook (fixes #3664)

### DIFF
--- a/pre_commit/commands/hook_impl.py
+++ b/pre_commit/commands/hook_impl.py
@@ -11,6 +11,7 @@ from pre_commit.envcontext import envcontext
 from pre_commit.parse_shebang import normalize_cmd
 from pre_commit.store import Store
 
+
 def _is_zero_oid(oid: str) -> bool:
     return len(oid) in (40, 64) and set(oid) == {'0'}
 

--- a/pre_commit/commands/hook_impl.py
+++ b/pre_commit/commands/hook_impl.py
@@ -11,6 +11,10 @@ from pre_commit.envcontext import envcontext
 from pre_commit.parse_shebang import normalize_cmd
 from pre_commit.store import Store
 
+def _is_zero_oid(oid: str) -> bool:
+    return len(oid) in (40, 64) and set(oid) == {'0'}
+
+
 Z40 = '0' * 40
 
 
@@ -128,9 +132,9 @@ def _pre_push_ns(
     for line in stdin.decode().splitlines():
         parts = line.rsplit(maxsplit=3)
         local_branch, local_sha, remote_branch, remote_sha = parts
-        if local_sha == Z40:
+        if _is_zero_oid(local_sha):
             continue
-        elif remote_sha != Z40 and _rev_exists(remote_sha):
+        elif not _is_zero_oid(remote_sha) and _rev_exists(remote_sha):
             return _ns(
                 'pre-push', color,
                 from_ref=remote_sha, to_ref=local_sha,


### PR DESCRIPTION
## Summary
When a git repo uses SHA-256 object format, git's pre-push hook emits 64-character zero OIDs instead of 40-character ones. The hardcoded `Z40 = '0' * 40` comparison never matches, causing `git push --delete` to fail with "Invalid revision range" errors.

## Fix
Added a helper function `_is_zero_oid(oid: str) -> bool` that returns `True` for both 40-character and 64-character zero OIDs. Updated the two comparison points in `_pre_push_ns` accordingly.

## Changes
- Added `_is_zero_oid` function: checks `len(oid) in (40, 64) and set(oid) == {'0'}`
- Replaced `local_sha == Z40` with `_is_zero_oid(local_sha)`
- Replaced `remote_sha != Z40` with `not _is_zero_oid(remote_sha)`

Fixes #3664