### PR TITLE
Choose a semver tag over the last tag in a repo

### DIFF
--- a/pre_commit/git.py
+++ b/pre_commit/git.py
@@ -236,8 +236,11 @@ def get_best_candidate_tag(rev: str, git_repo: str) -> str:
     Multiple tags can exist on a SHA. Sometimes a moving tag is attached
     to a version tag. Try to pick the tag that looks like a version.
     """
+    commit = cmd_output(
+        'git', 'rev-list', '-n', '1', rev, cwd=git_repo,
+    )[1].strip()
     tags = cmd_output(
-        'git', *NO_FS_MONITOR, 'tag', '--points-at', rev, cwd=git_repo,
+        'git', *NO_FS_MONITOR, 'tag', '--points-at', commit, cwd=git_repo,
     )[1].splitlines()
     for tag in tags:
         if '.' in tag:

--- a/tests/commands/autoupdate_test.py
+++ b/tests/commands/autoupdate_test.py
@@ -50,6 +50,13 @@ def tagged(out_of_date):
 
 
 @pytest.fixture
+def multiple_tagged(out_of_date):
+    cmd_output('git', 'tag', 'v1', cwd=out_of_date.path)
+    cmd_output('git', 'tag', 'v1.2.3', cwd=out_of_date.path)
+    yield out_of_date
+
+
+@pytest.fixture
 def hook_disappearing(tempdir_factory):
     path = make_repo(tempdir_factory, 'python_hooks_repo')
     original_rev = git.head_rev(path)
@@ -97,6 +104,17 @@ def test_rev_info_update_tags_even_if_not_tags_only(tagged):
 def test_rev_info_update_tags_only_does_not_pick_tip(tagged):
     git_commit(cwd=tagged.path)
     config = make_config_from_repo(tagged.path, rev=tagged.original_rev)
+    info = RevInfo.from_config(config)
+    new_info = info.update(tags_only=True, freeze=False)
+    assert new_info.rev == 'v1.2.3'
+
+
+def test_rev_info_update_tags_prefers_semver_tag(multiple_tagged):
+    git_commit(cwd=multiple_tagged.path)
+    config = make_config_from_repo(
+        multiple_tagged.path,
+        rev=multiple_tagged.original_rev,
+    )
     info = RevInfo.from_config(config)
     new_info = info.update(tags_only=True, freeze=False)
     assert new_info.rev == 'v1.2.3'

--- a/tests/git_test.py
+++ b/tests/git_test.py
@@ -308,4 +308,12 @@ def test_get_best_candidate_tag(in_git_dir):
     git_commit()
     cmd_output('git', 'tag', 'v1')
     cmd_output('git', 'tag', 'v1.0.1')
+    commit = cmd_output(
+        'git', 'rev-list', '-n', '1', 'v1', cwd=in_git_dir,
+    )[1].strip()
+    tags = cmd_output(
+        'git', *git.NO_FS_MONITOR, 'tag',
+        '--points-at', commit, cwd=in_git_dir,
+    )[1].splitlines()
+    assert tags == ['v1', 'v1.0.1']
     assert git.get_best_candidate_tag('v1', in_git_dir) == 'v1.0.1'

--- a/tests/git_test.py
+++ b/tests/git_test.py
@@ -302,3 +302,10 @@ def test_no_git_env():
 def test_init_repo_no_hooks(tmpdir):
     git.init_repo(str(tmpdir), remote='dne')
     assert not tmpdir.join('.git/hooks').exists()
+
+
+def test_get_best_candidate_tag(in_git_dir):
+    git_commit()
+    cmd_output('git', 'tag', 'v1')
+    cmd_output('git', 'tag', 'v1.0.1')
+    assert git.get_best_candidate_tag('v1', in_git_dir) == 'v1.0.1'


### PR DESCRIPTION
Problem: I'm (and it looks like others) are seeing this pop up with pre-commit hooks coming from repos like: https://github.com/crate-ci/typos where a tag like "v1" is maintained for the latest release along with a semver tag like "v1.Y.Z". When running `pre-commit autoupdate`, you always get the "v1" tag instead of the latest "v1.Y.Z" tag. This is reported with a workaround here: https://github.com/crate-ci/typos/issues/390 but it seems like the fix should actually be at the pre-commit level and not to go around mirroring repos to get a clean set of tags.

Solution: I believe the intention of the git.get_best_candidate_tag function is to choose a semver-compliant tag instead of necessarily the most recent one, where these tags may be off the same commit SHA. This PR gets the commit for the last found tag, then gets all tags associated with that commit SHA, and finally allows for returning that commit if there's a period in it. I've added tests for the git and autoupdate module to support the changes.

Edit: I'm reading your comments in #2366 and I'm seeing how there's a tradeoff between repeatability here in getting the right tags so this might not be an improvement even if it appears to fix what I've experienced. Happy to close this if so and take it as an opportunity to learn about the internals of pre-commit.