### PR TITLE
Handle SHA-256 zero OIDs in pre-push

### DIFF
--- a/pre_commit/commands/hook_impl.py
+++ b/pre_commit/commands/hook_impl.py
@@ -14,6 +14,10 @@ from pre_commit.store import Store
 Z40 = '0' * 40
 
 
+def _is_zero_oid(s: str) -> bool:
+    return len(s) in {40, 64} and set(s) == {'0'}
+
+
 def _run_legacy(
         hook_type: str,
         hook_dir: str | None,
@@ -128,9 +132,9 @@ def _pre_push_ns(
     for line in stdin.decode().splitlines():
         parts = line.rsplit(maxsplit=3)
         local_branch, local_sha, remote_branch, remote_sha = parts
-        if local_sha == Z40:
+        if _is_zero_oid(local_sha):
             continue
-        elif remote_sha != Z40 and _rev_exists(remote_sha):
+        elif not _is_zero_oid(remote_sha) and _rev_exists(remote_sha):
             return _ns(
                 'pre-push', color,
                 from_ref=remote_sha, to_ref=local_sha,

--- a/tests/commands/hook_impl_test.py
+++ b/tests/commands/hook_impl_test.py
@@ -347,6 +347,17 @@ def test_run_ns_pre_push_deleting_branch(push_example):
     assert ns is None
 
 
+def test_run_ns_pre_push_deleting_branch_sha256(push_example):
+    src, src_head, clone, _ = push_example
+
+    with cwd(clone):
+        args = ('origin', src)
+        stdin = f'(delete) {"0" * 64} refs/heads/b {src_head}'.encode()
+        ns = hook_impl._run_ns('pre-push', False, args, stdin)
+
+    assert ns is None
+
+
 def test_hook_impl_main_noop_pre_push(cap_out, store, push_example):
     src, src_head, clone, _ = push_example
 


### PR DESCRIPTION
Fixes #3664.

Git emits 64-character zero OIDs in SHA-256 repositories. The pre-push hook only recognised the SHA-1 zero OID, so deletion pushes could fall through into revision range handling instead of being skipped.

This recognises all-zero OIDs for both SHA-1 and SHA-256, and adds a regression test for deleting a branch from a SHA-256 repository.

Tested with:

```powershell
python -m pytest tests/commands/hook_impl_test.py::test_run_ns_pre_push_deleting_branch tests/commands/hook_impl_test.py::test_run_ns_pre_push_deleting_branch_sha256 tests/commands/hook_impl_test.py::test_hook_impl_main_noop_pre_push -q
python -m pytest tests/commands/hook_impl_test.py -q -k "pre_push"
```