### PR TITLE
Fix config path handling across Windows drives

### DIFF
--- a/pre_commit/main.py
+++ b/pre_commit/main.py
@@ -47,6 +47,13 @@ COMMANDS_NO_GIT = {
 }
 
 
+def _relpath(path: str) -> str:
+    try:
+        return os.path.relpath(path)
+    except ValueError:  # Windows paths on different drives.
+        return path
+
+
 def _add_config_option(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         '-c', '--config', default=C.CONFIG_FILE,
@@ -188,15 +195,13 @@ def _adjust_args_and_chdir(args: argparse.Namespace) -> None:
     toplevel = git.get_root()
     os.chdir(toplevel)
 
-    args.config = os.path.relpath(args.config)
+    args.config = _relpath(args.config)
     if args.command in {'run', 'try-repo'}:
-        args.files = [os.path.relpath(filename) for filename in args.files]
+        args.files = [_relpath(filename) for filename in args.files]
         if args.commit_msg_filename is not None:
-            args.commit_msg_filename = os.path.relpath(
-                args.commit_msg_filename,
-            )
+            args.commit_msg_filename = _relpath(args.commit_msg_filename)
     if args.command == 'try-repo' and os.path.exists(args.repo):
-        args.repo = os.path.relpath(args.repo)
+        args.repo = _relpath(args.repo)
 
 
 def main(argv: Sequence[str] | None = None) -> int:

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -78,6 +78,19 @@ def test_adjust_args_and_chdir_non_relative_config(in_git_dir):
         assert args.config == C.CONFIG_FILE
 
 
+@pytest.mark.skipif(os.name != 'nt', reason='windows feature')
+def test_adjust_args_and_chdir_config_on_different_drive(in_git_dir):
+    drive, _ = os.path.splitdrive(str(in_git_dir))
+    other_drive = 'Z:' if drive.upper() != 'Z:' else 'Y:'
+    config = other_drive + r'\cfg.yaml'
+
+    args = _args(config=config)
+    main._adjust_args_and_chdir(args)
+
+    assert os.getcwd() == in_git_dir
+    assert args.config == config
+
+
 def test_adjust_args_try_repo_repo_relative(in_git_dir):
     with in_git_dir.join('foo').ensure_dir().as_cwd():
         args = _args(command='try-repo', repo='../foo', files=[])


### PR DESCRIPTION
Fixes #2530.

## Summary

This fixes a Windows path handling error when `--config` points to a file on a different drive from the repository root.

`os.path.relpath` raises `ValueError` for paths on different Windows drives, so this keeps the original absolute path when a relative path cannot be computed.

## Tests

Added a Windows regression test for `--config` on another drive.

Validation run locally:

```text
python -m pytest tests/main_test.py -k different_drive
python -m pytest tests/main_test.py -k adjust_args_and_chdir
python -m pytest tests/main_test.py
python -m py_compile pre_commit/main.py tests/main_test.py
git diff --check
