### PR TITLE
Update virtualenv to min. 20.36.1

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,7 @@ install_requires =
     identify>=1.0.0
     nodeenv>=0.11.1
     pyyaml>=5.1
-    virtualenv>=20.10.0
+    virtualenv>=20.36.1
 python_requires = >=3.10
 
 [options.packages.find]


### PR DESCRIPTION
This version update fixes the disclosed TOCTOU vulnerability of `virtualenv` (https://github.com/pypa/virtualenv/security/advisories/GHSA-597g-3phw-6986).