### PR TITLE
docs: fix typos in comments (interfer, targetting)

### DIFF
--- a/pre_commit/languages/julia.py
+++ b/pre_commit/languages/julia.py
@@ -49,7 +49,7 @@ def run_hook(
 def get_env_patch(target_dir: str, version: str) -> PatchesT:
     return (
         ('JULIA_LOAD_PATH', target_dir),
-        # May be set, remove it to not interfer with LOAD_PATH
+        # May be set, remove it to not interfere with LOAD_PATH
         ('JULIA_PROJECT', UNSET),
     )
 

--- a/tests/error_handler_test.py
+++ b/tests/error_handler_test.py
@@ -197,7 +197,7 @@ def test_error_handler_no_tty(tempdir_factory):
 @xfailif_windows  # pragma: win32 no cover
 def test_error_handler_read_only_filesystem(mock_store_dir, cap_out, capsys):
     # a better scenario would be if even the Store crash would be handled
-    # but realistically we're only targetting systems where the Store has
+    # but realistically we're only targeting systems where the Store has
     # already been set up
     Store()
 


### PR DESCRIPTION
Two minor comment-typo fixes spotted by codespell:

- `pre_commit/languages/julia.py`: `not interfer with LOAD_PATH` → `not interfere with LOAD_PATH`
- `tests/error_handler_test.py`: `we're only targetting systems` → `we're only targeting systems`

Comment-only changes; no behavior or test logic affected.

### Verification
- `python -m pytest tests/error_handler_test.py` → 10 passed
- `from pre_commit.languages import julia; julia.get_env_patch(...)` still returns the same `PatchesT`