### PR TITLE
Remove deprecated npm ignore-prepublish option

### DIFF
--- a/pre_commit/languages/node.py
+++ b/pre_commit/languages/node.py
@@ -94,7 +94,7 @@ def install_environment(
 
         local_install_cmd = (
             'npm', 'install', '--include=dev', '--include=prod',
-            '--ignore-prepublish', '--no-progress', '--no-save',
+            '--no-progress', '--no-save',
         )
         lang_base.setup_cmd(prefix, local_install_cmd)
 

--- a/tests/languages/node_test.py
+++ b/tests/languages/node_test.py
@@ -139,6 +139,24 @@ def test_node_with_user_config_set(tmp_path):
         test_node_hook_system(tmp_path)
 
 
+def test_local_install_does_not_use_ignore_prepublish(tmp_path):
+    tmp_path.joinpath('package.json').write_text('{"name": "t"}')
+    prefix = Prefix(str(tmp_path))
+
+    with mock.patch.object(node, 'cmd_output_b'), mock.patch.object(
+            node.lang_base, 'setup_cmd',
+    ) as setup_cmd, mock.patch.object(
+            node, 'cmd_output', return_value=(0, 'package.tgz\n', ''),
+    ), mock.patch.object(node.os, 'remove'):
+        node.install_environment(prefix, 'system', ())
+
+    local_install_cmd = setup_cmd.call_args_list[0].args[1]
+    assert local_install_cmd == (
+        'npm', 'install', '--include=dev', '--include=prod',
+        '--no-progress', '--no-save',
+    )
+
+
 @pytest.mark.parametrize('version', (C.DEFAULT, '18.14.0'))
 def test_node_hook_versions(tmp_path, version):
     _make_hello_world(tmp_path)


### PR DESCRIPTION
Remove the deprecated `--ignore-prepublish` flag from the local `npm install` command used while installing node hook environments.

The flag now produces npm warnings and is not needed for the local install path, which already keeps the existing `--include=dev`, `--include=prod`, `--no-progress`, and `--no-save` options.

Validation:
- `/Volumes/STOREJET/2/Dependencies/pre-commit-py314-venv/bin/python -m pytest tests/languages/node_test.py -q -k "local_install_does_not_use_ignore_prepublish or sets_system_when_node_and_npm_are_available or uses_default_when_node_and_npm_are_not_available or sets_default_on_windows"`
- `/Volumes/STOREJET/2/Dependencies/pre-commit-py314-venv/bin/python -m py_compile pre_commit/languages/node.py tests/languages/node_test.py`
- `git diff --check`

I also ran the full `tests/languages/node_test.py` with `NPM_CONFIG_CACHE` redirected into this checkout. It reached 10 passed / 2 failed; the remaining failures were local environment issues unrelated to this change: one platform-specific `node --version` return code expectation (`126` vs `127`) and one npm cache hardlink failure on the external volume.

Fixes #3517
