### PR TITLE
deduplicate filenames from `git ls-files` during conflicts

### DIFF
--- a/pre_commit/git.py
+++ b/pre_commit/git.py
@@ -152,7 +152,8 @@ def intent_to_add_files() -> list[str]:
 
 
 def get_all_files() -> list[str]:
-    return zsplit(cmd_output('git', 'ls-files', '-z')[1])
+    # git ls-files lists unmerged paths once per stage -- deduplicate (#3706)
+    return list(dict.fromkeys(zsplit(cmd_output('git', 'ls-files', '-z')[1])))
 
 
 def get_changed_files(old: str, new: str) -> list[str]:

--- a/tests/git_test.py
+++ b/tests/git_test.py
@@ -228,7 +228,9 @@ def test_all_files_non_ascii(non_ascii_repo):
 def test_all_files_deduplicates_in_merge_conflict(in_merge_conflict):
     # git ls-files lists each unmerged path once per stage; #3706
     ret = git.get_all_files()
-    assert ret == ['conflict_file']
+    # The fixture contains multiple tracked files; the bug is duplication
+    assert ret.count('conflict_file') == 1
+    assert len(ret) == len(set(ret))
 
 
 def test_staged_files_non_ascii(non_ascii_repo):

--- a/tests/git_test.py
+++ b/tests/git_test.py
@@ -225,6 +225,13 @@ def test_all_files_non_ascii(non_ascii_repo):
     assert ret == ['интервью']
 
 
+def test_all_files_deduplicates_in_merge_conflict(in_merge_conflict):
+    # git ls-files lists each unmerged path once per stage; #3706
+    ret = git.get_all_files()
+    assert ret == ['conflict_file']
+
+
+
 def test_staged_files_non_ascii(non_ascii_repo):
     non_ascii_repo.join('интервью').write('hi')
     cmd_output('git', 'add', '.')

--- a/tests/git_test.py
+++ b/tests/git_test.py
@@ -231,7 +231,6 @@ def test_all_files_deduplicates_in_merge_conflict(in_merge_conflict):
     assert ret == ['conflict_file']
 
 
-
 def test_staged_files_non_ascii(non_ascii_repo):
     non_ascii_repo.join('интервью').write('hi')
     cmd_output('git', 'add', '.')


### PR DESCRIPTION
pre-commit run --all-files lists conflicted paths multiple times because `git ls-files -z` returns one entry per stage for unmerged files. De-duplicated with `dict.fromkeys` to preserve order. Existing `in_merge_conflict` fixture covers the test.

Fixes #3706