### PR TITLE
feat: report unmatched repos passed to autoupdate --repos

### DIFF
--- a/pre_commit/commands/autoupdate.py
+++ b/pre_commit/commands/autoupdate.py
@@ -176,6 +176,11 @@ def autoupdate(
         if repo['repo'] not in {LOCAL, META}
     ]
 
+    if repos:
+        config_repo_names = {repo['repo'] for repo in config_repos}
+        for repo in sorted(set(repos) - config_repo_names):
+            output.write_line(f"repo '{repo}' is not in the config")
+
     rev_infos: list[RevInfo | None] = [None] * len(config_repos)
     jobs = jobs or xargs.cpu_count()  # 0 => number of cpus
     jobs = min(jobs, len(repos) or len(config_repos))  # max 1-per-thread

--- a/tests/commands/autoupdate_test.py
+++ b/tests/commands/autoupdate_test.py
@@ -261,7 +261,7 @@ def test_autoupdate_out_of_date_repo_with_correct_repo_name(
 
 
 def test_autoupdate_out_of_date_repo_with_wrong_repo_name(
-        out_of_date, in_tmpdir,
+        out_of_date, in_tmpdir, cap_out,
 ):
     config = make_config_from_repo(
         out_of_date.path, rev=out_of_date.original_rev, check=False,
@@ -279,6 +279,29 @@ def test_autoupdate_out_of_date_repo_with_wrong_repo_name(
         after = f.read()
     assert ret == 0
     assert before == after
+    assert cap_out.get() == "repo 'dne' is not in the config\n"
+
+
+def test_autoupdate_out_of_date_repo_with_some_wrong_repo_names(
+        up_to_date, out_of_date, in_tmpdir, cap_out,
+):
+    stale_config = make_config_from_repo(
+        out_of_date.path, rev=out_of_date.original_rev, check=False,
+    )
+    up_to_date_config = make_config_from_repo(
+        up_to_date, rev=git.head_rev(up_to_date), check=False,
+    )
+    write_config('.', {'repos': [stale_config, up_to_date_config]})
+
+    ret = autoupdate(
+        C.CONFIG_FILE, freeze=False, tags_only=False,
+        repos=(f'file://{up_to_date}', 'dne', 'other'),
+    )
+    assert ret == 0
+    out = cap_out.get()
+    assert "repo 'dne' is not in the config\n" in out
+    assert "repo 'other' is not in the config\n" in out
+    assert f'[file://{up_to_date}] already up to date!' in out
 
 
 def test_does_not_reformat(tmpdir, out_of_date):


### PR DESCRIPTION
Fixes #3695\n\nWhen "pre-commit autoupdate --repos" is passed repo URLs that don't match any repo in the config, it now prints a message for each unmatched repo instead of exiting silently.\n\nExample:\n\n$ pre-commit autoupdate --repo https://github.com/example/missing-repo\nrepo 'https://github.com/example/missing-repo' is not in the config\n\nAdded tests for a single unmatched repo and a mix of matched and unmatched repos.