### PR TITLE
handle sha256 zero oid in pre-push

### DIFF
--- a/pre_commit/commands/hook_impl.py
+++ b/pre_commit/commands/hook_impl.py
@@ -12,6 +12,8 @@ from pre_commit.parse_shebang import normalize_cmd
 from pre_commit.store import Store
 
 Z40 = '0' * 40
+Z64 = '0' * 64
+ZERO_OIDS = frozenset((Z40, Z64))
 
 
 def _run_legacy(
@@ -128,9 +130,9 @@ def _pre_push_ns(
     for line in stdin.decode().splitlines():
         parts = line.rsplit(maxsplit=3)
         local_branch, local_sha, remote_branch, remote_sha = parts
-        if local_sha == Z40:
+        if local_sha in ZERO_OIDS:
             continue
-        elif remote_sha != Z40 and _rev_exists(remote_sha):
+        elif remote_sha not in ZERO_OIDS and _rev_exists(remote_sha):
             return _ns(
                 'pre-push', color,
                 from_ref=remote_sha, to_ref=local_sha,

--- a/tests/commands/hook_impl_test.py
+++ b/tests/commands/hook_impl_test.py
@@ -336,21 +336,23 @@ def test_pushing_orphan_branch(push_example):
     assert ns.all_files is True
 
 
-def test_run_ns_pre_push_deleting_branch(push_example):
+@pytest.mark.parametrize('zero_oid', (hook_impl.Z40, hook_impl.Z64))
+def test_run_ns_pre_push_deleting_branch(push_example, zero_oid):
     src, src_head, clone, _ = push_example
 
     with cwd(clone):
         args = ('origin', src)
-        stdin = f'(delete) {hook_impl.Z40} refs/heads/b {src_head}'.encode()
+        stdin = f'(delete) {zero_oid} refs/heads/b {src_head}'.encode()
         ns = hook_impl._run_ns('pre-push', False, args, stdin)
 
     assert ns is None
 
 
-def test_hook_impl_main_noop_pre_push(cap_out, store, push_example):
+@pytest.mark.parametrize('zero_oid', (hook_impl.Z40, hook_impl.Z64))
+def test_hook_impl_main_noop_pre_push(cap_out, store, push_example, zero_oid):
     src, src_head, clone, _ = push_example
 
-    stdin = f'(delete) {hook_impl.Z40} refs/heads/b {src_head}'.encode()
+    stdin = f'(delete) {zero_oid} refs/heads/b {src_head}'.encode()
     with mock.patch.object(sys.stdin.buffer, 'read', return_value=stdin):
         with cwd(clone):
             write_config('.', sample_local_config())


### PR DESCRIPTION
Treat the SHA-256 zero object id as a deleted ref in pre-push

In SHA-256 repositories, Git sends 64 zeroes for a deleted ref. pre-commit was only checking the SHA-1 40-zero value, so branch deletion could continue into the diff logic

Fixes #3664

Tests:
- python -m pytest tests/commands/hook_impl_test.py -k "pre_push_deleting_branch or hook_impl_main_noop_pre_push" -q
- python -m pytest tests/commands/hook_impl_test.py -k pre_push -q
- python -m pytest tests/commands/hook_impl_test.py -q
- manual SHA-256 pre-push deletion repro