### PR TITLE
autoupdate: report unmatched repos passed via --repos

### DIFF
--- a/pre_commit/commands/autoupdate.py
+++ b/pre_commit/commands/autoupdate.py
@@ -180,6 +180,15 @@ def autoupdate(
     jobs = jobs or xargs.cpu_count()  # 0 => number of cpus
     jobs = min(jobs, len(repos) or len(config_repos))  # max 1-per-thread
     jobs = max(jobs, 1)  # at least one thread
+
+    if repos:
+        config_repo_urls = {repo['repo'] for repo in config_repos}
+        unmatched = [repo for repo in repos if repo not in config_repo_urls]
+        for repo in unmatched:
+            output.write_line(f'[{repo}] not found in {config_file}')
+        if unmatched and not (set(repos) & config_repo_urls):
+            return 1
+
     with concurrent.futures.ThreadPoolExecutor(jobs) as exe:
         futures = [
             exe.submit(

--- a/tests/commands/autoupdate_test.py
+++ b/tests/commands/autoupdate_test.py
@@ -277,8 +277,31 @@ def test_autoupdate_out_of_date_repo_with_wrong_repo_name(
     )
     with open(C.CONFIG_FILE) as f:
         after = f.read()
-    assert ret == 0
+    assert ret == 1
     assert before == after
+
+
+def test_autoupdate_with_some_matched_some_unmatched_repos(
+        out_of_date, in_tmpdir,
+):
+    repo_name = f'file://{out_of_date.path}'
+    config = make_config_from_repo(
+        out_of_date.path, rev=out_of_date.original_rev, check=False,
+    )
+    write_config('.', config)
+
+    with open(C.CONFIG_FILE) as f:
+        before = f.read()
+    # 'dne' does not match any repo but repo_name does, so update proceeds
+    ret = autoupdate(
+        C.CONFIG_FILE, freeze=False, tags_only=False,
+        repos=(repo_name, 'dne'),
+    )
+    with open(C.CONFIG_FILE) as f:
+        after = f.read()
+    assert ret == 0
+    assert before != after
+    assert out_of_date.head_rev in after
 
 
 def test_does_not_reformat(tmpdir, out_of_date):


### PR DESCRIPTION
Fixes #3695. When `pre-commit autoupdate --repos` is passed repo URLs that do not match any repo in the config, the command currently exits silently with return code 0. This PR adds a diagnostic message for each unmatched repo and returns exit code 1 when no repos match at all. If at least one repo matches, the update proceeds normally (exit code 0) and unmatched repos are reported as warnings.

## Changes
- `pre_commit/commands/autoupdate.py`: added unmatched repo detection before the ThreadPoolExecutor block
- `tests/commands/autoupdate_test.py`: updated `test_autoupdate_out_of_date_repo_with_wrong_repo_name` to assert ret == 1, added `test_autoupdate_with_some_matched_some_unmatched_repos`