### PR TITLE
Read packaged resources with UTF-8

### DIFF
--- a/pre_commit/util.py
+++ b/pre_commit/util.py
@@ -37,7 +37,7 @@ def clean_path_on_failure(path: str) -> Generator[None]:
 
 def resource_text(filename: str) -> str:
     files = importlib.resources.files('pre_commit.resources')
-    return files.joinpath(filename).read_text()
+    return files.joinpath(filename).read_text(encoding='UTF-8')
 
 
 def make_executable(filename: str) -> None:

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -13,8 +13,8 @@ from pre_commit.util import cmd_output
 from pre_commit.util import cmd_output_b
 from pre_commit.util import cmd_output_p
 from pre_commit.util import make_executable
-from pre_commit.util import rmtree
 from pre_commit.util import resource_text
+from pre_commit.util import rmtree
 
 
 def test_CalledProcessError_str():

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os.path
 import stat
 import subprocess
+from unittest import mock
 
 import pytest
 
@@ -13,6 +14,7 @@ from pre_commit.util import cmd_output_b
 from pre_commit.util import cmd_output_p
 from pre_commit.util import make_executable
 from pre_commit.util import rmtree
+from pre_commit.util import resource_text
 
 
 def test_CalledProcessError_str():
@@ -106,3 +108,15 @@ def test_rmtree_read_only_directories(tmpdir):
     tmpdir.join('x/y/z').chmod(mode_no_w)
     tmpdir.join('x/y/z').chmod(mode_no_w)
     rmtree(str(tmpdir.join('x')))
+
+
+def test_resource_text_uses_utf8():
+    resource = mock.Mock()
+    resource.read_text.return_value = 'héllo'
+
+    with mock.patch('importlib.resources.files') as files:
+        files.return_value.joinpath.return_value = resource
+
+        assert resource_text('resource.txt') == 'héllo'
+
+    resource.read_text.assert_called_once_with(encoding='UTF-8')


### PR DESCRIPTION
## Summary

Read packaged text resources with an explicit UTF-8 encoding.

## Background

`pre_commit.util.resource_text()` currently calls `Traversable.read_text()` without an encoding. That makes the result depend on the operating system's default text encoding. A packaged resource containing non-ASCII text can therefore fail to load or be decoded differently on systems using a non-UTF-8 locale.

Package resources are project-owned text files, so their encoding should be deterministic across local environments and CI.

## Changes

- Pass `encoding='UTF-8'` when reading packaged resources.
- Add a regression test that verifies the explicit encoding and a non-ASCII result.

## Tests

- `python -m pytest tests/util_test.py -q`
- `git diff --check`

All targeted tests passed locally.