### PR TITLE
fix: support SHA-256 zero OIDs in pre-push

### DIFF
--- a/pre_commit/commands/hook_impl.py
+++ b/pre_commit/commands/hook_impl.py
@@ -12,6 +12,11 @@ from pre_commit.parse_shebang import normalize_cmd
 from pre_commit.store import Store
 
 Z40 = '0' * 40
+Z64 = '0' * 64
+
+
+def _is_zero_oid(oid: str) -> bool:
+    return oid in {Z40, Z64}
 
 
 def _run_legacy(
@@ -128,9 +133,9 @@ def _pre_push_ns(
     for line in stdin.decode().splitlines():
         parts = line.rsplit(maxsplit=3)
         local_branch, local_sha, remote_branch, remote_sha = parts
-        if local_sha == Z40:
+        if _is_zero_oid(local_sha):
             continue
-        elif remote_sha != Z40 and _rev_exists(remote_sha):
+        elif not _is_zero_oid(remote_sha) and _rev_exists(remote_sha):
             return _ns(
                 'pre-push', color,
                 from_ref=remote_sha, to_ref=local_sha,

--- a/tests/commands/hook_impl_test.py
+++ b/tests/commands/hook_impl_test.py
@@ -336,12 +336,13 @@ def test_pushing_orphan_branch(push_example):
     assert ns.all_files is True
 
 
-def test_run_ns_pre_push_deleting_branch(push_example):
+@pytest.mark.parametrize('zero_oid', (hook_impl.Z40, hook_impl.Z64))
+def test_run_ns_pre_push_deleting_branch(push_example, zero_oid):
     src, src_head, clone, _ = push_example
 
     with cwd(clone):
         args = ('origin', src)
-        stdin = f'(delete) {hook_impl.Z40} refs/heads/b {src_head}'.encode()
+        stdin = f'(delete) {zero_oid} refs/heads/b {src_head}'.encode()
         ns = hook_impl._run_ns('pre-push', False, args, stdin)
 
     assert ns is None


### PR DESCRIPTION
## Summary
- recognize the zero object ID used by SHA-256 repositories in pre-push input
- cover branch deletion for both SHA-1 and SHA-256 object formats

## Root cause
The pre-push parser only recognized Git's 40-character SHA-1 zero object ID. In SHA-256 repositories, deletion records use a 64-character zero ID, so the hook attempted to diff against an invalid revision instead of skipping the deletion.

Fixes #3664

## Validation
- `python -m pytest tests/commands/hook_impl_test.py -q` (45 passed)