### PR TITLE
Add Deno as a supported language

### DIFF
--- a/pre_commit/all_languages.py
+++ b/pre_commit/all_languages.py
@@ -4,6 +4,7 @@ from pre_commit.lang_base import Language
 from pre_commit.languages import conda
 from pre_commit.languages import coursier
 from pre_commit.languages import dart
+from pre_commit.languages import deno
 from pre_commit.languages import docker
 from pre_commit.languages import docker_image
 from pre_commit.languages import dotnet
@@ -28,6 +29,7 @@ languages: dict[str, Language] = {
     'conda': conda,
     'coursier': coursier,
     'dart': dart,
+    'deno': deno,
     'docker': docker,
     'docker_image': docker_image,
     'dotnet': dotnet,

--- a/pre_commit/languages/deno.py
+++ b/pre_commit/languages/deno.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from pre_commit import lang_base
+from pre_commit.prefix import Prefix
+from pre_commit.util import cmd_output_b
+
+ENVIRONMENT_DIR = 'deno_env'
+get_default_version = lang_base.basic_get_default_version
+in_env = lang_base.no_env
+run_hook = lang_base.basic_run_hook
+
+
+def health_check(prefix: Prefix, version: str) -> str | None:
+    retcode, _, _ = cmd_output_b('deno', '--version', check=False)
+    if retcode != 0:
+        return f'`deno --version` returned {retcode}'
+    else:
+        return None
+
+
+def install_environment(
+        prefix: Prefix, version: str, additional_dependencies: Sequence[str],
+) -> None:
+    lang_base.assert_version_default('deno', version)
+    lang_base.assert_no_additional_deps('deno', additional_dependencies)

--- a/tests/languages/deno_test.py
+++ b/tests/languages/deno_test.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import shutil
+from unittest import mock
+
+import pytest
+
+import pre_commit.constants as C
+from pre_commit.languages import deno
+from pre_commit.prefix import Prefix
+from testing.language_helpers import run_language
+
+
+def test_default_version():
+    assert deno.get_default_version() == C.DEFAULT
+
+
+def test_healthy_deno():
+    with mock.patch.object(deno, 'cmd_output_b', return_value=(0, b'', b'')):
+        assert deno.health_check(Prefix('/tmp'), C.DEFAULT) is None
+
+
+def test_unhealthy_deno():
+    with mock.patch.object(deno, 'cmd_output_b', return_value=(127, b'', b'')):
+        assert deno.health_check(Prefix('/tmp'), C.DEFAULT) == '`deno --version` returned 127'
+
+
+def test_rejects_version():
+    with pytest.raises(AssertionError, match='system-installed deno'):
+        deno.install_environment(Prefix('/tmp'), '2.0.0', ())
+
+
+def test_rejects_additional_dependencies():
+    with pytest.raises(AssertionError, match='additional_dependencies'):
+        deno.install_environment(Prefix('/tmp'), C.DEFAULT, ('npm:typescript',))
+
+
+@pytest.mark.skipif(shutil.which('deno') is None, reason='deno is not installed')
+def test_deno_hook():
+    assert run_language(
+        Prefix('/tmp').prefix_dir,
+        deno,
+        'deno eval \'console.log("hello from deno")\'',
+    ) == (0, b'hello from deno\n')


### PR DESCRIPTION
## Summary

- Register Deno as a supported language.
- Treat Deno as a system-provided runtime and report an actionable health-check failure when it is unavailable.
- Add focused tests for the language registration, version constraints, dependencies, and a real Deno hook.

Fixes #3410

## Testing

- `./.venv/bin/python -m pytest -q tests/languages/deno_test.py` — 6 passed
- `git diff --check`
