### PR TITLE
fix(pre-push): treat SHA-256 all-zero OIDs as null object

### DIFF
--- a/pre_commit/commands/hook_impl.py
+++ b/pre_commit/commands/hook_impl.py
@@ -12,6 +12,14 @@ from pre_commit.parse_shebang import normalize_cmd
 from pre_commit.store import Store
 
 Z40 = '0' * 40
+# Git may emit a 40-char (SHA-1) or 64-char (SHA-256) all-zero OID for
+# "no object" on pre-push stdin (new branch / deletion). Treat either as zero.
+Z64 = '0' * 64
+
+
+def _is_zero_oid(sha: str) -> bool:
+    """Return True for the all-zero OID of any supported hash length."""
+    return bool(sha) and set(sha) <= {'0'}
 
 
 def _run_legacy(
@@ -128,9 +136,9 @@ def _pre_push_ns(
     for line in stdin.decode().splitlines():
         parts = line.rsplit(maxsplit=3)
         local_branch, local_sha, remote_branch, remote_sha = parts
-        if local_sha == Z40:
+        if _is_zero_oid(local_sha):
             continue
-        elif remote_sha != Z40 and _rev_exists(remote_sha):
+        elif not _is_zero_oid(remote_sha) and _rev_exists(remote_sha):
             return _ns(
                 'pre-push', color,
                 from_ref=remote_sha, to_ref=local_sha,

--- a/tests/commands/hook_impl_test.py
+++ b/tests/commands/hook_impl_test.py
@@ -347,6 +347,26 @@ def test_run_ns_pre_push_deleting_branch(push_example):
     assert ns is None
 
 
+def test_run_ns_pre_push_deleting_branch_sha256_zero_oid(push_example):
+    """SHA-256 repos emit 64-char zero OIDs; deletion must still no-op (#3664)."""
+    src, src_head, clone, _ = push_example
+    z64 = '0' * 64
+
+    with cwd(clone):
+        args = ('origin', src)
+        stdin = f'(delete) {z64} refs/heads/b {src_head}'.encode()
+        ns = hook_impl._run_ns('pre-push', False, args, stdin)
+
+    assert ns is None
+
+
+def test_is_zero_oid():
+    assert hook_impl._is_zero_oid(hook_impl.Z40)
+    assert hook_impl._is_zero_oid(hook_impl.Z64)
+    assert not hook_impl._is_zero_oid('a' * 40)
+    assert not hook_impl._is_zero_oid('')
+
+
 def test_hook_impl_main_noop_pre_push(cap_out, store, push_example):
     src, src_head, clone, _ = push_example
 


### PR DESCRIPTION
## Description

`pre_commit/commands/hook_impl.py` hardcodes:

```python
Z40 = '0' * 40
```

and compares `local_sha` / `remote_sha` against it to detect deletion-only pushes and new branches.

On repositories initialized with `--object-format=sha256`, git's pre-push protocol emits **64-character** zero OIDs. The equality never matches, deletion short-circuit never fires, and pre-commit ends up running `git rev-list` / `diff` against invalid ranges, exiting non-zero — so `git push origin --delete <branch>` is refused.

## Fix

- Add `_is_zero_oid(sha)` that accepts any non-empty all-zero hex string (SHA-1 or SHA-256).
- Use it for both local and remote zero checks in `_pre_push_ns`.
- Keep `Z40` for existing tests; add `Z64` + regression tests for SHA-256 deletion stdin.

## Tests

```text
pytest tests/commands/hook_impl_test.py::test_run_ns_pre_push_deleting_branch \
  tests/commands/hook_impl_test.py::test_run_ns_pre_push_deleting_branch_sha256_zero_oid \
  tests/commands/hook_impl_test.py::test_is_zero_oid \
  tests/commands/hook_impl_test.py::test_run_ns_pre_push_new_branch -q
# 4 passed
```

## Linked Issue

Closes #3664
