### PR TITLE
fix `language: node` for hooks with build scripts and npm 11.x

### DIFF
--- a/pre_commit/languages/node.py
+++ b/pre_commit/languages/node.py
@@ -99,5 +99,8 @@ def install_environment(
     cmd_output_b(*cmd)
 
     with in_env(prefix, version):
-        install = ('npm', 'install', '--allow-git=root', '-g', *pkgs)
+        install = (
+            'npm', 'install', '--allow-git=root', '--install-links', '-g',
+            *pkgs,
+        )
         lang_base.setup_cmd(prefix, install)

--- a/tests/languages/node_test.py
+++ b/tests/languages/node_test.py
@@ -158,6 +158,21 @@ def test_node_hook_versions(tmp_path, version):
     assert ret == (0, b'Hello World\n')
 
 
+def test_npm_install_succeeds_with_build(tmp_path):
+    _make_hello_world(tmp_path)
+
+    with open(tmp_path.joinpath('package.json')) as f:
+        contents = json.load(f)
+    contents['scripts'] = {'build': 'echo hello hello'}
+    with open(tmp_path.joinpath('package.json'), 'w') as f:
+        json.dump(contents, f)
+    _make_repo(tmp_path)
+
+    # node version chosen to be npm 11.19.0 with this particular bug
+    ret = run_language(tmp_path, node, 'node-hello', version='26.7.0')
+    assert ret == (0, b'Hello World\n')
+
+
 def test_node_additional_deps(tmp_path):
     _make_local_repo(str(tmp_path))
     ret, out = run_language(tmp_path, node, 'npm ls -g', deps=('lodash',))


### PR DESCRIPTION
resolve #3737

(this appears to work fine without `--install-links` for npm 12.x)