### PR TITLE
Use a permanent directory for RUSTUP_HOME

### DIFF
--- a/pre_commit/languages/rust.py
+++ b/pre_commit/languages/rust.py
@@ -82,7 +82,7 @@ def _add_dependencies(
 
 def install_rust_with_toolchain(toolchain: str, envdir: str) -> None:
     with tempfile.TemporaryDirectory() as rustup_dir:
-        with envcontext((('CARGO_HOME', envdir), ('RUSTUP_HOME', rustup_dir))):
+        with envcontext((('CARGO_HOME', envdir), ('RUSTUP_HOME', envdir))):
             # acquire `rustup` if not present
             if parse_shebang.find_executable('rustup') is None:
                 # We did not detect rustup and need to download it first.


### PR DESCRIPTION
`rustup` installs the toolchain in RUSTUP_HOME, so we need it to be a permanent directory, and not a temporary one, to ensure that the toolchain isn't deleted after it is installed.