### PR TITLE
fix: handle SHA-256 zero OIDs in pre-push hook

### DIFF
--- a/pre_commit/commands/hook_impl.py
+++ b/pre_commit/commands/hook_impl.py
@@ -11,6 +11,12 @@ from pre_commit.envcontext import envcontext
 from pre_commit.parse_shebang import normalize_cmd
 from pre_commit.store import Store
 
+
+def _is_zero_oid(oid: str) -> bool:
+    """Returns True if oid is an all-zero OID of a supported git hash length."""
+    return len(oid) in (40, 64) and set(oid) == {'0'}
+
+
 Z40 = '0' * 40
 
 
@@ -128,9 +134,9 @@ def _pre_push_ns(
     for line in stdin.decode().splitlines():
         parts = line.rsplit(maxsplit=3)
         local_branch, local_sha, remote_branch, remote_sha = parts
-        if local_sha == Z40:
+        if _is_zero_oid(local_sha):
             continue
-        elif remote_sha != Z40 and _rev_exists(remote_sha):
+        elif not _is_zero_oid(remote_sha) and _rev_exists(remote_sha):
             return _ns(
                 'pre-push', color,
                 from_ref=remote_sha, to_ref=local_sha,

--- a/tests/commands/hook_impl_test.py
+++ b/tests/commands/hook_impl_test.py
@@ -347,6 +347,20 @@ def test_run_ns_pre_push_deleting_branch(push_example):
     assert ns is None
 
 
+def test_run_ns_pre_push_deleting_branch_sha256(push_example):
+    """Regression test for #3664 — deletion push with SHA-256 zero OID."""
+    src, src_head, clone, _ = push_example
+
+    with cwd(clone):
+        args = ('origin', src)
+        # SHA-256 zero OID (64 chars) instead of SHA-1 zero OID (40 chars)
+        sha256_zero = '0' * 64
+        stdin = f'(delete) {sha256_zero} refs/heads/b {src_head}'.encode()
+        ns = hook_impl._run_ns('pre-push', False, args, stdin)
+
+    assert ns is None
+
+
 def test_hook_impl_main_noop_pre_push(cap_out, store, push_example):
     src, src_head, clone, _ = push_example
 


### PR DESCRIPTION
## Fix SHA-256 zero OID handling in pre-push hook

In repositories initialized with `--object-format=sha256`, git's pre-push hook protocol emits 64-character zero OIDs instead of the SHA-1 40-character variety. The previous hardcoded check

```python
Z40 = '0' * 40
if local_sha == Z40:
```

never matched in SHA-256 repos, causing `git push --delete` to fail with:

```
fatal: Invalid symmetric difference expression <sha>...<64-zeros>
```

Add `_is_zero_oid()` as a hash-format-agnostic helper that accepts zero OIDs of either supported length (40 or 64), replacing the hardcoded `Z40` constant in `_pre_push_ns`.

Also adds `test_run_ns_pre_push_deleting_branch_sha256` as a regression test for the SHA-256 deletion push case.

Fixes #3664