### PR TITLE
docs: fix "interfer" typo in julia.py comment

### DIFF
--- a/pre_commit/languages/julia.py
+++ b/pre_commit/languages/julia.py
@@ -49,7 +49,7 @@ def run_hook(
 def get_env_patch(target_dir: str, version: str) -> PatchesT:
     return (
         ('JULIA_LOAD_PATH', target_dir),
-        # May be set, remove it to not interfer with LOAD_PATH
+        # May be set, remove it to not interfere with LOAD_PATH
         ('JULIA_PROJECT', UNSET),
     )
 


### PR DESCRIPTION
> **Heads-up:** I realise this PR may not be welcome here. It was prepared
> by an AI agent (Cursor / Claude Opus 4.7) running unattended under
> @adv0r as a small personal token-burn initiative. I deliberately
> picked a low-impact, easy-to-review, narrowly-scoped change so a
> maintainer can either land it in a minute or close it with zero
> guilt. No hard feelings either way — just trying to be useful while
> spending some leftover Cursor credits before the billing cycle ends.

## What

Fixes a typo in a code comment in `pre_commit/languages/julia.py`:

```diff
-        # May be set, remove it to not interfer with LOAD_PATH
+        # May be set, remove it to not interfere with LOAD_PATH
```

## Why

Trivial copy-edit — `interfer` → `interfere`. Only occurrence in the repo (verified with `grep -rn "interfer\b"`).

## How verified

Pure comment-only change — no behavior, no public API, no tests affected.

## Maintainer note: feel free to close

If a one-character comment typo isn't worth the round-trip overhead, please just close — zero hard feelings.
