### PR TITLE
Handle SHA-256 zero OIDs in pre-push

### DIFF
--- a/pre_commit/commands/hook_impl.py
+++ b/pre_commit/commands/hook_impl.py
@@ -14,6 +14,10 @@ from pre_commit.store import Store
 Z40 = '0' * 40
 
 
+def _is_zero_oid(rev: str) -> bool:
+    return bool(rev) and set(rev) == {'0'}
+
+
 def _run_legacy(
         hook_type: str,
         hook_dir: str | None,
@@ -128,9 +132,9 @@ def _pre_push_ns(
     for line in stdin.decode().splitlines():
         parts = line.rsplit(maxsplit=3)
         local_branch, local_sha, remote_branch, remote_sha = parts
-        if local_sha == Z40:
+        if _is_zero_oid(local_sha):
             continue
-        elif remote_sha != Z40 and _rev_exists(remote_sha):
+        elif not _is_zero_oid(remote_sha) and _rev_exists(remote_sha):
             return _ns(
                 'pre-push', color,
                 from_ref=remote_sha, to_ref=local_sha,

--- a/tests/commands/hook_impl_test.py
+++ b/tests/commands/hook_impl_test.py
@@ -18,6 +18,8 @@ from testing.fixtures import write_config
 from testing.util import cwd
 from testing.util import git_commit
 
+Z64 = '0' * 64
+
 
 def test_validate_config_file_exists(tmpdir):
     cfg = tmpdir.join(C.CONFIG_FILE).ensure()
@@ -347,10 +349,43 @@ def test_run_ns_pre_push_deleting_branch(push_example):
     assert ns is None
 
 
+def test_run_ns_pre_push_deleting_branch_sha256_zero_oid(push_example):
+    src, src_head, clone, _ = push_example
+
+    with cwd(clone):
+        args = ('origin', src)
+        stdin = f'(delete) {Z64} refs/heads/b {src_head}'.encode()
+        ns = hook_impl._run_ns('pre-push', False, args, stdin)
+
+    assert ns is None
+
+
 def test_hook_impl_main_noop_pre_push(cap_out, store, push_example):
     src, src_head, clone, _ = push_example
 
     stdin = f'(delete) {hook_impl.Z40} refs/heads/b {src_head}'.encode()
+    with mock.patch.object(sys.stdin.buffer, 'read', return_value=stdin):
+        with cwd(clone):
+            write_config('.', sample_local_config())
+            ret = hook_impl.hook_impl(
+                store,
+                config=C.CONFIG_FILE,
+                color=False,
+                hook_type='pre-push',
+                hook_dir='.git/hooks',
+                skip_on_missing_config=False,
+                args=('origin', src),
+            )
+    assert ret == 0
+    assert cap_out.get() == ''
+
+
+def test_hook_impl_main_noop_pre_push_sha256_zero_oid(
+        cap_out, store, push_example,
+):
+    src, src_head, clone, _ = push_example
+
+    stdin = f'(delete) {Z64} refs/heads/b {src_head}'.encode()
     with mock.patch.object(sys.stdin.buffer, 'read', return_value=stdin):
         with cwd(clone):
             write_config('.', sample_local_config())


### PR DESCRIPTION
## Summary
- treat any all-zero object ID as the null push sentinel in `pre-push`
- keep branch deletion short-circuits working for SHA-256 repos
- add regression coverage for 64-zero delete lines in both `_run_ns()` and `hook_impl()`

Closes #3664.

## Validation
- baseline repro on current `main`: SHA-256 `pre-push` delete exited non-zero and raised `CalledProcessError` from `git diff ...<64 zeros>`
- `.venv/bin/python -m pytest tests/commands/hook_impl_test.py -k 'sha256_zero_oid' -q`
- `.venv/bin/python -m pytest tests/commands/hook_impl_test.py -k 'pre_push' -q`
- direct SHA-256 shell repro after fix: exit status `0`

## Gates
- `E1` baseline repro exists: yes
- `E2` new regression tests fail on baseline: yes
- `E3` new regression tests pass after fix: yes
- `E4` nearby targeted suite passes: yes
- `E5` diff localized to `pre_commit/commands/hook_impl.py` and `tests/commands/hook_impl_test.py`: yes
