### PR TITLE
feat: Add `--no-fail-fast` CLI option to override fail-fast behavior

### DIFF
--- a/pre_commit/commands/hook_impl.py
+++ b/pre_commit/commands/hook_impl.py
@@ -110,6 +110,7 @@ def _ns(
         verbose=False,
         show_diff_on_failure=False,
         fail_fast=False,
+        no_fail_fast=False,
     )
 
 

--- a/pre_commit/commands/run.py
+++ b/pre_commit/commands/run.py
@@ -298,7 +298,10 @@ def _run_hooks(
             verbose=args.verbose, use_color=args.color,
         )
         retval |= current_retval
-        fail_fast = (config['fail_fast'] or hook.fail_fast or args.fail_fast)
+        fail_fast = (
+            (config['fail_fast'] or hook.fail_fast or args.fail_fast) and
+            not args.no_fail_fast
+        )
         if current_retval and fail_fast:
             break
     if retval and args.show_diff_on_failure and prior_diff:

--- a/pre_commit/main.py
+++ b/pre_commit/main.py
@@ -77,9 +77,14 @@ def _add_run_options(parser: argparse.ArgumentParser) -> None:
         '--show-diff-on-failure', action='store_true',
         help='When hooks fail, run `git diff` directly afterward.',
     )
-    parser.add_argument(
+    fail_fast_group = parser.add_mutually_exclusive_group(required=False)
+    fail_fast_group.add_argument(
         '--fail-fast', action='store_true',
         help='Stop after the first failing hook.',
+    )
+    fail_fast_group.add_argument(
+        '--no-fail-fast', action='store_true',
+        help="Don't stop after the first failing hook.",
     )
     parser.add_argument(
         '--hook-stage',

--- a/testing/util.py
+++ b/testing/util.py
@@ -41,6 +41,7 @@ def run_opts(
         verbose=False,
         hook=None,
         fail_fast=False,
+        no_fail_fast=False,
         remote_branch='',
         local_branch='',
         from_ref='',
@@ -60,6 +61,7 @@ def run_opts(
 ):
     # These are mutually exclusive
     assert not (all_files and files)
+    assert not (fail_fast and no_fail_fast)
     return auto_namedtuple(
         all_files=all_files,
         files=files,
@@ -67,6 +69,7 @@ def run_opts(
         verbose=verbose,
         hook=hook,
         fail_fast=fail_fast,
+        no_fail_fast=no_fail_fast,
         remote_branch=remote_branch,
         local_branch=local_branch,
         from_ref=from_ref,

--- a/tests/commands/hook_impl_test.py
+++ b/tests/commands/hook_impl_test.py
@@ -384,3 +384,19 @@ def test_hook_impl_main_runs_hooks(cap_out, tempdir_factory, store):
 Block if "DO NOT COMMIT" is found....................(no files to check)Skipped
 '''
     assert cap_out.get() == expected
+
+
+def test_hook_impl_with_fail_fast(cap_out, tempdir_factory, store):
+    with cwd(git_dir(tempdir_factory)):
+        config = {'fail_fast': True, 'repos': [sample_local_config()]}
+        write_config('.', config)
+        ret = hook_impl.hook_impl(
+            store,
+            config=C.CONFIG_FILE,
+            color=False,
+            hook_type='pre-commit',
+            hook_dir='.git/hooks',
+            skip_on_missing_config=False,
+            args=(),
+        )
+    assert ret == 0

--- a/tests/commands/run_test.py
+++ b/tests/commands/run_test.py
@@ -1117,6 +1117,32 @@ def test_fail_fast_run_arg(cap_out, store, repo_with_failing_hook):
     assert printed.count(b'Failing hook') == 1
 
 
+def test_no_fail_fast_config_override(cap_out, store, repo_with_failing_hook):
+    with modify_config() as config:
+        config['fail_fast'] = True
+        config['repos'][0]['hooks'] *= 2
+    stage_a_file()
+
+    ret, printed = _do_run(
+        cap_out, store, repo_with_failing_hook, run_opts(no_fail_fast=True),
+    )
+    # it should run both hooks because of the no-fail-fast override
+    assert printed.count(b'Failing hook') == 2
+
+
+def test_no_fail_fast_hook_override(cap_out, store, repo_with_failing_hook):
+    with modify_config() as config:
+        config['repos'][0]['hooks'] *= 2
+        config['repos'][0]['hooks'][0]['fail_fast'] = True
+    stage_a_file()
+
+    ret, printed = _do_run(
+        cap_out, store, repo_with_failing_hook, run_opts(no_fail_fast=True),
+    )
+    # it should run both hooks because of the no-fail-fast override
+    assert printed.count(b'Failing hook') == 2
+
+
 def test_classifier_removes_dne():
     classifier = Classifier(('this_file_does_not_exist',))
     assert classifier.filenames == []

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -239,3 +239,8 @@ def test_hook_stage_migration(mock_store_dir):
     with mock.patch.object(main, 'run') as mck:
         main.main(('run', '--hook-stage', 'commit'))
     assert mck.call_args[0][2].hook_stage == 'pre-commit'
+
+
+def test_fail_fast_mutual_exclusion(mock_store_dir):
+    with pytest.raises(SystemExit):
+        main.main(('run', '--fail-fast', '--no-fail-fast'))


### PR DESCRIPTION
Introduce a mutually exclusive `--no-fail-fast` CLI argument alongside `--fail-fast`. 

This option allows disabling fail-fast behavior even if it has been enabled globally in the config or at the individual hook level. 
Also update hook-impl to safely support the no_fail_fast attribute.