### PR TITLE
set `JULIA_DEPOT_PATH`

### DIFF
--- a/pre_commit/languages/julia.py
+++ b/pre_commit/languages/julia.py
@@ -51,6 +51,13 @@ def get_env_patch(target_dir: str, version: str) -> PatchesT:
         ('JULIA_LOAD_PATH', target_dir),
         # May be set, remove it to not interfer with LOAD_PATH
         ('JULIA_PROJECT', UNSET),
+        # Keep the package depot inside the hook environment so installed
+        # packages and precompile caches persist with the env instead of
+        # leaking into a shared depot. The trailing separator leaves an empty
+        # entry, which julia expands to its default depots. This keeps the
+        # bundled stdlib resources (and their precompile caches) available so
+        # hooks don't recompile from scratch on first run.
+        ('JULIA_DEPOT_PATH', os.path.join(target_dir, 'depot') + os.pathsep),
     )
 
 

--- a/tests/languages/julia_test.py
+++ b/tests/languages/julia_test.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import os
 from unittest import mock
 
+from pre_commit import constants as C
 from pre_commit.languages import julia
+from pre_commit.prefix import Prefix
 from testing.language_helpers import run_language
 from testing.util import cwd
 
@@ -40,6 +42,19 @@ def test_julia_hook_with_startup(tmp_path):
     depo_path_var = f'{depot_path}{os.pathsep}'
     with mock.patch.dict(os.environ, {'JULIA_DEPOT_PATH': depo_path_var}):
         test_julia_hook(tmp_path)
+
+
+def test_julia_hook_installs_into_env_local_depot(tmp_path):
+    code = """
+    using Example
+    println("Hello, world!")
+    """
+    _make_hook(tmp_path, code)
+
+    julia.install_environment(Prefix(str(tmp_path)), C.DEFAULT, ())
+
+    d = tmp_path.joinpath('juliaenv-default', 'depot', 'packages', 'Example')
+    assert d.is_dir()
 
 
 def test_julia_hook_manifest(tmp_path):


### PR DESCRIPTION
This PR pins Julia's package depot to the per-hook environment directory by setting
`JULIA_DEPOT_PATH` in `get_env_patch`, instead of leaving it at its default (`~/.julia`).

I believe this is required for `julia` to fully qualify as a second-class language:
https://github.com/pre-commit/pre-commit/blob/1553b465fd7ea42321ae0d04d1b41e706b89ae45/CONTRIBUTING.md#L68-L70

This surfaced in a review from @asottile of https://github.com/pre-commit-ci/runner-image/pull/335.

Details about `JULIA_DEPOT_PATH` are available [here](https://docs.julialang.org/en/v1/manual/environment-variables/#JULIA_DEPOT_PATH).