### PR TITLE
Don't use identify if not necessary

### DIFF
--- a/pre_commit/commands/run.py
+++ b/pre_commit/commands/run.py
@@ -88,6 +88,11 @@ class Classifier:
         types = frozenset(types)
         types_or = frozenset(types_or)
         exclude_types = frozenset(exclude_types)
+        if not types and not types_or and not exclude_types:
+            # We're not filtering on types, just return all filenames.
+            for filename in names:
+                yield filename
+            return
         for filename in names:
             tags = self._types_for_file(filename)
             if (

--- a/tests/commands/run_test.py
+++ b/tests/commands/run_test.py
@@ -1160,6 +1160,20 @@ def test_classifier_empty_types_or(tmpdir):
         assert tuple(for_file) == ('bar',)
 
 
+def test_classifier_no_types(tmpdir):
+    tmpdir.join('bar').ensure()
+    os.symlink(tmpdir.join('bar'), tmpdir.join('foo'))
+    with tmpdir.as_cwd():
+        classifier = Classifier(('foo', 'bar'))
+        res = classifier.by_types(
+            classifier.filenames,
+            types=[],
+            types_or=[],
+            exclude_types=[],
+        )
+        assert tuple(res) == ('foo', 'bar')
+
+
 @pytest.fixture
 def some_filenames():
     return (


### PR DESCRIPTION
If we're not filtering on types, there's no need to call identify.