### PR TITLE
fix: keep absolute path when os.path.relpath raises ValueError on Windows cross-drive

### DIFF
--- a/pre_commit/main.py
+++ b/pre_commit/main.py
@@ -172,6 +172,17 @@ def _add_run_options(parser: argparse.ArgumentParser) -> None:
     )
 
 
+def _relpath(path: str) -> str:
+    # On Windows, os.path.relpath raises ValueError when `path` and the
+    # current directory are on different drives (e.g. config on C:\ but the
+    # git repo is on D:\).  Fall back to the absolute path in that case so
+    # pre-commit still works cross-drive.
+    try:
+        return os.path.relpath(path)
+    except ValueError:
+        return path
+
+
 def _adjust_args_and_chdir(args: argparse.Namespace) -> None:
     # `--config` was specified relative to the non-root working directory
     if os.path.exists(args.config):
@@ -188,15 +199,13 @@ def _adjust_args_and_chdir(args: argparse.Namespace) -> None:
     toplevel = git.get_root()
     os.chdir(toplevel)
 
-    args.config = os.path.relpath(args.config)
+    args.config = _relpath(args.config)
     if args.command in {'run', 'try-repo'}:
-        args.files = [os.path.relpath(filename) for filename in args.files]
+        args.files = [_relpath(filename) for filename in args.files]
         if args.commit_msg_filename is not None:
-            args.commit_msg_filename = os.path.relpath(
-                args.commit_msg_filename,
-            )
+            args.commit_msg_filename = _relpath(args.commit_msg_filename)
     if args.command == 'try-repo' and os.path.exists(args.repo):
-        args.repo = os.path.relpath(args.repo)
+        args.repo = _relpath(args.repo)
 
 
 def main(argv: Sequence[str] | None = None) -> int:

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -89,6 +89,20 @@ def test_adjust_args_try_repo_repo_relative(in_git_dir):
         assert args.repo == 'foo'
 
 
+def test_relpath_falls_back_on_cross_drive_valueerror():
+    # On Windows, os.path.relpath raises ValueError when path and cwd are on
+    # different drives.  _relpath must return the original path unchanged.
+    abs_path = 'C:\\configs\\pre-commit-config.yaml'
+    with mock.patch('os.path.relpath', side_effect=ValueError('different drives')):
+        assert main._relpath(abs_path) == abs_path
+
+
+def test_relpath_returns_relative_path_on_same_drive():
+    # Normal case: os.path.relpath succeeds and the result is returned.
+    with mock.patch('os.path.relpath', return_value=os.path.join('foo', 'bar')):
+        assert main._relpath('/any/path') == os.path.join('foo', 'bar')
+
+
 FNS = (
     'autoupdate', 'clean', 'gc', 'install', 'install_hooks',
     'migrate_config', 'run', 'sample_config', 'uninstall',


### PR DESCRIPTION
Fixes #2530.

## Problem

On Windows, `os.path.relpath` raises `ValueError` when the start path
and the target path are on different drives — for example when
`--config` points to `C:\configs\pre-commit-config.yaml` but the git
repository root is on `D:\`.

`_adjust_args_and_chdir` calls `os.path.relpath` unconditionally after
`os.chdir(toplevel)`, so the combination of a cross-drive config (or
`--commit-msg-filename` / `try-repo` repo path) and a git repo on a
different drive crashed with an unhandled `ValueError` instead of
falling back gracefully.

## Fix

Add a `_relpath()` helper that wraps `os.path.relpath` and catches
`ValueError`, returning the original path unchanged (keeping it
absolute).  All four `os.path.relpath` call-sites in
`_adjust_args_and_chdir` are replaced with `_relpath()`.

On same-drive paths the behaviour is identical to before.  On
cross-drive paths the absolute path is preserved, which is valid since
absolute paths work regardless of the current directory.

## Tests

- `test_relpath_falls_back_on_cross_drive_valueerror` — unit test that
  directly verifies `_relpath` returns the original path when
  `os.path.relpath` raises `ValueError`.
- `test_relpath_returns_relative_path_on_same_drive` — verifies the
  normal (non-Windows-cross-drive) code path still works.

All existing `main_test.py` tests continue to pass (30 passed, 1
skipped on non-Windows).