### PR TITLE
fix(node): install git hooks as real directories

### DIFF
--- a/pre_commit/languages/node.py
+++ b/pre_commit/languages/node.py
@@ -99,5 +99,8 @@ def install_environment(
     cmd_output_b(*cmd)
 
     with in_env(prefix, version):
-        install = ('npm', 'install', '--allow-git=root', '-g', *pkgs)
+        install = (
+            'npm', 'install', '--allow-git=root', '--install-links=true',
+            '-g', *pkgs,
+        )
         lang_base.setup_cmd(prefix, install)

--- a/tests/languages/node_test.py
+++ b/tests/languages/node_test.py
@@ -103,12 +103,16 @@ def test_installs_without_links_outside_env(tmpdir):
         '#!/usr/bin/env node\n'
         '_ = require("lodash"); console.log("success!")\n',
     )
+    tmpdir.join('packages/bar/package.json').ensure().write(
+        json.dumps({'name': 'bar', 'version': '0.0.1'}),
+    )
     tmpdir.join('package.json').write(
         json.dumps({
             'name': 'foo',
             'version': '0.0.1',
             'bin': {'foo': './bin/main.js'},
             'dependencies': {'lodash': '*'},
+            'workspaces': ['packages/*'],
         }),
     )
     _make_repo(str(tmpdir))


### PR DESCRIPTION
Fixes #3737.

After the switch to git-based npm installation, a workspace package could remain a symlink to npm's temporary `_cacache/tmp/git-clone...` directory. Once npm removed that temporary clone, the installed hook executable was no longer available.

Pass `--install-links=true` for this installation so npm materializes the package. Add a regression test using a workspace package.

Validation:
- regression test: passed
- relevant Node subset: 10 passed
- ESLint reproducer: executable successfully launched
- format/style/flake8: passed
- `git diff --check`: passed

`mypy` did not pass because of a macOS-specific `sched_getaffinity` error. The same failure reproduces on the clean upstream commit `242ce8a`, so it is unrelated to this patch.
