### PR TITLE
use --store-dir for haskell

### DIFF
--- a/pre_commit/languages/haskell.py
+++ b/pre_commit/languages/haskell.py
@@ -43,12 +43,13 @@ def install_environment(
         raise FatalError('Expected .cabal files or additional_dependencies')
 
     bindir = os.path.join(envdir, 'bin')
+    storedir = os.path.join(envdir, 'store')
     os.makedirs(bindir, exist_ok=True)
     lang_base.setup_cmd(prefix, ('cabal', 'update'))
     lang_base.setup_cmd(
         prefix,
         (
-            'cabal', 'install',
+            'cabal', '--store-dir', storedir, 'install',
             '--install-method', 'copy',
             '--installdir', bindir,
             *pkgs,

--- a/tests/languages/haskell_test.py
+++ b/tests/languages/haskell_test.py
@@ -1,11 +1,41 @@
 from __future__ import annotations
 
+from unittest import mock
+
 import pytest
 
+import pre_commit.constants as C
+from pre_commit import lang_base
 from pre_commit.errors import FatalError
 from pre_commit.languages import haskell
+from pre_commit.prefix import Prefix
 from pre_commit.util import win_exe
 from testing.language_helpers import run_language
+
+
+def test_install_uses_env_local_store(tmp_path):
+    hook_dir = tmp_path.joinpath('hook dir')
+    hook_dir.mkdir()
+    hook_dir.joinpath('example.cabal').touch()
+    prefix = Prefix(str(hook_dir))
+    envdir = hook_dir.joinpath('hs_env-default')
+
+    with mock.patch.object(lang_base, 'setup_cmd') as setup_cmd:
+        haskell.install_environment(prefix, C.DEFAULT, ())
+
+    assert setup_cmd.call_args_list == [
+        mock.call(prefix, ('cabal', 'update')),
+        mock.call(
+            prefix,
+            (
+                'cabal', '--store-dir', str(envdir.joinpath('store')),
+                'install',
+                '--install-method', 'copy',
+                '--installdir', str(envdir.joinpath('bin')),
+                'example.cabal',
+            ),
+        ),
+    ]
 
 
 def test_run_example_executable(tmp_path):
@@ -41,6 +71,7 @@ main = putStrLn "Hello, Haskell!"
 def test_run_dep(tmp_path):
     result = run_language(tmp_path, haskell, 'hello', deps=['hello'])
     assert result == (0, b'Hello, World!\n')
+    assert tmp_path.joinpath('hs_env-default', 'store').is_dir()
 
 
 def test_run_empty(tmp_path):


### PR DESCRIPTION
## Summary

Configure Cabal’s package store inside the pre-commit-managed Haskell environment instead of leaving it in the user-level store.

- pass `--store-dir <hook-env>/store` as a Cabal global option
- keep the existing copied executable directory unchanged
- add focused command-construction coverage, including an environment path containing spaces
- extend the existing live Haskell dependency test to assert that the environment-local store is created

Fixes #3501

## Validation

Passed in clean focused worktrees:

- `python -m pytest -q tests/languages/haskell_test.py -k test_install_uses_env_local_store` — 1 passed, 3 deselected
- `python -m pytest --collect-only -q tests/languages/haskell_test.py` — 4 tests collected
- `python -m compileall -q pre_commit/languages/haskell.py tests/languages/haskell_test.py`
- `python -m tabnanny pre_commit/languages/haskell.py tests/languages/haskell_test.py`
- `git diff --check`

The focused regression fails on current main because the command lacks `--store-dir` and passes after the change. Cabal and GHC were unavailable in the worker VM, so the live Haskell integration assertion and full repository suite were not executed locally; this is left to upstream CI.