### PR TITLE
fix: fix capitalization and grammar in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,7 +90,7 @@ language, for example:
 
 ### `language` api
 
-here are the apis that should be implemented for a language
+Here are the APIs that should be implemented for a language
 
 Note that these are also documented in [`pre_commit/lang_base.py`](https://github.com/pre-commit/pre-commit/blob/main/pre_commit/lang_base.py)
 


### PR DESCRIPTION
Fixed sentence starting with lowercase 'here are the apis' to proper capitalization 'Here are the APIs'.