### PR TITLE
fix: remove deprecated --ignore-prepublish from npm install

### DIFF
--- a/pre_commit/languages/node.py
+++ b/pre_commit/languages/node.py
@@ -94,7 +94,7 @@ def install_environment(
 
         local_install_cmd = (
             'npm', 'install', '--include=dev', '--include=prod',
-            '--ignore-prepublish', '--no-progress', '--no-save',
+            '--no-progress', '--no-save',
         )
         lang_base.setup_cmd(prefix, local_install_cmd)
 


### PR DESCRIPTION
  npm 8 started barking warnings about this flag in CI.
  not worth the noise, just dropped it.

  ---
  PR description:
  npm 8 deprecated `--ignore-prepublish` and now it screams warnings at us:

  > Unknown cli config "--ignore-prepublish". This will stop working in the next major version of npm.

  Our CI treats warnings as errors so it was breaking builds. Simple fix — just
  remove the flag from the node language installer. The other npm flags are
  unaffected.

  fixes #3517

  ---