### PR TITLE
Handle SHA-256 zero OIDs in pre-push

### DIFF
--- a/pre_commit/commands/hook_impl.py
+++ b/pre_commit/commands/hook_impl.py
@@ -14,6 +14,10 @@ from pre_commit.store import Store
 Z40 = '0' * 40
 
 
+def _is_zero_oid(oid: str) -> bool:
+    return len(oid) in {40, 64} and oid == '0' * len(oid)
+
+
 def _run_legacy(
         hook_type: str,
         hook_dir: str | None,
@@ -128,9 +132,9 @@ def _pre_push_ns(
     for line in stdin.decode().splitlines():
         parts = line.rsplit(maxsplit=3)
         local_branch, local_sha, remote_branch, remote_sha = parts
-        if local_sha == Z40:
+        if _is_zero_oid(local_sha):
             continue
-        elif remote_sha != Z40 and _rev_exists(remote_sha):
+        elif not _is_zero_oid(remote_sha) and _rev_exists(remote_sha):
             return _ns(
                 'pre-push', color,
                 from_ref=remote_sha, to_ref=local_sha,

--- a/tests/commands/hook_impl_test.py
+++ b/tests/commands/hook_impl_test.py
@@ -253,6 +253,14 @@ def test_run_ns_post_checkout():
     assert ns.checkout_type == 'c'
 
 
+def test_is_zero_oid():
+    assert hook_impl._is_zero_oid(hook_impl.Z40)
+    assert hook_impl._is_zero_oid('0' * 64)
+    assert not hook_impl._is_zero_oid('0' * 39)
+    assert not hook_impl._is_zero_oid('0' * 63)
+    assert not hook_impl._is_zero_oid('1'.zfill(40))
+
+
 @pytest.fixture
 def push_example(tempdir_factory):
     src = git_dir(tempdir_factory)
@@ -342,6 +350,17 @@ def test_run_ns_pre_push_deleting_branch(push_example):
     with cwd(clone):
         args = ('origin', src)
         stdin = f'(delete) {hook_impl.Z40} refs/heads/b {src_head}'.encode()
+        ns = hook_impl._run_ns('pre-push', False, args, stdin)
+
+    assert ns is None
+
+
+def test_run_ns_pre_push_deleting_branch_sha256(push_example):
+    src, src_head, clone, _ = push_example
+
+    with cwd(clone):
+        args = ('origin', src)
+        stdin = f'(delete) {"0" * 64} refs/heads/b {src_head}'.encode()
         ns = hook_impl._run_ns('pre-push', False, args, stdin)
 
     assert ns is None


### PR DESCRIPTION
Fixes #3664.

## Summary

- Recognize both SHA-1 (40 hex) and SHA-256 (64 hex) all-zero object IDs in the pre-push hook protocol.
- Keep deletion-only pushes as no-op pre-push runs instead of constructing a diff against a zero object ID.
- Add regression coverage for SHA-256 branch deletion stdin while preserving the existing SHA-1 deletion behavior.

## Verification

- `python -m pytest tests\commands\hook_impl_test.py -k "zero_oid or pre_push" -q` passed: 9 passed.
- `python -m pytest tests\commands\hook_impl_test.py -k "not legacy" -q` passed: 41 passed, 5 deselected.
- `python -m compileall -q pre_commit\commands\hook_impl.py tests\commands\hook_impl_test.py` passed.
- `git diff --check` passed.
- `SKIP=mypy pre-commit run --files pre_commit\commands\hook_impl.py tests\commands\hook_impl_test.py` passed all non-mypy hooks.

Windows-local notes:

- `python -m pytest tests\commands\hook_impl_test.py -q` reported 45 passed and 1 failed because `test_run_legacy_executes_legacy_script` needs `bash`, which is not available in this Windows environment.
- The full `mypy` pre-commit hook reported existing Windows/platform-specific errors in unrelated modules (`pre_commit\color.py`, `pre_commit\xargs.py`, `pre_commit\languages\docker.py`) while checking these files.